### PR TITLE
Appointment activity log (audit + GET /activity)

### DIFF
--- a/backend/db/db.go
+++ b/backend/db/db.go
@@ -43,6 +43,17 @@ func Migrate(ctx context.Context) error {
 		CREATE INDEX IF NOT EXISTS idx_appointments_doctor_id ON appointments(doctor_id);
 		CREATE INDEX IF NOT EXISTS idx_appointments_status ON appointments(status);
 		CREATE INDEX IF NOT EXISTS idx_appointments_scheduled_at ON appointments(scheduled_at);
+
+		CREATE TABLE IF NOT EXISTS appointment_activities (
+			id              UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+			appointment_id  UUID NOT NULL REFERENCES appointments(id) ON DELETE CASCADE,
+			actor_user_id   UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+			action          TEXT NOT NULL,
+			detail          TEXT NOT NULL DEFAULT '',
+			created_at      TIMESTAMPTZ NOT NULL DEFAULT NOW()
+		);
+
+		CREATE INDEX IF NOT EXISTS idx_appointment_activities_appt ON appointment_activities(appointment_id);
 	`)
 	return err
 }

--- a/backend/handlers/appointments.go
+++ b/backend/handlers/appointments.go
@@ -228,6 +228,80 @@ func (h *AppointmentHandler) GetByID(c *gin.Context) {
 	c.JSON(http.StatusOK, appt)
 }
 
+// ListActivity returns audit rows for an appointment when the caller is the patient or assigned doctor.
+func (h *AppointmentHandler) ListActivity(c *gin.Context) {
+	claims, ok := getClaims(c)
+	if !ok {
+		return
+	}
+	if claims.Role != "patient" && claims.Role != "doctor" {
+		c.JSON(http.StatusForbidden, gin.H{"error": "Forbidden"})
+		return
+	}
+
+	id, err := uuid.Parse(c.Param("id"))
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid appointment id"})
+		return
+	}
+
+	var appt models.Appointment
+	err = db.Pool.QueryRow(c.Request.Context(), `
+		SELECT id, patient_id, doctor_id, scheduled_at, reason, status, created_at, updated_at
+		FROM appointments
+		WHERE id = $1
+	`, id).Scan(&appt.ID, &appt.PatientID, &appt.DoctorID, &appt.ScheduledAt, &appt.Reason, &appt.Status, &appt.CreatedAt, &appt.UpdatedAt)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			c.JSON(http.StatusNotFound, gin.H{"error": "Appointment not found"})
+			return
+		}
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Internal error"})
+		return
+	}
+
+	switch claims.Role {
+	case "patient":
+		if appt.PatientID != claims.UserID {
+			c.JSON(http.StatusNotFound, gin.H{"error": "Appointment not found"})
+			return
+		}
+	case "doctor":
+		if appt.DoctorID != claims.UserID {
+			c.JSON(http.StatusNotFound, gin.H{"error": "Appointment not found"})
+			return
+		}
+	}
+
+	rows, err := db.Pool.Query(c.Request.Context(), `
+		SELECT id, appointment_id, actor_user_id, action, detail, created_at
+		FROM appointment_activities
+		WHERE appointment_id = $1
+		ORDER BY created_at ASC
+	`, id)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Internal error"})
+		return
+	}
+	defer rows.Close()
+
+	activities := make([]models.AppointmentActivity, 0)
+	for rows.Next() {
+		var row models.AppointmentActivity
+		if err := rows.Scan(&row.ID, &row.AppointmentID, &row.ActorUserID, &row.Action, &row.Detail, &row.CreatedAt); err != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "Internal error"})
+			return
+		}
+		activities = append(activities, row)
+	}
+	if rows.Err() != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Internal error"})
+		return
+	}
+
+	c.JSON(http.StatusOK, gin.H{"activities": activities})
+}
+
 func (h *AppointmentHandler) ListAvailableDoctors(c *gin.Context) {
 	rows, err := db.Pool.Query(c.Request.Context(), `
 		SELECT id, email
@@ -282,8 +356,15 @@ func (h *AppointmentHandler) UpdateStatus(c *gin.Context) {
 		return
 	}
 
+	tx, err := db.Pool.Begin(c.Request.Context())
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Internal error"})
+		return
+	}
+	defer tx.Rollback(c.Request.Context())
+
 	var appt models.Appointment
-	err = db.Pool.QueryRow(c.Request.Context(), `
+	err = tx.QueryRow(c.Request.Context(), `
 		UPDATE appointments
 		SET status = $1, updated_at = NOW()
 		WHERE id = $2 AND doctor_id = $3
@@ -295,6 +376,20 @@ func (h *AppointmentHandler) UpdateStatus(c *gin.Context) {
 			c.JSON(http.StatusNotFound, gin.H{"error": "Appointment not found"})
 			return
 		}
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Internal error"})
+		return
+	}
+
+	_, err = tx.Exec(c.Request.Context(), `
+		INSERT INTO appointment_activities (appointment_id, actor_user_id, action, detail)
+		VALUES ($1, $2, $3, $4)
+	`, appt.ID, claims.UserID, "status_changed", status)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Internal error"})
+		return
+	}
+
+	if err := tx.Commit(c.Request.Context()); err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "Internal error"})
 		return
 	}

--- a/backend/main.go
+++ b/backend/main.go
@@ -74,6 +74,7 @@ func main() {
 		api.POST("/appointments", auth.RequireAuth(), auth.RequireRole("patient"), appointments.Create)
 		api.GET("/appointments/patient", auth.RequireAuth(), auth.RequireRole("patient"), appointments.ListPatient)
 		api.GET("/appointments/doctor", auth.RequireAuth(), auth.RequireRole("doctor"), appointments.ListDoctor)
+		api.GET("/appointments/:id/activity", auth.RequireAuth(), appointments.ListActivity)
 		api.GET("/appointments/:id", auth.RequireAuth(), appointments.GetByID)
 		api.GET("/doctors", auth.RequireAuth(), auth.RequireRole("patient"), appointments.ListAvailableDoctors)
 		api.PATCH("/appointments/:id/status", auth.RequireAuth(), auth.RequireRole("doctor"), appointments.UpdateStatus)

--- a/backend/models/appointment_activity.go
+++ b/backend/models/appointment_activity.go
@@ -1,0 +1,16 @@
+package models
+
+import (
+	"time"
+
+	"github.com/google/uuid"
+)
+
+type AppointmentActivity struct {
+	ID            uuid.UUID `json:"id"`
+	AppointmentID uuid.UUID `json:"appointment_id"`
+	ActorUserID   uuid.UUID `json:"actor_user_id"`
+	Action        string    `json:"action"`
+	Detail        string    `json:"detail,omitempty"`
+	CreatedAt     time.Time `json:"created_at"`
+}


### PR DESCRIPTION
Persists an audit trail when doctors approve or reject, and exposes it for the same parties who can read the appointment.

What changed

Migration: appointment_activities with FKs to appointments and users.
PATCH /api/appointments/:id/status updates appointment and inserts an activity row in one transaction.
GET /api/appointments/:id/activity returns ordered activities; access rules match GET /api/appointments/:id (patient or assigned doctor only).
Depends on

Merge of s2/pavan-frontend-doctor-appointment-detail into dev (or rebase onto current dev after prior PRs).
How to test

As doctor, approve/reject a pending request; call GET /api/appointments/:id/activity and confirm a status_changed row with expected detail.
As patient for that appointment, same GET should succeed; as another user, expect 404.