### PR TITLE
Add appointments schema foundation for Sprint 2.

### DIFF
--- a/backend/db/db.go
+++ b/backend/db/db.go
@@ -26,6 +26,23 @@ func Migrate(ctx context.Context) error {
 			role       TEXT NOT NULL CHECK (role IN ('patient', 'doctor', 'admin')),
 			created_at TIMESTAMPTZ DEFAULT NOW()
 		);
+
+		CREATE TABLE IF NOT EXISTS appointments (
+			id           UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+			patient_id   UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+			doctor_id    UUID NOT NULL REFERENCES users(id) ON DELETE RESTRICT,
+			scheduled_at TIMESTAMPTZ NOT NULL,
+			reason       TEXT NOT NULL,
+			status       TEXT NOT NULL DEFAULT 'pending' CHECK (status IN ('pending', 'approved', 'rejected')),
+			created_at   TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+			updated_at   TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+			CHECK (patient_id <> doctor_id)
+		);
+
+		CREATE INDEX IF NOT EXISTS idx_appointments_patient_id ON appointments(patient_id);
+		CREATE INDEX IF NOT EXISTS idx_appointments_doctor_id ON appointments(doctor_id);
+		CREATE INDEX IF NOT EXISTS idx_appointments_status ON appointments(status);
+		CREATE INDEX IF NOT EXISTS idx_appointments_scheduled_at ON appointments(scheduled_at);
 	`)
 	return err
 }

--- a/backend/models/appointment.go
+++ b/backend/models/appointment.go
@@ -1,0 +1,24 @@
+package models
+
+import (
+	"time"
+
+	"github.com/google/uuid"
+)
+
+const (
+	AppointmentStatusPending  = "pending"
+	AppointmentStatusApproved = "approved"
+	AppointmentStatusRejected = "rejected"
+)
+
+type Appointment struct {
+	ID          uuid.UUID `json:"id"`
+	PatientID   uuid.UUID `json:"patient_id"`
+	DoctorID    uuid.UUID `json:"doctor_id"`
+	ScheduledAt time.Time `json:"scheduled_at"`
+	Reason      string    `json:"reason"`
+	Status      string    `json:"status"`
+	CreatedAt   time.Time `json:"created_at"`
+	UpdatedAt   time.Time `json:"updated_at"`
+}


### PR DESCRIPTION
This introduces the appointments table, constraints, and indexes plus a shared appointment model so subsequent API and UI stories can build on a stable data contract.
