### PR TITLE
Doctor appointment detail screen

### DIFF
--- a/frontend/src/app/app.routes.ts
+++ b/frontend/src/app/app.routes.ts
@@ -7,6 +7,7 @@ import { DashboardPlaceholderComponent } from './components/dashboard-placeholde
 import { PatientAppointmentsComponent } from './components/patient-appointments/patient-appointments.component';
 import { PatientAppointmentDetailComponent } from './components/patient-appointment-detail/patient-appointment-detail.component';
 import { DoctorAppointmentsComponent } from './components/doctor-appointments/doctor-appointments.component';
+import { DoctorAppointmentDetailComponent } from './components/doctor-appointment-detail/doctor-appointment-detail.component';
 import { authGuard } from './guards/auth.guard';
 import { roleGuard } from './guards/role.guard';
 
@@ -45,6 +46,12 @@ export const routes: Routes = [
         canActivate: [roleGuard],
         children: [
           { path: '', pathMatch: 'full', redirectTo: 'appointments' },
+          {
+            path: 'appointments/:id',
+            component: DoctorAppointmentDetailComponent,
+            data: { title: 'Request details', roles: ['doctor'] },
+            canActivate: [roleGuard]
+          },
           {
             path: 'appointments',
             component: DoctorAppointmentsComponent,

--- a/frontend/src/app/components/doctor-appointment-detail/doctor-appointment-detail.component.ts
+++ b/frontend/src/app/components/doctor-appointment-detail/doctor-appointment-detail.component.ts
@@ -1,0 +1,85 @@
+import { Component, OnInit } from '@angular/core';
+import { CommonModule, DatePipe, TitleCasePipe } from '@angular/common';
+import { ActivatedRoute, Router, RouterModule } from '@angular/router';
+import { finalize } from 'rxjs';
+import { Appointment, AppointmentsService } from '../../services/appointments.service';
+
+@Component({
+  selector: 'app-doctor-appointment-detail',
+  standalone: true,
+  imports: [CommonModule, RouterModule, DatePipe, TitleCasePipe],
+  template: `
+    <section class="detail">
+      <header class="toolbar">
+        <button type="button" class="back" (click)="back()">Back to queue</button>
+        <h1>Request details</h1>
+      </header>
+      <p *ngIf="loading" class="muted">Loading...</p>
+      <p *ngIf="error" class="error">{{ error }}</p>
+      <div *ngIf="!loading && appointment" class="card">
+        <div class="top-row">
+          <strong>{{ appointment.scheduled_at | date: 'medium' }}</strong>
+          <span class="badge" [class]="'badge ' + appointment.status">
+            {{ appointment.status | titlecase }}
+          </span>
+        </div>
+        <div class="meta">Patient: {{ appointment.patient_id }}</div>
+        <div class="reason">{{ appointment.reason }}</div>
+      </div>
+    </section>
+  `,
+  styles: [`
+    .detail { max-width: 720px; margin: 0 auto; display: grid; gap: 1rem; }
+    .toolbar { display: flex; flex-direction: column; gap: 0.35rem; }
+    .back { width: fit-content; padding: 0.45rem 0.75rem; border-radius: 8px; border: 1px solid #64748b; background: #0f172a; color: #e2e8f0; cursor: pointer; }
+    h1 { margin: 0; font-size: 1.35rem; }
+    .card { background: rgba(15, 23, 42, 0.7); border: 1px solid rgba(148, 163, 184, 0.2); border-radius: 12px; padding: 1rem; }
+    .top-row { display: flex; justify-content: space-between; align-items: center; gap: 0.5rem; }
+    .badge { border-radius: 999px; padding: 0.15rem 0.55rem; font-size: 0.78rem; border: 1px solid transparent; }
+    .pending { color: #facc15; border-color: rgba(250, 204, 21, 0.5); }
+    .approved { color: #22c55e; border-color: rgba(34, 197, 94, 0.5); }
+    .rejected { color: #f87171; border-color: rgba(248, 113, 113, 0.5); }
+    .meta { color: #94a3b8; margin-top: 0.35rem; font-size: 0.9rem; }
+    .reason { margin-top: 0.5rem; }
+    .error { color: #f87171; }
+    .muted { color: #94a3b8; }
+  `]
+})
+export class DoctorAppointmentDetailComponent implements OnInit {
+  appointment: Appointment | null = null;
+  loading = false;
+  error = '';
+
+  constructor(
+    private route: ActivatedRoute,
+    private router: Router,
+    private appointmentsService: AppointmentsService
+  ) {}
+
+  ngOnInit(): void {
+    const id = this.route.snapshot.paramMap.get('id');
+    if (!id) {
+      this.error = 'Missing appointment id';
+      return;
+    }
+    this.load(id);
+  }
+
+  load(id: string): void {
+    this.loading = true;
+    this.error = '';
+    this.appointmentsService
+      .getById(id)
+      .pipe(finalize(() => (this.loading = false)))
+      .subscribe({
+        next: (appt) => (this.appointment = appt),
+        error: (err) => {
+          this.error = err?.error?.error ?? 'Unable to load appointment';
+        }
+      });
+  }
+
+  back(): void {
+    void this.router.navigate(['/doctor/appointments']);
+  }
+}

--- a/frontend/src/app/components/doctor-appointments/doctor-appointments.component.ts
+++ b/frontend/src/app/components/doctor-appointments/doctor-appointments.component.ts
@@ -1,12 +1,13 @@
 import { Component, OnInit } from '@angular/core';
 import { CommonModule, DatePipe, TitleCasePipe } from '@angular/common';
+import { RouterModule } from '@angular/router';
 import { finalize } from 'rxjs';
 import { Appointment, AppointmentsService } from '../../services/appointments.service';
 
 @Component({
   selector: 'app-doctor-appointments',
   standalone: true,
-  imports: [CommonModule, DatePipe, TitleCasePipe],
+  imports: [CommonModule, RouterModule, DatePipe, TitleCasePipe],
   template: `
     <section class="appointments">
       <h1>Doctor Appointments</h1>
@@ -25,21 +26,26 @@ import { Appointment, AppointmentsService } from '../../services/appointments.se
         </p>
         <ul *ngIf="appointments.length > 0">
           <li *ngFor="let appointment of appointments">
-            <div class="top-row">
-              <strong>{{ appointment.scheduled_at | date: 'medium' }}</strong>
-              <span class="badge" [class]="'badge ' + appointment.status">
-                {{ appointment.status | titlecase }}
-              </span>
-            </div>
-            <div class="meta">Patient: {{ appointment.patient_id }}</div>
-            <div class="reason">{{ appointment.reason }}</div>
-            <div class="actions" *ngIf="appointment.status === 'pending'">
-              <button type="button" (click)="updateStatus(appointment.id, 'approved')" [disabled]="processingId === appointment.id">
-                Approve
-              </button>
-              <button type="button" (click)="updateStatus(appointment.id, 'rejected')" [disabled]="processingId === appointment.id">
-                Reject
-              </button>
+            <div class="row">
+              <a class="row-link" [routerLink]="['/doctor/appointments', appointment.id]">
+                <div class="top-row">
+                  <strong>{{ appointment.scheduled_at | date: 'medium' }}</strong>
+                  <span class="badge" [class]="'badge ' + appointment.status">
+                    {{ appointment.status | titlecase }}
+                  </span>
+                </div>
+                <div class="meta">Patient: {{ appointment.patient_id }}</div>
+                <div class="reason">{{ appointment.reason }}</div>
+                <span class="hint">View details</span>
+              </a>
+              <div class="actions" *ngIf="appointment.status === 'pending'">
+                <button type="button" (click)="updateStatus(appointment.id, 'approved')" [disabled]="processingId === appointment.id">
+                  Approve
+                </button>
+                <button type="button" (click)="updateStatus(appointment.id, 'rejected')" [disabled]="processingId === appointment.id">
+                  Reject
+                </button>
+              </div>
             </div>
           </li>
         </ul>
@@ -54,7 +60,16 @@ import { Appointment, AppointmentsService } from '../../services/appointments.se
     button { width: fit-content; padding: 0.55rem 0.85rem; border-radius: 8px; border: 1px solid #22d3ee; background: #0f172a; color: #22d3ee; cursor: pointer; }
     button:disabled { opacity: 0.7; cursor: not-allowed; }
     ul { list-style: none; margin: 0; padding: 0; display: grid; gap: 0.75rem; }
-    li { border: 1px solid rgba(148, 163, 184, 0.2); border-radius: 8px; padding: 0.75rem; }
+    li { border: 1px solid rgba(148, 163, 184, 0.2); border-radius: 8px; padding: 0; overflow: hidden; }
+    .row { display: grid; gap: 0.65rem; padding: 0.75rem; }
+    .row-link {
+      display: grid;
+      gap: 0.35rem;
+      color: inherit;
+      text-decoration: none;
+    }
+    .row-link:hover { background: rgba(34, 211, 238, 0.06); border-radius: 8px; margin: -0.35rem; padding: 0.35rem; }
+    .hint { font-size: 0.78rem; color: #22d3ee; margin-top: 0.25rem; }
     .top-row { display: flex; justify-content: space-between; align-items: center; gap: 0.5rem; }
     .badge { border-radius: 999px; padding: 0.15rem 0.55rem; font-size: 0.78rem; border: 1px solid transparent; }
     .pending { color: #facc15; border-color: rgba(250, 204, 21, 0.5); }


### PR DESCRIPTION
Adds a doctor-facing detail view consistent with the patient experience, reusing the same detail endpoint with a doctor JWT.

What changed

Route /doctor/appointments/:id with a detail component (schedule, status, reason, patient id, back to queue).
Queue list links into the detail route; approve/reject remain on the list as before.
Depends on

Merge of s2/pavan-frontend-patient-appointment-detail into dev (or equivalent linear stack).
How to test

Log in as doctor, open a request from the queue, confirm fields and back navigation