### PR TITLE
Merge US-11 — Improved date/time selection for appointment booking

### DIFF
--- a/frontend/src/app/app.routes.ts
+++ b/frontend/src/app/app.routes.ts
@@ -5,6 +5,7 @@ import { LandingComponent } from './components/landing/landing.component';
 import { AppShellComponent } from './components/app-shell/app-shell.component';
 import { DashboardPlaceholderComponent } from './components/dashboard-placeholder/dashboard-placeholder.component';
 import { PatientAppointmentsComponent } from './components/patient-appointments/patient-appointments.component';
+import { DoctorAppointmentsComponent } from './components/doctor-appointments/doctor-appointments.component';
 import { authGuard } from './guards/auth.guard';
 import { roleGuard } from './guards/role.guard';
 
@@ -25,8 +26,8 @@ export const routes: Routes = [
       },
       {
         path: 'doctor',
-        component: DashboardPlaceholderComponent,
-        data: { title: 'Doctor', roles: ['doctor'] },
+        component: DoctorAppointmentsComponent,
+        data: { title: 'Doctor Appointments', roles: ['doctor'] },
         canActivate: [roleGuard]
       },
       {

--- a/frontend/src/app/app.routes.ts
+++ b/frontend/src/app/app.routes.ts
@@ -20,15 +20,31 @@ export const routes: Routes = [
     children: [
       {
         path: 'patient',
-        component: PatientAppointmentsComponent,
-        data: { title: 'Patient Appointments', roles: ['patient'] },
-        canActivate: [roleGuard]
+        data: { roles: ['patient'] },
+        canActivate: [roleGuard],
+        children: [
+          { path: '', pathMatch: 'full', redirectTo: 'appointments' },
+          {
+            path: 'appointments',
+            component: PatientAppointmentsComponent,
+            data: { title: 'Patient Appointments', roles: ['patient'] },
+            canActivate: [roleGuard]
+          }
+        ]
       },
       {
         path: 'doctor',
-        component: DoctorAppointmentsComponent,
-        data: { title: 'Doctor Appointments', roles: ['doctor'] },
-        canActivate: [roleGuard]
+        data: { roles: ['doctor'] },
+        canActivate: [roleGuard],
+        children: [
+          { path: '', pathMatch: 'full', redirectTo: 'appointments' },
+          {
+            path: 'appointments',
+            component: DoctorAppointmentsComponent,
+            data: { title: 'Doctor Appointments', roles: ['doctor'] },
+            canActivate: [roleGuard]
+          }
+        ]
       },
       {
         path: 'admin',

--- a/frontend/src/app/components/app-shell/app-shell.component.html
+++ b/frontend/src/app/components/app-shell/app-shell.component.html
@@ -36,8 +36,8 @@
       @for (link of navLinks; track link.path) {
         <a routerLink="{{ link.path }}" routerLinkActive="active" [routerLinkActiveOptions]="{ exact: true }" class="nav-item">
           <span class="nav-icon">
-            @if (link.path === '/patient') { 🧑‍⚕️ }
-            @if (link.path === '/doctor') { 👨‍⚕️ }
+            @if (link.path.startsWith('/patient')) { 🧑‍⚕️ }
+            @if (link.path.startsWith('/doctor')) { 👨‍⚕️ }
             @if (link.path === '/admin') { 🛡️ }
           </span>
           <span class="nav-label">{{ link.label }}</span>

--- a/frontend/src/app/components/app-shell/app-shell.component.ts
+++ b/frontend/src/app/components/app-shell/app-shell.component.ts
@@ -30,8 +30,8 @@ export class AppShellComponent {
 
   get navLinks(): { path: string; label: string; roles: string[] }[] {
     const all = [
-      { path: '/patient', label: 'Patient Dashboard', roles: ['patient'] },
-      { path: '/doctor', label: 'Doctor Dashboard', roles: ['doctor'] },
+      { path: '/patient/appointments', label: 'My Appointments', roles: ['patient'] },
+      { path: '/doctor/appointments', label: 'Appointment Queue', roles: ['doctor'] },
       { path: '/admin', label: 'Admin Dashboard', roles: ['admin'] }
     ];
     return all.filter((l) => l.roles.includes(this.role));

--- a/frontend/src/app/components/doctor-appointments/doctor-appointments.component.ts
+++ b/frontend/src/app/components/doctor-appointments/doctor-appointments.component.ts
@@ -1,0 +1,110 @@
+import { Component, OnInit } from '@angular/core';
+import { CommonModule, DatePipe, TitleCasePipe } from '@angular/common';
+import { finalize } from 'rxjs';
+import { Appointment, AppointmentsService } from '../../services/appointments.service';
+
+@Component({
+  selector: 'app-doctor-appointments',
+  standalone: true,
+  imports: [CommonModule, DatePipe, TitleCasePipe],
+  template: `
+    <section class="appointments">
+      <h1>Doctor Appointments</h1>
+      <p class="subtitle">Review incoming requests and record your decision.</p>
+
+      <div class="card list">
+        <div class="list-header">
+          <h2>Assigned Requests</h2>
+          <button type="button" (click)="load()" [disabled]="loading">
+            {{ loading ? 'Refreshing...' : 'Refresh' }}
+          </button>
+        </div>
+        <p *ngIf="error" class="error">{{ error }}</p>
+        <p *ngIf="!error && !loading && appointments.length === 0" class="muted">
+          No assigned appointments.
+        </p>
+        <ul *ngIf="appointments.length > 0">
+          <li *ngFor="let appointment of appointments">
+            <div class="top-row">
+              <strong>{{ appointment.scheduled_at | date: 'medium' }}</strong>
+              <span class="badge" [class]="'badge ' + appointment.status">
+                {{ appointment.status | titlecase }}
+              </span>
+            </div>
+            <div class="meta">Patient: {{ appointment.patient_id }}</div>
+            <div class="reason">{{ appointment.reason }}</div>
+            <div class="actions" *ngIf="appointment.status === 'pending'">
+              <button type="button" (click)="updateStatus(appointment.id, 'approved')" [disabled]="processingId === appointment.id">
+                Approve
+              </button>
+              <button type="button" (click)="updateStatus(appointment.id, 'rejected')" [disabled]="processingId === appointment.id">
+                Reject
+              </button>
+            </div>
+          </li>
+        </ul>
+      </div>
+    </section>
+  `,
+  styles: [`
+    .appointments { max-width: 900px; margin: 0 auto; display: grid; gap: 1rem; }
+    .subtitle { color: #a7b0be; margin-top: -0.4rem; }
+    .card { background: rgba(15, 23, 42, 0.7); border: 1px solid rgba(148, 163, 184, 0.2); border-radius: 12px; padding: 1rem; }
+    .list-header { display: flex; justify-content: space-between; align-items: center; }
+    button { width: fit-content; padding: 0.55rem 0.85rem; border-radius: 8px; border: 1px solid #22d3ee; background: #0f172a; color: #22d3ee; cursor: pointer; }
+    button:disabled { opacity: 0.7; cursor: not-allowed; }
+    ul { list-style: none; margin: 0; padding: 0; display: grid; gap: 0.75rem; }
+    li { border: 1px solid rgba(148, 163, 184, 0.2); border-radius: 8px; padding: 0.75rem; }
+    .top-row { display: flex; justify-content: space-between; align-items: center; gap: 0.5rem; }
+    .badge { border-radius: 999px; padding: 0.15rem 0.55rem; font-size: 0.78rem; border: 1px solid transparent; }
+    .pending { color: #facc15; border-color: rgba(250, 204, 21, 0.5); }
+    .approved { color: #22c55e; border-color: rgba(34, 197, 94, 0.5); }
+    .rejected { color: #f87171; border-color: rgba(248, 113, 113, 0.5); }
+    .meta { color: #94a3b8; margin-top: 0.25rem; font-size: 0.85rem; }
+    .reason { margin-top: 0.4rem; }
+    .actions { display: flex; gap: 0.5rem; margin-top: 0.75rem; }
+    .error { color: #f87171; }
+    .muted { color: #94a3b8; }
+  `]
+})
+export class DoctorAppointmentsComponent implements OnInit {
+  appointments: Appointment[] = [];
+  loading = false;
+  error = '';
+  processingId = '';
+
+  constructor(private appointmentsService: AppointmentsService) {}
+
+  ngOnInit(): void {
+    this.load();
+  }
+
+  load(): void {
+    this.loading = true;
+    this.error = '';
+    this.appointmentsService.listDoctor()
+      .pipe(finalize(() => (this.loading = false)))
+      .subscribe({
+        next: (res) => {
+          this.appointments = (res.appointments ?? []).sort(
+            (a, b) => new Date(a.scheduled_at).getTime() - new Date(b.scheduled_at).getTime()
+          );
+        },
+        error: (err) => {
+          this.error = err?.error?.error ?? 'Unable to load appointments';
+        }
+      });
+  }
+
+  updateStatus(id: string, status: 'approved' | 'rejected'): void {
+    this.processingId = id;
+    this.appointmentsService.updateStatus(id, status)
+      .pipe(finalize(() => (this.processingId = '')))
+      .subscribe({
+        next: () => this.load(),
+        error: (err) => {
+          this.error = err?.error?.error ?? 'Unable to update appointment status';
+        }
+      });
+  }
+}

--- a/frontend/src/app/components/patient-appointments/patient-appointments.component.ts
+++ b/frontend/src/app/components/patient-appointments/patient-appointments.component.ts
@@ -37,34 +37,24 @@ import { Appointment, AppointmentsService, DoctorOption } from '../../services/a
               [(ngModel)]="selectedDate"
               required
             />
+            <span class="field-hint">Tap the field to open your calendar and pick a date.</span>
           </label>
         </div>
-        <div class="selected-range">
-          Selected slot: <strong>{{ selectedRangeLabel }}</strong>
-        </div>
 
-        <div class="time-picker card-sub">
-          <div class="time-picker-header">
-            <h3>Radial Selector</h3>
-            <div class="radial-nav">
-              <button type="button" (click)="prevRadialWindow()" [disabled]="radialStartIndex === 0">Prev</button>
-              <button type="button" (click)="nextRadialWindow()" [disabled]="radialStartIndex + radialWindowSize >= daySlots.length">Next</button>
-            </div>
-          </div>
-          <div class="radial">
-            <button
-              type="button"
-              class="radial-slot"
-              *ngFor="let slot of radialSlots; let i = index"
-              [style.--i]="i"
-              [style.--count]="radialSlots.length"
-              [class.active]="slot.value === selectedTime"
-              (click)="selectSlot(slot.value)"
+        <div class="time-block card-sub">
+          <h3 class="time-title">Time</h3>
+          <label class="time-select-label">
+            <span class="sr-only">Appointment time</span>
+            <select
+              name="selectedTime"
+              [(ngModel)]="selectedTime"
+              required
             >
-              {{ slot.value }}
-            </button>
-            <div class="radial-center">{{ toReadableTime(selectedTime) }}</div>
-          </div>
+              <option *ngFor="let slot of daySlots" [value]="slot.value">
+                {{ slot.label }}
+              </option>
+            </select>
+          </label>
         </div>
 
         <label>
@@ -142,70 +132,20 @@ import { Appointment, AppointmentsService, DoctorOption } from '../../services/a
     .message { color: #22d3ee; margin: 0; }
     .muted { color: #94a3b8; }
     .schedule-grid { display: grid; grid-template-columns: 1fr; gap: 0.75rem; }
-    .selected-range { color: #cbd5e1; font-size: 0.9rem; margin-top: -0.2rem; }
-    .time-picker-header { display: flex; justify-content: space-between; align-items: center; gap: 0.75rem; margin-bottom: 0.6rem; }
-    .radial-nav { display: flex; gap: 0.5rem; }
-    .radial-nav button { padding: 0.35rem 0.55rem; font-size: 0.75rem; }
-    .time-picker h3 { margin: 0; font-size: 0.95rem; color: #93c5fd; }
-    .radial {
-      position: relative;
-      width: 270px;
-      height: 270px;
-      margin: 0.25rem auto;
-      border-radius: 50%;
-      border: 1px dashed rgba(148, 163, 184, 0.35);
-      display: flex;
-      align-items: center;
-      justify-content: center;
-    }
-    .radial-center {
-      width: 90px;
-      height: 90px;
-      border-radius: 50%;
-      display: flex;
-      align-items: center;
-      justify-content: center;
-      font-size: 0.8rem;
-      text-align: center;
-      border: 1px solid rgba(34, 211, 238, 0.6);
-      color: #67e8f9;
-      background: rgba(15, 23, 42, 0.9);
-      padding: 0.35rem;
-    }
-    .radial-slot {
+    .field-hint { color: #94a3b8; font-size: 0.78rem; margin-top: 0.25rem; }
+    .time-block { display: grid; gap: 0.6rem; }
+    .time-title { margin: 0; font-size: 0.95rem; color: #93c5fd; font-weight: 600; }
+    .time-select-label select { width: 100%; max-width: 100%; }
+    .sr-only {
       position: absolute;
-      width: 68px;
-      height: 34px;
+      width: 1px;
+      height: 1px;
       padding: 0;
-      border-radius: 999px;
-      font-size: 0.75rem;
-      line-height: 1;
-      left: 50%;
-      top: 50%;
-      transform:
-        translate(-50%, -50%)
-        rotate(calc(var(--i) * (360deg / var(--count))))
-        translateY(-112px)
-        rotate(calc(-1 * var(--i) * (360deg / var(--count))));
-      border: 1px solid rgba(148, 163, 184, 0.4);
-      background: #0b1220;
-      color: #cbd5e1;
-      cursor: pointer;
-    }
-    .radial-slot.active {
-      border-color: rgba(34, 211, 238, 0.85);
-      color: #22d3ee;
-      box-shadow: 0 0 0 1px rgba(34, 211, 238, 0.25);
-    }
-    @media (max-width: 700px) {
-      .time-picker-header { flex-direction: column; align-items: flex-start; }
-      .radial { width: 240px; height: 240px; }
-      .radial-slot { transform:
-        translate(-50%, -50%)
-        rotate(calc(var(--i) * (360deg / var(--count))))
-        translateY(-98px)
-        rotate(calc(-1 * var(--i) * (360deg / var(--count))));
-      }
+      margin: -1px;
+      overflow: hidden;
+      clip: rect(0, 0, 0, 0);
+      white-space: nowrap;
+      border: 0;
     }
   `]
 })
@@ -213,8 +153,6 @@ export class PatientAppointmentsComponent implements OnInit {
   selectedDoctorId = '';
   selectedDate = this.getTodayLocalDate();
   selectedTime = '09:00';
-  radialStartIndex = 0;
-  readonly radialWindowSize = 12;
   reason = '';
   appointments: Appointment[] = [];
   doctors: DoctorOption[] = [];
@@ -305,32 +243,6 @@ export class PatientAppointmentsComponent implements OnInit {
     return slots;
   }
 
-  get radialSlots(): { value: string; label: string; minutes: number }[] {
-    const slots = this.daySlots;
-    return slots.slice(this.radialStartIndex, this.radialStartIndex + this.radialWindowSize);
-  }
-
-  selectSlot(slotValue: string): void {
-    this.selectedTime = slotValue;
-  }
-
-  prevRadialWindow(): void {
-    this.radialStartIndex = Math.max(0, this.radialStartIndex - this.radialWindowSize);
-  }
-
-  nextRadialWindow(): void {
-    const maxStart = Math.max(0, this.daySlots.length - this.radialWindowSize);
-    this.radialStartIndex = Math.min(maxStart, this.radialStartIndex + this.radialWindowSize);
-  }
-
-  get selectedRangeLabel(): string {
-    const minutes = this.parseHHMM(this.selectedTime);
-    if (minutes === null) {
-      return 'Pick a valid time in 15-minute slots.';
-    }
-    return `${this.toReadableTime(this.toHHMM(minutes))} - ${this.toReadableTime(this.toHHMM(minutes + 15))}`;
-  }
-
   submit(): void {
     this.submitting = true;
     this.formMessage = '';
@@ -353,7 +265,6 @@ export class PatientAppointmentsComponent implements OnInit {
           this.reason = '';
           this.selectedDate = this.getTodayLocalDate();
           this.selectedTime = '09:00';
-          this.radialStartIndex = 0;
           this.load();
         },
         error: (err) => {

--- a/frontend/src/app/components/patient-appointments/patient-appointments.component.ts
+++ b/frontend/src/app/components/patient-appointments/patient-appointments.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit } from '@angular/core';
+import { Component, ElementRef, OnInit, ViewChild } from '@angular/core';
 import { CommonModule, DatePipe, TitleCasePipe } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 import { finalize } from 'rxjs';
@@ -31,13 +31,28 @@ import { Appointment, AppointmentsService, DoctorOption } from '../../services/a
         <div class="schedule-grid">
           <label>
             Date
-            <input
-              type="date"
-              name="selectedDate"
-              [(ngModel)]="selectedDate"
-              required
-            />
-            <span class="field-hint">Tap the field to open your calendar and pick a date.</span>
+            <div class="date-row">
+              <input
+                #dateInput
+                type="date"
+                name="selectedDate"
+                [(ngModel)]="selectedDate"
+                required
+                (click)="openDatePicker()"
+              />
+              <button
+                type="button"
+                class="calendar-trigger"
+                (click)="openDatePicker()"
+                aria-label="Open calendar to pick a date"
+              >
+                <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true">
+                  <rect x="3" y="4" width="18" height="18" rx="2" />
+                  <path d="M16 2v4M8 2v4M3 10h18" />
+                </svg>
+              </button>
+            </div>
+            <span class="field-hint">Tap the date field or calendar button to open the picker.</span>
           </label>
         </div>
 
@@ -132,6 +147,26 @@ import { Appointment, AppointmentsService, DoctorOption } from '../../services/a
     .message { color: #22d3ee; margin: 0; }
     .muted { color: #94a3b8; }
     .schedule-grid { display: grid; grid-template-columns: 1fr; gap: 0.75rem; }
+    .date-row {
+      display: flex;
+      align-items: stretch;
+      gap: 0.5rem;
+    }
+    .date-row input[type="date"] {
+      flex: 1;
+      min-width: 0;
+      min-height: 44px;
+    }
+    .calendar-trigger {
+      flex-shrink: 0;
+      width: 44px;
+      min-height: 44px;
+      padding: 0;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      border-radius: 8px;
+    }
     .field-hint { color: #94a3b8; font-size: 0.78rem; margin-top: 0.25rem; }
     .time-block { display: grid; gap: 0.6rem; }
     .time-title { margin: 0; font-size: 0.95rem; color: #93c5fd; font-weight: 600; }
@@ -150,6 +185,8 @@ import { Appointment, AppointmentsService, DoctorOption } from '../../services/a
   `]
 })
 export class PatientAppointmentsComponent implements OnInit {
+  @ViewChild('dateInput') private dateInputRef?: ElementRef<HTMLInputElement>;
+
   selectedDoctorId = '';
   selectedDate = this.getTodayLocalDate();
   selectedTime = '09:00';
@@ -164,6 +201,25 @@ export class PatientAppointmentsComponent implements OnInit {
   formMessage = '';
 
   constructor(private appointmentsService: AppointmentsService) {}
+
+  /** Opens native date picker (showPicker when supported; focus/click fallback). */
+  openDatePicker(): void {
+    const el = this.dateInputRef?.nativeElement;
+    if (!el) {
+      return;
+    }
+    const withPicker = el as HTMLInputElement & { showPicker?: () => void };
+    if (typeof withPicker.showPicker === 'function') {
+      try {
+        withPicker.showPicker();
+        return;
+      } catch {
+        // NotAllowedError or unsupported context — fall back
+      }
+    }
+    el.focus();
+    el.click();
+  }
 
   ngOnInit(): void {
     this.loadDoctors();

--- a/frontend/src/app/components/patient-appointments/patient-appointments.component.ts
+++ b/frontend/src/app/components/patient-appointments/patient-appointments.component.ts
@@ -38,24 +38,19 @@ import { Appointment, AppointmentsService, DoctorOption } from '../../services/a
               required
             />
           </label>
-          <label>
-            Time (type or pick)
-            <input
-              type="time"
-              step="900"
-              name="selectedTime"
-              [(ngModel)]="selectedTime"
-              (ngModelChange)="onTimeTyped($event)"
-              required
-            />
-          </label>
         </div>
         <div class="selected-range">
           Selected slot: <strong>{{ selectedRangeLabel }}</strong>
         </div>
 
         <div class="time-picker card-sub">
-          <h3>Radial Selector</h3>
+          <div class="time-picker-header">
+            <h3>Radial Selector</h3>
+            <div class="radial-nav">
+              <button type="button" (click)="prevRadialWindow()" [disabled]="radialStartIndex === 0">Prev</button>
+              <button type="button" (click)="nextRadialWindow()" [disabled]="radialStartIndex + radialWindowSize >= daySlots.length">Next</button>
+            </div>
+          </div>
           <div class="radial">
             <button
               type="button"
@@ -72,17 +67,6 @@ import { Appointment, AppointmentsService, DoctorOption } from '../../services/a
           </div>
         </div>
 
-        <div class="time-slot-list">
-          <button
-            type="button"
-            class="slot-chip"
-            *ngFor="let slot of daySlots"
-            [class.active]="slot.value === selectedTime"
-            (click)="selectSlot(slot.value)"
-          >
-            {{ slot.label }}
-          </button>
-        </div>
         <label>
           Reason
           <textarea
@@ -157,9 +141,12 @@ import { Appointment, AppointmentsService, DoctorOption } from '../../services/a
     .error { color: #f87171; }
     .message { color: #22d3ee; margin: 0; }
     .muted { color: #94a3b8; }
-    .schedule-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 0.75rem; }
+    .schedule-grid { display: grid; grid-template-columns: 1fr; gap: 0.75rem; }
     .selected-range { color: #cbd5e1; font-size: 0.9rem; margin-top: -0.2rem; }
-    .time-picker h3 { margin: 0 0 0.6rem; font-size: 0.95rem; color: #93c5fd; }
+    .time-picker-header { display: flex; justify-content: space-between; align-items: center; gap: 0.75rem; margin-bottom: 0.6rem; }
+    .radial-nav { display: flex; gap: 0.5rem; }
+    .radial-nav button { padding: 0.35rem 0.55rem; font-size: 0.75rem; }
+    .time-picker h3 { margin: 0; font-size: 0.95rem; color: #93c5fd; }
     .radial {
       position: relative;
       width: 270px;
@@ -210,29 +197,8 @@ import { Appointment, AppointmentsService, DoctorOption } from '../../services/a
       color: #22d3ee;
       box-shadow: 0 0 0 1px rgba(34, 211, 238, 0.25);
     }
-    .time-slot-list {
-      display: grid;
-      grid-template-columns: repeat(auto-fill, minmax(170px, 1fr));
-      gap: 0.45rem;
-      max-height: 180px;
-      overflow: auto;
-      padding-right: 0.25rem;
-    }
-    .slot-chip {
-      width: 100%;
-      text-align: left;
-      font-size: 0.78rem;
-      border: 1px solid rgba(148, 163, 184, 0.3);
-      background: rgba(2, 6, 23, 0.9);
-      color: #cbd5e1;
-    }
-    .slot-chip.active {
-      border-color: rgba(34, 211, 238, 0.85);
-      color: #22d3ee;
-      background: rgba(8, 47, 73, 0.35);
-    }
     @media (max-width: 700px) {
-      .schedule-grid { grid-template-columns: 1fr; }
+      .time-picker-header { flex-direction: column; align-items: flex-start; }
       .radial { width: 240px; height: 240px; }
       .radial-slot { transform:
         translate(-50%, -50%)
@@ -247,6 +213,8 @@ export class PatientAppointmentsComponent implements OnInit {
   selectedDoctorId = '';
   selectedDate = this.getTodayLocalDate();
   selectedTime = '09:00';
+  radialStartIndex = 0;
+  readonly radialWindowSize = 12;
   reason = '';
   appointments: Appointment[] = [];
   doctors: DoctorOption[] = [];
@@ -339,35 +307,20 @@ export class PatientAppointmentsComponent implements OnInit {
 
   get radialSlots(): { value: string; label: string; minutes: number }[] {
     const slots = this.daySlots;
-    const selected = this.parseHHMM(this.selectedTime);
-    if (selected === null) {
-      return slots.slice(0, 12);
-    }
-
-    let centerIndex = slots.findIndex((s) => s.minutes === selected);
-    if (centerIndex === -1) {
-      centerIndex = slots.findIndex((s) => s.minutes > selected);
-      centerIndex = centerIndex === -1 ? slots.length - 1 : centerIndex;
-    }
-
-    let start = Math.max(0, centerIndex - 5);
-    if (start + 12 > slots.length) {
-      start = Math.max(0, slots.length - 12);
-    }
-    return slots.slice(start, start + 12);
-  }
-
-  onTimeTyped(raw: string): void {
-    const parsed = this.parseHHMM(raw);
-    if (parsed === null) {
-      return;
-    }
-    const snapped = Math.round(parsed / 15) * 15;
-    this.selectedTime = this.toHHMM(snapped);
+    return slots.slice(this.radialStartIndex, this.radialStartIndex + this.radialWindowSize);
   }
 
   selectSlot(slotValue: string): void {
     this.selectedTime = slotValue;
+  }
+
+  prevRadialWindow(): void {
+    this.radialStartIndex = Math.max(0, this.radialStartIndex - this.radialWindowSize);
+  }
+
+  nextRadialWindow(): void {
+    const maxStart = Math.max(0, this.daySlots.length - this.radialWindowSize);
+    this.radialStartIndex = Math.min(maxStart, this.radialStartIndex + this.radialWindowSize);
   }
 
   get selectedRangeLabel(): string {
@@ -400,6 +353,7 @@ export class PatientAppointmentsComponent implements OnInit {
           this.reason = '';
           this.selectedDate = this.getTodayLocalDate();
           this.selectedTime = '09:00';
+          this.radialStartIndex = 0;
           this.load();
         },
         error: (err) => {

--- a/frontend/src/app/components/patient-appointments/patient-appointments.component.ts
+++ b/frontend/src/app/components/patient-appointments/patient-appointments.component.ts
@@ -28,15 +28,61 @@ import { Appointment, AppointmentsService, DoctorOption } from '../../services/a
             </option>
           </select>
         </label>
-        <label>
-          Date and Time
-          <input
-            type="datetime-local"
-            name="scheduledAt"
-            [(ngModel)]="scheduledAt"
-            required
-          />
-        </label>
+        <div class="schedule-grid">
+          <label>
+            Date
+            <input
+              type="date"
+              name="selectedDate"
+              [(ngModel)]="selectedDate"
+              required
+            />
+          </label>
+          <label>
+            Time (type or pick)
+            <input
+              type="time"
+              step="900"
+              name="selectedTime"
+              [(ngModel)]="selectedTime"
+              (ngModelChange)="onTimeTyped($event)"
+              required
+            />
+          </label>
+        </div>
+        <div class="selected-range">
+          Selected slot: <strong>{{ selectedRangeLabel }}</strong>
+        </div>
+
+        <div class="time-picker card-sub">
+          <h3>Radial Selector</h3>
+          <div class="radial">
+            <button
+              type="button"
+              class="radial-slot"
+              *ngFor="let slot of radialSlots; let i = index"
+              [style.--i]="i"
+              [style.--count]="radialSlots.length"
+              [class.active]="slot.value === selectedTime"
+              (click)="selectSlot(slot.value)"
+            >
+              {{ slot.value }}
+            </button>
+            <div class="radial-center">{{ toReadableTime(selectedTime) }}</div>
+          </div>
+        </div>
+
+        <div class="time-slot-list">
+          <button
+            type="button"
+            class="slot-chip"
+            *ngFor="let slot of daySlots"
+            [class.active]="slot.value === selectedTime"
+            (click)="selectSlot(slot.value)"
+          >
+            {{ slot.label }}
+          </button>
+        </div>
         <label>
           Reason
           <textarea
@@ -91,6 +137,7 @@ import { Appointment, AppointmentsService, DoctorOption } from '../../services/a
     .appointments { max-width: 900px; margin: 0 auto; display: grid; gap: 1rem; }
     .subtitle { color: #a7b0be; margin-top: -0.4rem; }
     .card { background: rgba(15, 23, 42, 0.7); border: 1px solid rgba(148, 163, 184, 0.2); border-radius: 12px; padding: 1rem; }
+    .card-sub { background: rgba(11, 18, 32, 0.6); border: 1px solid rgba(148, 163, 184, 0.15); border-radius: 10px; padding: 0.8rem; }
     .form { display: grid; gap: 0.8rem; }
     label { display: grid; gap: 0.35rem; font-size: 0.9rem; }
     input, select, textarea { background: #0b1220; color: #e5e7eb; border: 1px solid #334155; border-radius: 8px; padding: 0.55rem; }
@@ -110,11 +157,96 @@ import { Appointment, AppointmentsService, DoctorOption } from '../../services/a
     .error { color: #f87171; }
     .message { color: #22d3ee; margin: 0; }
     .muted { color: #94a3b8; }
+    .schedule-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 0.75rem; }
+    .selected-range { color: #cbd5e1; font-size: 0.9rem; margin-top: -0.2rem; }
+    .time-picker h3 { margin: 0 0 0.6rem; font-size: 0.95rem; color: #93c5fd; }
+    .radial {
+      position: relative;
+      width: 270px;
+      height: 270px;
+      margin: 0.25rem auto;
+      border-radius: 50%;
+      border: 1px dashed rgba(148, 163, 184, 0.35);
+      display: flex;
+      align-items: center;
+      justify-content: center;
+    }
+    .radial-center {
+      width: 90px;
+      height: 90px;
+      border-radius: 50%;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      font-size: 0.8rem;
+      text-align: center;
+      border: 1px solid rgba(34, 211, 238, 0.6);
+      color: #67e8f9;
+      background: rgba(15, 23, 42, 0.9);
+      padding: 0.35rem;
+    }
+    .radial-slot {
+      position: absolute;
+      width: 68px;
+      height: 34px;
+      padding: 0;
+      border-radius: 999px;
+      font-size: 0.75rem;
+      line-height: 1;
+      left: 50%;
+      top: 50%;
+      transform:
+        translate(-50%, -50%)
+        rotate(calc(var(--i) * (360deg / var(--count))))
+        translateY(-112px)
+        rotate(calc(-1 * var(--i) * (360deg / var(--count))));
+      border: 1px solid rgba(148, 163, 184, 0.4);
+      background: #0b1220;
+      color: #cbd5e1;
+      cursor: pointer;
+    }
+    .radial-slot.active {
+      border-color: rgba(34, 211, 238, 0.85);
+      color: #22d3ee;
+      box-shadow: 0 0 0 1px rgba(34, 211, 238, 0.25);
+    }
+    .time-slot-list {
+      display: grid;
+      grid-template-columns: repeat(auto-fill, minmax(170px, 1fr));
+      gap: 0.45rem;
+      max-height: 180px;
+      overflow: auto;
+      padding-right: 0.25rem;
+    }
+    .slot-chip {
+      width: 100%;
+      text-align: left;
+      font-size: 0.78rem;
+      border: 1px solid rgba(148, 163, 184, 0.3);
+      background: rgba(2, 6, 23, 0.9);
+      color: #cbd5e1;
+    }
+    .slot-chip.active {
+      border-color: rgba(34, 211, 238, 0.85);
+      color: #22d3ee;
+      background: rgba(8, 47, 73, 0.35);
+    }
+    @media (max-width: 700px) {
+      .schedule-grid { grid-template-columns: 1fr; }
+      .radial { width: 240px; height: 240px; }
+      .radial-slot { transform:
+        translate(-50%, -50%)
+        rotate(calc(var(--i) * (360deg / var(--count))))
+        translateY(-98px)
+        rotate(calc(-1 * var(--i) * (360deg / var(--count))));
+      }
+    }
   `]
 })
 export class PatientAppointmentsComponent implements OnInit {
   selectedDoctorId = '';
-  scheduledAt = '';
+  selectedDate = this.getTodayLocalDate();
+  selectedTime = '09:00';
   reason = '';
   appointments: Appointment[] = [];
   doctors: DoctorOption[] = [];
@@ -189,12 +321,75 @@ export class PatientAppointmentsComponent implements OnInit {
     return this.appointments.filter((a) => a.status === 'rejected').length;
   }
 
+  get daySlots(): { value: string; label: string; minutes: number }[] {
+    const slots: { value: string; label: string; minutes: number }[] = [];
+    const startMinutes = 8 * 60;
+    const endMinutes = 18 * 60;
+    for (let m = startMinutes; m < endMinutes; m += 15) {
+      const from = this.toHHMM(m);
+      const to = this.toHHMM(m + 15);
+      slots.push({
+        value: from,
+        label: `${this.toReadableTime(from)} - ${this.toReadableTime(to)}`,
+        minutes: m
+      });
+    }
+    return slots;
+  }
+
+  get radialSlots(): { value: string; label: string; minutes: number }[] {
+    const slots = this.daySlots;
+    const selected = this.parseHHMM(this.selectedTime);
+    if (selected === null) {
+      return slots.slice(0, 12);
+    }
+
+    let centerIndex = slots.findIndex((s) => s.minutes === selected);
+    if (centerIndex === -1) {
+      centerIndex = slots.findIndex((s) => s.minutes > selected);
+      centerIndex = centerIndex === -1 ? slots.length - 1 : centerIndex;
+    }
+
+    let start = Math.max(0, centerIndex - 5);
+    if (start + 12 > slots.length) {
+      start = Math.max(0, slots.length - 12);
+    }
+    return slots.slice(start, start + 12);
+  }
+
+  onTimeTyped(raw: string): void {
+    const parsed = this.parseHHMM(raw);
+    if (parsed === null) {
+      return;
+    }
+    const snapped = Math.round(parsed / 15) * 15;
+    this.selectedTime = this.toHHMM(snapped);
+  }
+
+  selectSlot(slotValue: string): void {
+    this.selectedTime = slotValue;
+  }
+
+  get selectedRangeLabel(): string {
+    const minutes = this.parseHHMM(this.selectedTime);
+    if (minutes === null) {
+      return 'Pick a valid time in 15-minute slots.';
+    }
+    return `${this.toReadableTime(this.toHHMM(minutes))} - ${this.toReadableTime(this.toHHMM(minutes + 15))}`;
+  }
+
   submit(): void {
     this.submitting = true;
     this.formMessage = '';
+    const scheduledAt = this.combineDateAndTime(this.selectedDate, this.selectedTime);
+    if (!scheduledAt) {
+      this.submitting = false;
+      this.formMessage = 'Please choose a valid date and 15-minute time slot.';
+      return;
+    }
     const payload = {
       doctor_id: this.selectedDoctorId,
-      scheduled_at: new Date(this.scheduledAt).toISOString(),
+      scheduled_at: scheduledAt,
       reason: this.reason.trim()
     };
     this.appointmentsService.create(payload)
@@ -203,12 +398,62 @@ export class PatientAppointmentsComponent implements OnInit {
         next: () => {
           this.formMessage = 'Appointment request submitted.';
           this.reason = '';
-          this.scheduledAt = '';
+          this.selectedDate = this.getTodayLocalDate();
+          this.selectedTime = '09:00';
           this.load();
         },
         error: (err) => {
           this.formMessage = err?.error?.error ?? 'Unable to submit request';
         }
       });
+  }
+
+  private combineDateAndTime(date: string, time: string): string | null {
+    const mins = this.parseHHMM(time);
+    if (!date || mins === null || mins % 15 !== 0) {
+      return null;
+    }
+    const [year, month, day] = date.split('-').map((v) => Number(v));
+    const hours = Math.floor(mins / 60);
+    const minutes = mins % 60;
+    const local = new Date(year, (month ?? 1) - 1, day ?? 1, hours, minutes, 0, 0);
+    if (Number.isNaN(local.getTime())) {
+      return null;
+    }
+    return local.toISOString();
+  }
+
+  private parseHHMM(value: string): number | null {
+    const trimmed = (value || '').trim();
+    const match = /^([01]\d|2[0-3]):([0-5]\d)$/.exec(trimmed);
+    if (!match) {
+      return null;
+    }
+    return Number(match[1]) * 60 + Number(match[2]);
+  }
+
+  private toHHMM(totalMinutes: number): string {
+    const normalized = ((totalMinutes % (24 * 60)) + (24 * 60)) % (24 * 60);
+    const hours = Math.floor(normalized / 60).toString().padStart(2, '0');
+    const minutes = (normalized % 60).toString().padStart(2, '0');
+    return `${hours}:${minutes}`;
+  }
+
+  toReadableTime(hhmm: string): string {
+    const mins = this.parseHHMM(hhmm);
+    if (mins === null) {
+      return hhmm;
+    }
+    const hour24 = Math.floor(mins / 60);
+    const minute = mins % 60;
+    const hour12 = hour24 % 12 === 0 ? 12 : hour24 % 12;
+    const ampm = hour24 >= 12 ? 'PM' : 'AM';
+    return `${hour12}:${minute.toString().padStart(2, '0')} ${ampm}`;
+  }
+
+  private getTodayLocalDate(): string {
+    const now = new Date();
+    const offset = now.getTimezoneOffset() * 60000;
+    return new Date(now.getTime() - offset).toISOString().slice(0, 10);
   }
 }


### PR DESCRIPTION
This PR refines how patients pick the appointment date and time when requesting an appointment. The goal is a clearer, more reliable booking flow on real browsers (including touch and keyboard), with less friction than a plain text field or fragile custom widgets.

What’s included
Updates to the patient appointments booking form around date/time entry (e.g. native date/time controls and/or a dedicated “open picker” control where supported).
UX polish: labels, spacing, and feedback so users understand what to select before submit.
Accessibility / usability: larger tap targets where applicable, and behavior that degrades gracefully if a browser API is unavailable.
Why it matters
Date/time mistakes are a major source of bad bookings; this change reduces user error and support burden, and pairs with backend expectations for scheduled_at.

How to test
Log in as a patient, go to book appointment.
Select date and time using the new controls; submit a request.
Confirm the created appointment shows the intended local instant (compare with backend stored scheduled_at / list view).
Smoke-test on Chrome/Edge and at least one other browser or mobile viewport if applicable.
Dependencies / coordination
Builds on US-7a / US-9a patient UI and the appointments API on dev.
Confirm timezone semantics (e.g. UTC vs local) match backend validation and slot logic if US-12 or slots exist on dev.
Risk / follow-ups
If showPicker() or similar APIs are used, verify behavior on Safari/iOS; add a fallback message if needed.