### PR TITLE
Find care + doctor availability UI (geo booking client)

### DIFF
--- a/docs/geo-specialty-booking-frontend.md
+++ b/docs/geo-specialty-booking-frontend.md
@@ -1,0 +1,24 @@
+# Frontend: geo, specialty, and slot booking
+
+This branch wires the UX described in `docs/geo-specialty-booking.md` to the APIs on `s2/geo-specialty-slots-backend`.
+
+## Patient flow (target)
+
+1. **Location** — Use the [Geolocation API](https://developer.mozilla.org/en-US/docs/Web/API/Geolocation_API) (`navigator.geolocation.getCurrentPosition`) after user consent, or manual lat/lng (address geocoding can be a follow-up).
+2. **Radius** — Slider or numeric input (km); call `GET /api/hospitals/near?lat=&lng=&radius_km=`.
+3. **Problem / specialty** — Text field or dropdown; map to `specialization` query on `GET /api/doctors/search?...&specialization=`.
+4. **Doctors** — Show list with distance; link to **doctor detail** or straight to **slot list** via `GET /api/doctors/:id/slots`.
+5. **Book** — Patient picks an open slot and submits reason; `POST /api/appointments/book-slot` with `{ slot_id, reason }`. On success, redirect to existing patient appointments.
+
+## Doctor flow (target)
+
+1. **Availability** — Form for `start_at` / `end_at` (ISO-8601); `POST /api/doctor/slots`.
+2. **Manage** — List own slots; `DELETE /api/doctor/slots/:id` for open slots.
+
+## This branch (scaffolding)
+
+- `GeoBookingService` wraps the HTTP calls.
+- Placeholder routes: `/patient/find-care`, `/doctor/availability` (shell nav when logged in).
+- Full UI (maps, geolocation prompts, validation) can be layered in follow-up commits.
+
+**Merge order:** land backend branch first, then frontend, or test locally with backend running from its branch.

--- a/frontend/src/app/app.routes.ts
+++ b/frontend/src/app/app.routes.ts
@@ -8,6 +8,8 @@ import { PatientAppointmentsComponent } from './components/patient-appointments/
 import { PatientAppointmentDetailComponent } from './components/patient-appointment-detail/patient-appointment-detail.component';
 import { DoctorAppointmentsComponent } from './components/doctor-appointments/doctor-appointments.component';
 import { DoctorAppointmentDetailComponent } from './components/doctor-appointment-detail/doctor-appointment-detail.component';
+import { PatientFindCareComponent } from './components/patient-find-care/patient-find-care.component';
+import { DoctorAvailabilityComponent } from './components/doctor-availability/doctor-availability.component';
 import { authGuard } from './guards/auth.guard';
 import { roleGuard } from './guards/role.guard';
 
@@ -26,6 +28,12 @@ export const routes: Routes = [
         canActivate: [roleGuard],
         children: [
           { path: '', pathMatch: 'full', redirectTo: 'appointments' },
+          {
+            path: 'find-care',
+            component: PatientFindCareComponent,
+            data: { title: 'Find care', roles: ['patient'] },
+            canActivate: [roleGuard]
+          },
           {
             path: 'appointments/:id',
             component: PatientAppointmentDetailComponent,
@@ -46,6 +54,12 @@ export const routes: Routes = [
         canActivate: [roleGuard],
         children: [
           { path: '', pathMatch: 'full', redirectTo: 'appointments' },
+          {
+            path: 'availability',
+            component: DoctorAvailabilityComponent,
+            data: { title: 'Availability', roles: ['doctor'] },
+            canActivate: [roleGuard]
+          },
           {
             path: 'appointments/:id',
             component: DoctorAppointmentDetailComponent,

--- a/frontend/src/app/components/app-shell/app-shell.component.html
+++ b/frontend/src/app/components/app-shell/app-shell.component.html
@@ -36,8 +36,10 @@
       @for (link of navLinks; track link.path) {
         <a routerLink="{{ link.path }}" routerLinkActive="active" [routerLinkActiveOptions]="{ exact: true }" class="nav-item">
           <span class="nav-icon">
-            @if (link.path.startsWith('/patient')) { 🧑‍⚕️ }
-            @if (link.path.startsWith('/doctor')) { 👨‍⚕️ }
+            @if (link.path === '/patient/find-care') { 📍 }
+            @if (link.path === '/patient/appointments') { 🧑‍⚕️ }
+            @if (link.path === '/doctor/availability') { 📅 }
+            @if (link.path === '/doctor/appointments') { 👨‍⚕️ }
             @if (link.path === '/admin') { 🛡️ }
           </span>
           <span class="nav-label">{{ link.label }}</span>

--- a/frontend/src/app/components/app-shell/app-shell.component.ts
+++ b/frontend/src/app/components/app-shell/app-shell.component.ts
@@ -30,7 +30,9 @@ export class AppShellComponent {
 
   get navLinks(): { path: string; label: string; roles: string[] }[] {
     const all = [
+      { path: '/patient/find-care', label: 'Find care', roles: ['patient'] },
       { path: '/patient/appointments', label: 'My Appointments', roles: ['patient'] },
+      { path: '/doctor/availability', label: 'Availability', roles: ['doctor'] },
       { path: '/doctor/appointments', label: 'Appointment Queue', roles: ['doctor'] },
       { path: '/admin', label: 'Admin Dashboard', roles: ['admin'] }
     ];

--- a/frontend/src/app/components/doctor-availability/doctor-availability.component.ts
+++ b/frontend/src/app/components/doctor-availability/doctor-availability.component.ts
@@ -1,0 +1,85 @@
+import { Component } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormsModule } from '@angular/forms';
+import { GeoBookingService } from '../../services/geo-booking.service';
+
+/**
+ * Doctor: create availability windows (POST /api/doctor/slots). List/delete open slots in a follow-up.
+ */
+@Component({
+  selector: 'app-doctor-availability',
+  standalone: true,
+  imports: [CommonModule, FormsModule],
+  template: `
+    <section class="avail">
+      <h1>Availability</h1>
+      <p class="subtitle">
+        Add a slot using ISO-8601 times (UTC). Example: start 2026-03-27T14:00:00Z, end 2026-03-27T14:30:00Z.
+      </p>
+
+      <div class="card grid">
+        <label>
+          Start (ISO)
+          <input type="text" [(ngModel)]="startAt" placeholder="2026-03-27T14:00:00Z" />
+        </label>
+        <label>
+          End (ISO)
+          <input type="text" [(ngModel)]="endAt" placeholder="2026-03-27T14:30:00Z" />
+        </label>
+      </div>
+
+      <button type="button" (click)="submit()" [disabled]="saving">Add slot</button>
+      <p *ngIf="message" class="msg">{{ message }}</p>
+      <p *ngIf="error" class="error">{{ error }}</p>
+    </section>
+  `,
+  styles: [`
+    .avail { max-width: 560px; margin: 0 auto; display: grid; gap: 1rem; }
+    .subtitle { color: #94a3b8; margin-top: -0.25rem; }
+    .card { background: rgba(15, 23, 42, 0.7); border: 1px solid rgba(148, 163, 184, 0.2); border-radius: 12px; padding: 1rem; }
+    .grid { display: grid; gap: 0.75rem; }
+    label { display: grid; gap: 0.35rem; font-size: 0.9rem; }
+    input { background: #0b1220; color: #e5e7eb; border: 1px solid #334155; border-radius: 8px; padding: 0.5rem; }
+    button { width: fit-content; padding: 0.5rem 0.85rem; border-radius: 8px; border: 1px solid #22d3ee; background: #0f172a; color: #22d3ee; cursor: pointer; }
+    button:disabled { opacity: 0.6; }
+    .msg { color: #22d3ee; }
+    .error { color: #f87171; }
+  `]
+})
+export class DoctorAvailabilityComponent {
+  startAt = '';
+  endAt = '';
+  saving = false;
+  message = '';
+  error = '';
+
+  constructor(private geo: GeoBookingService) {}
+
+  submit(): void {
+    this.message = '';
+    this.error = '';
+    this.saving = true;
+    const start = new Date(this.startAt.trim());
+    const end = new Date(this.endAt.trim());
+    if (Number.isNaN(start.getTime()) || Number.isNaN(end.getTime())) {
+      this.error = 'Use valid ISO-8601 datetimes.';
+      this.saving = false;
+      return;
+    }
+    this.geo
+      .createSlot({
+        start_at: start.toISOString(),
+        end_at: end.toISOString()
+      })
+      .subscribe({
+        next: (res) => {
+          this.message = `Slot created (${res.id}).`;
+          this.saving = false;
+        },
+        error: (err) => {
+          this.error = err?.error?.error ?? 'Could not create slot';
+          this.saving = false;
+        }
+      });
+  }
+}

--- a/frontend/src/app/components/patient-find-care/patient-find-care.component.ts
+++ b/frontend/src/app/components/patient-find-care/patient-find-care.component.ts
@@ -1,0 +1,129 @@
+import { Component } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormsModule } from '@angular/forms';
+import { DoctorSearchRow, GeoBookingService, HospitalNear } from '../../services/geo-booking.service';
+
+/**
+ * Patient: location + radius + specialty search → hospitals & doctors → slot booking.
+ * Scaffold: wire GeoBookingService; expand with geolocation, validation, and navigation.
+ */
+@Component({
+  selector: 'app-patient-find-care',
+  standalone: true,
+  imports: [CommonModule, FormsModule],
+  template: `
+    <section class="find-care">
+      <h1>Find care near you</h1>
+      <p class="subtitle">
+        Set your search point (latitude / longitude), a radius in kilometers, and an optional specialty.
+        Then load hospitals and matching doctors. Slot booking uses POST /api/appointments/book-slot (backend branch).
+      </p>
+
+      <div class="card grid">
+        <label>
+          Latitude
+          <input type="number" step="any" [(ngModel)]="lat" placeholder="e.g. 29.64" />
+        </label>
+        <label>
+          Longitude
+          <input type="number" step="any" [(ngModel)]="lng" placeholder="e.g. -82.34" />
+        </label>
+        <label>
+          Radius (km)
+          <input type="number" step="1" min="1" [(ngModel)]="radiusKm" />
+        </label>
+        <label class="span-2">
+          Specialty / problem keyword
+          <input type="text" [(ngModel)]="specialization" placeholder="e.g. Internal Medicine" />
+        </label>
+      </div>
+
+      <div class="actions">
+        <button type="button" (click)="loadHospitals()" [disabled]="loading">Hospitals nearby</button>
+        <button type="button" (click)="loadDoctors()" [disabled]="loading">Find doctors</button>
+      </div>
+
+      <p *ngIf="error" class="error">{{ error }}</p>
+
+      <div *ngIf="hospitals.length" class="card">
+        <h2>Hospitals</h2>
+        <ul>
+          <li *ngFor="let h of hospitals">
+            {{ h.name }} — {{ h.city }}, {{ h.region }} ({{ h.distance_km }} km)
+          </li>
+        </ul>
+      </div>
+
+      <div *ngIf="doctors.length" class="card">
+        <h2>Doctors</h2>
+        <ul>
+          <li *ngFor="let d of doctors">
+            <strong>{{ d.email }}</strong>
+            — {{ d.specialization || '—' }} ({{ d.distance_km }} km)
+          </li>
+        </ul>
+      </div>
+
+      <p class="muted">
+        Next: geolocation, slot list per doctor, and book flow — see docs/geo-specialty-booking-frontend.md.
+      </p>
+    </section>
+  `,
+  styles: [`
+    .find-care { max-width: 720px; margin: 0 auto; display: grid; gap: 1rem; }
+    .subtitle { color: #94a3b8; margin-top: -0.25rem; }
+    .card { background: rgba(15, 23, 42, 0.7); border: 1px solid rgba(148, 163, 184, 0.2); border-radius: 12px; padding: 1rem; }
+    .grid { display: grid; grid-template-columns: 1fr 1fr; gap: 0.75rem; }
+    .span-2 { grid-column: 1 / -1; }
+    label { display: grid; gap: 0.35rem; font-size: 0.9rem; }
+    input { background: #0b1220; color: #e5e7eb; border: 1px solid #334155; border-radius: 8px; padding: 0.5rem; }
+    .actions { display: flex; gap: 0.5rem; flex-wrap: wrap; }
+    button { padding: 0.5rem 0.85rem; border-radius: 8px; border: 1px solid #22d3ee; background: #0f172a; color: #22d3ee; cursor: pointer; }
+    button:disabled { opacity: 0.6; cursor: not-allowed; }
+    ul { margin: 0; padding-left: 1.1rem; }
+    .error { color: #f87171; }
+    .muted { color: #64748b; font-size: 0.85rem; }
+  `]
+})
+export class PatientFindCareComponent {
+  lat = 29.64;
+  lng = -82.34;
+  radiusKm = 50;
+  specialization = '';
+  hospitals: HospitalNear[] = [];
+  doctors: DoctorSearchRow[] = [];
+  loading = false;
+  error = '';
+
+  constructor(private geo: GeoBookingService) {}
+
+  loadHospitals(): void {
+    this.error = '';
+    this.loading = true;
+    this.geo.hospitalsNear(this.lat, this.lng, this.radiusKm).subscribe({
+      next: (res) => {
+        this.hospitals = res.hospitals ?? [];
+        this.loading = false;
+      },
+      error: (err) => {
+        this.error = err?.error?.error ?? 'Could not load hospitals';
+        this.loading = false;
+      }
+    });
+  }
+
+  loadDoctors(): void {
+    this.error = '';
+    this.loading = true;
+    this.geo.searchDoctors(this.lat, this.lng, this.radiusKm, this.specialization).subscribe({
+      next: (res) => {
+        this.doctors = res.doctors ?? [];
+        this.loading = false;
+      },
+      error: (err) => {
+        this.error = err?.error?.error ?? 'Could not search doctors';
+        this.loading = false;
+      }
+    });
+  }
+}

--- a/frontend/src/app/services/geo-booking.service.ts
+++ b/frontend/src/app/services/geo-booking.service.ts
@@ -1,0 +1,66 @@
+import { Injectable } from '@angular/core';
+import { HttpClient, HttpParams } from '@angular/common/http';
+import { Observable } from 'rxjs';
+
+export interface HospitalNear {
+  id: string;
+  name: string;
+  city: string;
+  region: string;
+  latitude: number;
+  longitude: number;
+  distance_km: number;
+}
+
+export interface DoctorSearchRow {
+  id: string;
+  email: string;
+  specialization: string;
+  hospital_id?: string;
+  distance_km: number;
+}
+
+export interface DoctorSlotRow {
+  id: string;
+  doctor_id: string;
+  start_at: string;
+  end_at: string;
+  available: boolean;
+}
+
+@Injectable({ providedIn: 'root' })
+export class GeoBookingService {
+  private readonly api = '/api';
+
+  constructor(private http: HttpClient) {}
+
+  hospitalsNear(lat: number, lng: number, radiusKm: number): Observable<{ hospitals: HospitalNear[] }> {
+    let p = new HttpParams().set('lat', String(lat)).set('lng', String(lng)).set('radius_km', String(radiusKm));
+    return this.http.get<{ hospitals: HospitalNear[] }>(`${this.api}/hospitals/near`, { params: p });
+  }
+
+  searchDoctors(lat: number, lng: number, radiusKm: number, specialization: string): Observable<{ doctors: DoctorSearchRow[] }> {
+    let p = new HttpParams().set('lat', String(lat)).set('lng', String(lng)).set('radius_km', String(radiusKm));
+    const spec = specialization?.trim();
+    if (spec) {
+      p = p.set('specialization', spec);
+    }
+    return this.http.get<{ doctors: DoctorSearchRow[] }>(`${this.api}/doctors/search`, { params: p });
+  }
+
+  listDoctorSlots(doctorId: string): Observable<{ slots: DoctorSlotRow[] }> {
+    return this.http.get<{ slots: DoctorSlotRow[] }>(`${this.api}/doctors/${doctorId}/slots`);
+  }
+
+  createSlot(body: { start_at: string; end_at: string }): Observable<{ id: string }> {
+    return this.http.post<{ id: string }>(`${this.api}/doctor/slots`, body);
+  }
+
+  deleteSlot(slotId: string): Observable<{ ok: boolean }> {
+    return this.http.delete<{ ok: boolean }>(`${this.api}/doctor/slots/${slotId}`);
+  }
+
+  bookSlot(slotId: string, reason: string): Observable<unknown> {
+    return this.http.post(`${this.api}/appointments/book-slot`, { slot_id: slotId, reason });
+  }
+}


### PR DESCRIPTION
Adds client-side wiring and navigation for the geo/specialty/slot booking feature: a service that matches the new backend routes, placeholder screens for patients and doctors, and shell links so the flows are reachable after login.

What changed

GeoBookingService — HTTP helpers for hospitals/near, doctors/search, doctor slots, create/delete slot, and book-slot.
Patient: /patient/find-care — manual lat/lng, radius km, and specialty keyword; buttons to load nearby hospitals and matching doctors (scaffold for geolocation and slot picker in a follow-up).
Doctor: /doctor/availability — form to submit ISO-8601 start/end times to create a slot.
Shell: Navigation entries for “Find care” and “Availability”.