### PR TITLE
Merge US-7b / US-8a — Appointments API (patient & doctor flows + doctor directory)

### DIFF
--- a/backend/handlers/appointments.go
+++ b/backend/handlers/appointments.go
@@ -1,6 +1,7 @@
 package handlers
 
 import (
+	"errors"
 	"net/http"
 	"strings"
 	"time"
@@ -9,6 +10,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/healthonyx/backend/db"
 	"github.com/healthonyx/backend/models"
+	"github.com/jackc/pgx/v5"
 )
 
 type AppointmentHandler struct{}
@@ -17,6 +19,10 @@ type CreateAppointmentRequest struct {
 	DoctorID    string    `json:"doctor_id" binding:"required"`
 	ScheduledAt time.Time `json:"scheduled_at" binding:"required"`
 	Reason      string    `json:"reason" binding:"required"`
+}
+
+type UpdateAppointmentStatusRequest struct {
+	Status string `json:"status" binding:"required"`
 }
 
 func NewAppointmentHandler() *AppointmentHandler {
@@ -167,4 +173,48 @@ func (h *AppointmentHandler) ListDoctor(c *gin.Context) {
 	}
 
 	c.JSON(http.StatusOK, gin.H{"appointments": appointments})
+}
+
+func (h *AppointmentHandler) UpdateStatus(c *gin.Context) {
+	claims, ok := getClaims(c)
+	if !ok {
+		return
+	}
+
+	id, err := uuid.Parse(c.Param("id"))
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid appointment id"})
+		return
+	}
+
+	var req UpdateAppointmentStatusRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid request body"})
+		return
+	}
+
+	status := strings.ToLower(strings.TrimSpace(req.Status))
+	if status != models.AppointmentStatusApproved && status != models.AppointmentStatusRejected {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "status must be approved or rejected"})
+		return
+	}
+
+	var appt models.Appointment
+	err = db.Pool.QueryRow(c.Request.Context(), `
+		UPDATE appointments
+		SET status = $1, updated_at = NOW()
+		WHERE id = $2 AND doctor_id = $3
+		RETURNING id, patient_id, doctor_id, scheduled_at, reason, status, created_at, updated_at
+	`, status, id, claims.UserID).
+		Scan(&appt.ID, &appt.PatientID, &appt.DoctorID, &appt.ScheduledAt, &appt.Reason, &appt.Status, &appt.CreatedAt, &appt.UpdatedAt)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			c.JSON(http.StatusNotFound, gin.H{"error": "Appointment not found"})
+			return
+		}
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Internal error"})
+		return
+	}
+
+	c.JSON(http.StatusOK, appt)
 }

--- a/backend/handlers/appointments.go
+++ b/backend/handlers/appointments.go
@@ -25,6 +25,11 @@ type UpdateAppointmentStatusRequest struct {
 	Status string `json:"status" binding:"required"`
 }
 
+type DoctorOption struct {
+	ID    uuid.UUID `json:"id"`
+	Email string    `json:"email"`
+}
+
 func NewAppointmentHandler() *AppointmentHandler {
 	return &AppointmentHandler{}
 }
@@ -173,6 +178,36 @@ func (h *AppointmentHandler) ListDoctor(c *gin.Context) {
 	}
 
 	c.JSON(http.StatusOK, gin.H{"appointments": appointments})
+}
+
+func (h *AppointmentHandler) ListAvailableDoctors(c *gin.Context) {
+	rows, err := db.Pool.Query(c.Request.Context(), `
+		SELECT id, email
+		FROM users
+		WHERE role = 'doctor'
+		ORDER BY email ASC
+	`)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Internal error"})
+		return
+	}
+	defer rows.Close()
+
+	doctors := make([]DoctorOption, 0)
+	for rows.Next() {
+		var doctor DoctorOption
+		if err := rows.Scan(&doctor.ID, &doctor.Email); err != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "Internal error"})
+			return
+		}
+		doctors = append(doctors, doctor)
+	}
+	if rows.Err() != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Internal error"})
+		return
+	}
+
+	c.JSON(http.StatusOK, gin.H{"doctors": doctors})
 }
 
 func (h *AppointmentHandler) UpdateStatus(c *gin.Context) {

--- a/backend/handlers/appointments.go
+++ b/backend/handlers/appointments.go
@@ -1,0 +1,170 @@
+package handlers
+
+import (
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
+	"github.com/healthonyx/backend/db"
+	"github.com/healthonyx/backend/models"
+)
+
+type AppointmentHandler struct{}
+
+type CreateAppointmentRequest struct {
+	DoctorID    string    `json:"doctor_id" binding:"required"`
+	ScheduledAt time.Time `json:"scheduled_at" binding:"required"`
+	Reason      string    `json:"reason" binding:"required"`
+}
+
+func NewAppointmentHandler() *AppointmentHandler {
+	return &AppointmentHandler{}
+}
+
+func getClaims(c *gin.Context) (*Claims, bool) {
+	claimsVal, ok := c.Get("claims")
+	if !ok {
+		c.JSON(http.StatusUnauthorized, gin.H{"error": "Unauthorized"})
+		return nil, false
+	}
+	claims, ok := claimsVal.(*Claims)
+	if !ok {
+		c.JSON(http.StatusUnauthorized, gin.H{"error": "Unauthorized"})
+		return nil, false
+	}
+	return claims, true
+}
+
+func (h *AppointmentHandler) Create(c *gin.Context) {
+	claims, ok := getClaims(c)
+	if !ok {
+		return
+	}
+
+	var req CreateAppointmentRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid request body"})
+		return
+	}
+
+	if req.ScheduledAt.IsZero() {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "scheduled_at is required"})
+		return
+	}
+
+	reason := strings.TrimSpace(req.Reason)
+	if reason == "" {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "reason is required"})
+		return
+	}
+
+	doctorID, err := uuid.Parse(req.DoctorID)
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "doctor_id must be a valid UUID"})
+		return
+	}
+	if doctorID == claims.UserID {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "doctor_id cannot match patient user"})
+		return
+	}
+
+	var doctorExists bool
+	err = db.Pool.QueryRow(c.Request.Context(),
+		`SELECT EXISTS(SELECT 1 FROM users WHERE id = $1 AND role = 'doctor')`,
+		doctorID,
+	).Scan(&doctorExists)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Internal error"})
+		return
+	}
+	if !doctorExists {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "doctor_id must reference a doctor account"})
+		return
+	}
+
+	var appt models.Appointment
+	err = db.Pool.QueryRow(c.Request.Context(), `
+		INSERT INTO appointments (patient_id, doctor_id, scheduled_at, reason, status)
+		VALUES ($1, $2, $3, $4, $5)
+		RETURNING id, patient_id, doctor_id, scheduled_at, reason, status, created_at, updated_at
+	`, claims.UserID, doctorID, req.ScheduledAt, reason, models.AppointmentStatusPending).
+		Scan(&appt.ID, &appt.PatientID, &appt.DoctorID, &appt.ScheduledAt, &appt.Reason, &appt.Status, &appt.CreatedAt, &appt.UpdatedAt)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Internal error"})
+		return
+	}
+
+	c.JSON(http.StatusCreated, appt)
+}
+
+func (h *AppointmentHandler) ListPatient(c *gin.Context) {
+	claims, ok := getClaims(c)
+	if !ok {
+		return
+	}
+
+	rows, err := db.Pool.Query(c.Request.Context(), `
+		SELECT id, patient_id, doctor_id, scheduled_at, reason, status, created_at, updated_at
+		FROM appointments
+		WHERE patient_id = $1
+		ORDER BY scheduled_at DESC, created_at DESC
+	`, claims.UserID)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Internal error"})
+		return
+	}
+	defer rows.Close()
+
+	appointments := make([]models.Appointment, 0)
+	for rows.Next() {
+		var appt models.Appointment
+		if err := rows.Scan(&appt.ID, &appt.PatientID, &appt.DoctorID, &appt.ScheduledAt, &appt.Reason, &appt.Status, &appt.CreatedAt, &appt.UpdatedAt); err != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "Internal error"})
+			return
+		}
+		appointments = append(appointments, appt)
+	}
+	if rows.Err() != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Internal error"})
+		return
+	}
+
+	c.JSON(http.StatusOK, gin.H{"appointments": appointments})
+}
+
+func (h *AppointmentHandler) ListDoctor(c *gin.Context) {
+	claims, ok := getClaims(c)
+	if !ok {
+		return
+	}
+
+	rows, err := db.Pool.Query(c.Request.Context(), `
+		SELECT id, patient_id, doctor_id, scheduled_at, reason, status, created_at, updated_at
+		FROM appointments
+		WHERE doctor_id = $1
+		ORDER BY status ASC, scheduled_at ASC, created_at DESC
+	`, claims.UserID)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Internal error"})
+		return
+	}
+	defer rows.Close()
+
+	appointments := make([]models.Appointment, 0)
+	for rows.Next() {
+		var appt models.Appointment
+		if err := rows.Scan(&appt.ID, &appt.PatientID, &appt.DoctorID, &appt.ScheduledAt, &appt.Reason, &appt.Status, &appt.CreatedAt, &appt.UpdatedAt); err != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "Internal error"})
+			return
+		}
+		appointments = append(appointments, appt)
+	}
+	if rows.Err() != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Internal error"})
+		return
+	}
+
+	c.JSON(http.StatusOK, gin.H{"appointments": appointments})
+}

--- a/backend/main.go
+++ b/backend/main.go
@@ -33,6 +33,7 @@ func main() {
 	}
 
 	auth := handlers.NewAuthHandler(cfg.JWTSecret)
+	appointments := handlers.NewAppointmentHandler()
 	r := gin.Default()
 
 	// CORS: allow Angular dev server and any configured origins
@@ -69,6 +70,10 @@ func main() {
 		api.GET("/patient", auth.RequireAuth(), auth.RequireRole("patient"), func(c *gin.Context) {
 			c.JSON(http.StatusOK, gin.H{"message": "Patient only"})
 		})
+
+		api.POST("/appointments", auth.RequireAuth(), auth.RequireRole("patient"), appointments.Create)
+		api.GET("/appointments/patient", auth.RequireAuth(), auth.RequireRole("patient"), appointments.ListPatient)
+		api.GET("/appointments/doctor", auth.RequireAuth(), auth.RequireRole("doctor"), appointments.ListDoctor)
 	}
 
 	addr := fmt.Sprintf(":%s", cfg.Port)

--- a/backend/main.go
+++ b/backend/main.go
@@ -74,6 +74,7 @@ func main() {
 		api.POST("/appointments", auth.RequireAuth(), auth.RequireRole("patient"), appointments.Create)
 		api.GET("/appointments/patient", auth.RequireAuth(), auth.RequireRole("patient"), appointments.ListPatient)
 		api.GET("/appointments/doctor", auth.RequireAuth(), auth.RequireRole("doctor"), appointments.ListDoctor)
+		api.PATCH("/appointments/:id/status", auth.RequireAuth(), auth.RequireRole("doctor"), appointments.UpdateStatus)
 	}
 
 	addr := fmt.Sprintf(":%s", cfg.Port)

--- a/backend/main.go
+++ b/backend/main.go
@@ -74,6 +74,7 @@ func main() {
 		api.POST("/appointments", auth.RequireAuth(), auth.RequireRole("patient"), appointments.Create)
 		api.GET("/appointments/patient", auth.RequireAuth(), auth.RequireRole("patient"), appointments.ListPatient)
 		api.GET("/appointments/doctor", auth.RequireAuth(), auth.RequireRole("doctor"), appointments.ListDoctor)
+		api.GET("/doctors", auth.RequireAuth(), auth.RequireRole("patient"), appointments.ListAvailableDoctors)
 		api.PATCH("/appointments/:id/status", auth.RequireAuth(), auth.RequireRole("doctor"), appointments.UpdateStatus)
 	}
 


### PR DESCRIPTION
This change brings the backend appointments feature into dev: patients can create and list their requests, doctors can list assigned requests and update status, and patients can choose a doctor from a safe directory endpoint instead of pasting raw UUIDs.

What’s included
Appointments data model integration with existing auth (JWT, role checks).
Patient APIs: create appointment request, list my appointments.
Doctor APIs: list appointments for the logged-in doctor, approve/reject (or equivalent status update) for pending requests.
Directory: GET endpoint(s) exposing doctors available for selection (no sensitive fields), so the frontend can populate a dropdown.
Validation and error handling for invalid doctor IDs, self-booking, and basic request body checks.
Why it matters
Unblocks the patient and doctor UIs for Sprint 2 booking flows and keeps doctor selection guided and consistent with backend rules.

How to test
Run backend with a seeded DB; authenticate as patient and doctor test users.
Patient: create request with a valid doctor_id, list patient appointments.
Doctor: list doctor queue, update status on a pending item.
Directory: call doctors list as patient and confirm only expected fields are returned.
Risk / follow-ups
Ensure DB migrations (if any) are applied before testing.
Frontend work may depend on exact response shapes; coordinate with Abhinava’s UI branch if contract changes.
Related
US-7b / US-8a (backend)
Depends on earlier schema/migration work (e.g. US-6) if present in dev.