### PR TITLE
Patient appointment detail screen

### DIFF
--- a/frontend/src/app/app.routes.ts
+++ b/frontend/src/app/app.routes.ts
@@ -5,6 +5,7 @@ import { LandingComponent } from './components/landing/landing.component';
 import { AppShellComponent } from './components/app-shell/app-shell.component';
 import { DashboardPlaceholderComponent } from './components/dashboard-placeholder/dashboard-placeholder.component';
 import { PatientAppointmentsComponent } from './components/patient-appointments/patient-appointments.component';
+import { PatientAppointmentDetailComponent } from './components/patient-appointment-detail/patient-appointment-detail.component';
 import { DoctorAppointmentsComponent } from './components/doctor-appointments/doctor-appointments.component';
 import { authGuard } from './guards/auth.guard';
 import { roleGuard } from './guards/role.guard';
@@ -24,6 +25,12 @@ export const routes: Routes = [
         canActivate: [roleGuard],
         children: [
           { path: '', pathMatch: 'full', redirectTo: 'appointments' },
+          {
+            path: 'appointments/:id',
+            component: PatientAppointmentDetailComponent,
+            data: { title: 'Appointment details', roles: ['patient'] },
+            canActivate: [roleGuard]
+          },
           {
             path: 'appointments',
             component: PatientAppointmentsComponent,

--- a/frontend/src/app/components/patient-appointment-detail/patient-appointment-detail.component.ts
+++ b/frontend/src/app/components/patient-appointment-detail/patient-appointment-detail.component.ts
@@ -1,0 +1,85 @@
+import { Component, OnInit } from '@angular/core';
+import { CommonModule, DatePipe, TitleCasePipe } from '@angular/common';
+import { ActivatedRoute, Router, RouterModule } from '@angular/router';
+import { finalize } from 'rxjs';
+import { Appointment, AppointmentsService } from '../../services/appointments.service';
+
+@Component({
+  selector: 'app-patient-appointment-detail',
+  standalone: true,
+  imports: [CommonModule, RouterModule, DatePipe, TitleCasePipe],
+  template: `
+    <section class="detail">
+      <header class="toolbar">
+        <button type="button" class="back" (click)="back()">Back to list</button>
+        <h1>Appointment details</h1>
+      </header>
+      <p *ngIf="loading" class="muted">Loading...</p>
+      <p *ngIf="error" class="error">{{ error }}</p>
+      <div *ngIf="!loading && appointment" class="card">
+        <div class="top-row">
+          <strong>{{ appointment.scheduled_at | date: 'medium' }}</strong>
+          <span class="badge" [class]="'badge ' + appointment.status">
+            {{ appointment.status | titlecase }}
+          </span>
+        </div>
+        <div class="meta">Doctor: {{ appointment.doctor_id }}</div>
+        <div class="reason">{{ appointment.reason }}</div>
+      </div>
+    </section>
+  `,
+  styles: [`
+    .detail { max-width: 720px; margin: 0 auto; display: grid; gap: 1rem; }
+    .toolbar { display: flex; flex-direction: column; gap: 0.35rem; }
+    .back { width: fit-content; padding: 0.45rem 0.75rem; border-radius: 8px; border: 1px solid #64748b; background: #0f172a; color: #e2e8f0; cursor: pointer; }
+    h1 { margin: 0; font-size: 1.35rem; }
+    .card { background: rgba(15, 23, 42, 0.7); border: 1px solid rgba(148, 163, 184, 0.2); border-radius: 12px; padding: 1rem; }
+    .top-row { display: flex; justify-content: space-between; align-items: center; gap: 0.5rem; }
+    .badge { border-radius: 999px; padding: 0.15rem 0.55rem; font-size: 0.78rem; border: 1px solid transparent; }
+    .pending { color: #facc15; border-color: rgba(250, 204, 21, 0.5); }
+    .approved { color: #22c55e; border-color: rgba(34, 197, 94, 0.5); }
+    .rejected { color: #f87171; border-color: rgba(248, 113, 113, 0.5); }
+    .meta { color: #94a3b8; margin-top: 0.35rem; font-size: 0.9rem; }
+    .reason { margin-top: 0.5rem; }
+    .error { color: #f87171; }
+    .muted { color: #94a3b8; }
+  `]
+})
+export class PatientAppointmentDetailComponent implements OnInit {
+  appointment: Appointment | null = null;
+  loading = false;
+  error = '';
+
+  constructor(
+    private route: ActivatedRoute,
+    private router: Router,
+    private appointmentsService: AppointmentsService
+  ) {}
+
+  ngOnInit(): void {
+    const id = this.route.snapshot.paramMap.get('id');
+    if (!id) {
+      this.error = 'Missing appointment id';
+      return;
+    }
+    this.load(id);
+  }
+
+  load(id: string): void {
+    this.loading = true;
+    this.error = '';
+    this.appointmentsService
+      .getById(id)
+      .pipe(finalize(() => (this.loading = false)))
+      .subscribe({
+        next: (appt) => (this.appointment = appt),
+        error: (err) => {
+          this.error = err?.error?.error ?? 'Unable to load appointment';
+        }
+      });
+  }
+
+  back(): void {
+    void this.router.navigate(['/patient/appointments']);
+  }
+}

--- a/frontend/src/app/components/patient-appointments/patient-appointments.component.ts
+++ b/frontend/src/app/components/patient-appointments/patient-appointments.component.ts
@@ -1,5 +1,6 @@
 import { Component, ElementRef, OnInit, ViewChild } from '@angular/core';
 import { CommonModule, DatePipe, TitleCasePipe } from '@angular/common';
+import { RouterModule } from '@angular/router';
 import { FormsModule } from '@angular/forms';
 import { finalize } from 'rxjs';
 import { Appointment, AppointmentsService, DoctorOption } from '../../services/appointments.service';
@@ -7,7 +8,7 @@ import { Appointment, AppointmentsService, DoctorOption } from '../../services/a
 @Component({
   selector: 'app-patient-appointments',
   standalone: true,
-  imports: [CommonModule, FormsModule, DatePipe, TitleCasePipe],
+  imports: [CommonModule, FormsModule, RouterModule, DatePipe, TitleCasePipe],
   template: `
     <section class="appointments">
       <h1>Patient Appointments</h1>
@@ -109,14 +110,17 @@ import { Appointment, AppointmentsService, DoctorOption } from '../../services/a
         </p>
         <ul *ngIf="appointments.length > 0">
           <li *ngFor="let appointment of sortedAppointments">
-            <div class="top-row">
-              <strong>{{ appointment.scheduled_at | date: 'medium' }}</strong>
-              <span class="badge" [class]="'badge ' + appointment.status">
-                {{ appointment.status | titlecase }}
-              </span>
-            </div>
-            <div class="meta">Doctor: {{ appointment.doctor_id }}</div>
-            <div class="reason">{{ appointment.reason }}</div>
+            <a class="row-link" [routerLink]="['/patient/appointments', appointment.id]">
+              <div class="top-row">
+                <strong>{{ appointment.scheduled_at | date: 'medium' }}</strong>
+                <span class="badge" [class]="'badge ' + appointment.status">
+                  {{ appointment.status | titlecase }}
+                </span>
+              </div>
+              <div class="meta">Doctor: {{ appointment.doctor_id }}</div>
+              <div class="reason">{{ appointment.reason }}</div>
+              <span class="hint">View details</span>
+            </a>
           </li>
         </ul>
       </div>
@@ -135,7 +139,16 @@ import { Appointment, AppointmentsService, DoctorOption } from '../../services/a
     .list-header { display: flex; justify-content: space-between; align-items: center; }
     .summary { display: flex; gap: 0.5rem; margin-bottom: 0.75rem; }
     ul { list-style: none; margin: 0; padding: 0; display: grid; gap: 0.75rem; }
-    li { border: 1px solid rgba(148, 163, 184, 0.2); border-radius: 8px; padding: 0.75rem; }
+    li { border: 1px solid rgba(148, 163, 184, 0.2); border-radius: 8px; padding: 0; overflow: hidden; }
+    .row-link {
+      display: grid;
+      gap: 0.35rem;
+      padding: 0.75rem;
+      color: inherit;
+      text-decoration: none;
+    }
+    .row-link:hover { background: rgba(34, 211, 238, 0.06); }
+    .hint { font-size: 0.78rem; color: #22d3ee; margin-top: 0.25rem; }
     .top-row { display: flex; justify-content: space-between; align-items: center; gap: 0.5rem; }
     .badge { border-radius: 999px; padding: 0.15rem 0.55rem; font-size: 0.78rem; border: 1px solid transparent; }
     .pending { color: #facc15; border-color: rgba(250, 204, 21, 0.5); }

--- a/frontend/src/app/services/appointments.service.ts
+++ b/frontend/src/app/services/appointments.service.ts
@@ -37,6 +37,10 @@ export class AppointmentsService {
     return this.http.post<Appointment>(this.API, input);
   }
 
+  getById(id: string): Observable<Appointment> {
+    return this.http.get<Appointment>(`${this.API}/${id}`);
+  }
+
   listPatient(): Observable<AppointmentListResponse> {
     return this.http.get<AppointmentListResponse>(`${this.API}/patient`);
   }


### PR DESCRIPTION
Adds a patient-facing detail view that uses the appointment detail API from PR 1.

What changed

AppointmentsService.getById() calling GET /api/appointments/:id.
Route /patient/appointments/:id with a detail component (schedule, status, reason, doctor id, back to list).
“My Requests” list rows link into the detail route.
Depends on

Merge of s2/kaushik-backend-appointment-detail-api into dev (or rebase this branch onto dev after that merge).
How to test

Log in as patient, open an appointment from the list, confirm fields and back navigation.