### PR TITLE
Appointment detail API (GET /api/appointments/:id)

### DIFF
--- a/backend/handlers/appointments.go
+++ b/backend/handlers/appointments.go
@@ -180,6 +180,54 @@ func (h *AppointmentHandler) ListDoctor(c *gin.Context) {
 	c.JSON(http.StatusOK, gin.H{"appointments": appointments})
 }
 
+// GetByID returns one appointment when the caller is the patient or assigned doctor.
+func (h *AppointmentHandler) GetByID(c *gin.Context) {
+	claims, ok := getClaims(c)
+	if !ok {
+		return
+	}
+	if claims.Role != "patient" && claims.Role != "doctor" {
+		c.JSON(http.StatusForbidden, gin.H{"error": "Forbidden"})
+		return
+	}
+
+	id, err := uuid.Parse(c.Param("id"))
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid appointment id"})
+		return
+	}
+
+	var appt models.Appointment
+	err = db.Pool.QueryRow(c.Request.Context(), `
+		SELECT id, patient_id, doctor_id, scheduled_at, reason, status, created_at, updated_at
+		FROM appointments
+		WHERE id = $1
+	`, id).Scan(&appt.ID, &appt.PatientID, &appt.DoctorID, &appt.ScheduledAt, &appt.Reason, &appt.Status, &appt.CreatedAt, &appt.UpdatedAt)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			c.JSON(http.StatusNotFound, gin.H{"error": "Appointment not found"})
+			return
+		}
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Internal error"})
+		return
+	}
+
+	switch claims.Role {
+	case "patient":
+		if appt.PatientID != claims.UserID {
+			c.JSON(http.StatusNotFound, gin.H{"error": "Appointment not found"})
+			return
+		}
+	case "doctor":
+		if appt.DoctorID != claims.UserID {
+			c.JSON(http.StatusNotFound, gin.H{"error": "Appointment not found"})
+			return
+		}
+	}
+
+	c.JSON(http.StatusOK, appt)
+}
+
 func (h *AppointmentHandler) ListAvailableDoctors(c *gin.Context) {
 	rows, err := db.Pool.Query(c.Request.Context(), `
 		SELECT id, email

--- a/backend/main.go
+++ b/backend/main.go
@@ -74,6 +74,7 @@ func main() {
 		api.POST("/appointments", auth.RequireAuth(), auth.RequireRole("patient"), appointments.Create)
 		api.GET("/appointments/patient", auth.RequireAuth(), auth.RequireRole("patient"), appointments.ListPatient)
 		api.GET("/appointments/doctor", auth.RequireAuth(), auth.RequireRole("doctor"), appointments.ListDoctor)
+		api.GET("/appointments/:id", auth.RequireAuth(), appointments.GetByID)
 		api.GET("/doctors", auth.RequireAuth(), auth.RequireRole("patient"), appointments.ListAvailableDoctors)
 		api.PATCH("/appointments/:id/status", auth.RequireAuth(), auth.RequireRole("doctor"), appointments.UpdateStatus)
 	}

--- a/docs/sprint3-assigned-features.md
+++ b/docs/sprint3-assigned-features.md
@@ -1,0 +1,70 @@
+# Sprint 3 — assigned features (stacked branches)
+
+Integration base: `dev` (`b4524cf` at time of planning). Work is sequenced so each branch builds on the previous; merge in order into `dev` or rebase the next branch after each merge.
+
+| Order | Assignee | Branch | Scope |
+| ----- | -------- | ------ | ----- |
+| 1 | Kaushik | `s3/kaushik-backend-appointment-detail-api` | Backend: single-appointment API |
+| 2 | Pavan | `s3/pavan-frontend-patient-appointment-detail` | Frontend: patient detail screen |
+| 3 | Pavan | `s3/pavan-frontend-doctor-appointment-detail` | Frontend: doctor detail screen |
+| 4 | Rohith | `s3/rohith-backend-appointment-activity-log` | Backend: activity log + listing |
+
+---
+
+## 1. Kaushik — `GET /api/appointments/:id`
+
+**Goal:** Let authenticated patients load their own appointment by id, and doctors load appointments assigned to them.
+
+**Acceptance criteria**
+
+- `GET /api/appointments/:id` requires JWT.
+- Patient may only read rows where `patient_id` matches the caller.
+- Doctor may only read rows where `doctor_id` matches the caller.
+- Other roles receive 403; unknown id or wrong party receives 404 (no id enumeration).
+- Response body is the existing `Appointment` JSON shape.
+
+---
+
+## 2. Pavan — Patient appointment detail (frontend)
+
+**Goal:** From “My Requests”, open a dedicated detail view that uses Kaushik’s endpoint.
+
+**Acceptance criteria**
+
+- Route under `/patient/appointments/:id` (guarded for patients).
+- Shows scheduled time, status, reason, doctor id (or label), with navigation back to the list.
+- Uses `AppointmentsService.getById` (or equivalent) calling `GET /api/appointments/:id`.
+- List entries link into the detail route.
+
+---
+
+## 3. Pavan — Doctor appointment detail (frontend)
+
+**Goal:** Mirror the patient experience for doctors reviewing a single request.
+
+**Acceptance criteria**
+
+- Route under `/doctor/appointments/:id` (guarded for doctors).
+- Shows scheduled time, status, reason, patient id, with back navigation to the queue.
+- Reuses the same backend detail endpoint with the doctor JWT.
+
+---
+
+## 4. Rohith — Appointment activity log (backend)
+
+**Goal:** Persist an audit trail when a doctor approves/rejects, and expose it over the API.
+
+**Acceptance criteria**
+
+- Migration adds `appointment_activities` (or equivalent) with FK to `appointments`.
+- Successful `PATCH /api/appointments/:id/status` inserts an activity row (actor = doctor, action + optional detail).
+- `GET /api/appointments/:id/activity` returns activities for that appointment; same access rules as `GET /api/appointments/:id`.
+
+---
+
+## Merge order
+
+1. `s3/kaushik-backend-appointment-detail-api`
+2. `s3/pavan-frontend-patient-appointment-detail`
+3. `s3/pavan-frontend-doctor-appointment-detail`
+4. `s3/rohith-backend-appointment-activity-log`


### PR DESCRIPTION
Adds a Sprint 2 backlog note and a role-safe way to load a single appointment by id.

What changed

New docs/sprint3-assigned-features.md describing the stacked S2 work and merge order.
GET /api/appointments/:id (JWT required): patients only see their own rows; assigned doctors only see theirs; others get 403; wrong or unknown id returns 404 to avoid leaking ids.
How to test

As a patient, request an id from your list; expect 200 and full appointment JSON.
As another patient or uninvolved doctor, same id should return 404.
Without a token, expect 401.