### PR TITLE
Geo hospitals, doctor search, availability slots, and book-slot API

### DIFF
--- a/backend/cmd/seed/main.go
+++ b/backend/cmd/seed/main.go
@@ -4,9 +4,11 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"time"
 
 	"github.com/healthonyx/backend/config"
 	"github.com/healthonyx/backend/db"
+	"github.com/google/uuid"
 	"golang.org/x/crypto/bcrypt"
 )
 
@@ -20,6 +22,35 @@ func main() {
 		log.Fatalf("database connection: %v", err)
 	}
 	defer db.Close()
+
+	ctx := context.Background()
+
+	hospitals := []struct {
+		name, city, region string
+		lat, lng            float64
+	}{
+		{"UF Health Shands Hospital", "Gainesville", "Florida", 29.6406, -82.3444},
+		{"Orlando Health", "Orlando", "Florida", 28.5383, -81.3792},
+		{"Mayo Clinic", "Jacksonville", "Florida", 30.2849, -81.3961},
+	}
+
+	var shandsID uuid.UUID
+	for _, h := range hospitals {
+		var id uuid.UUID
+		err := db.Pool.QueryRow(ctx, `
+			INSERT INTO hospitals (name, city, region, latitude, longitude)
+			VALUES ($1, $2, $3, $4, $5)
+			ON CONFLICT (name, region) DO UPDATE SET city = EXCLUDED.city, latitude = EXCLUDED.latitude, longitude = EXCLUDED.longitude
+			RETURNING id
+		`, h.name, h.city, h.region, h.lat, h.lng).Scan(&id)
+		if err != nil {
+			log.Fatalf("hospital %s: %v", h.name, err)
+		}
+		if h.name == "UF Health Shands Hospital" {
+			shandsID = id
+		}
+		fmt.Printf("Hospital: %s — %s, %s\n", h.name, h.city, h.region)
+	}
 
 	users := []struct {
 		email string
@@ -36,7 +67,7 @@ func main() {
 		if err != nil {
 			log.Fatal(err)
 		}
-		_, err = db.Pool.Exec(context.Background(),
+		_, err = db.Pool.Exec(ctx,
 			`INSERT INTO users (email, password_hash, role) VALUES ($1, $2, $3)
 			 ON CONFLICT (email) DO UPDATE SET password_hash = EXCLUDED.password_hash, role = EXCLUDED.role`,
 			u.email, string(hash), u.role,
@@ -45,6 +76,39 @@ func main() {
 			log.Fatalf("seed %s: %v", u.email, err)
 		}
 		fmt.Printf("Seeded: %s / %s (%s)\n", u.email, u.pass, u.role)
+	}
+
+	if shandsID != uuid.Nil {
+		_, err := db.Pool.Exec(ctx, `
+			UPDATE users
+			SET specialization = $1, hospital_id = $2
+			WHERE email = 'doctor@healthonyx.demo' AND role = 'doctor'
+		`, "Internal Medicine", shandsID)
+		if err != nil {
+			log.Fatalf("doctor profile: %v", err)
+		}
+		fmt.Println("Doctor profile: specialization + hospital linked.")
+	}
+
+	// One demo open slot for the demo doctor (tomorrow 10:00 UTC window — adjust in app as needed)
+	var docID uuid.UUID
+	err := db.Pool.QueryRow(ctx, `SELECT id FROM users WHERE email = 'doctor@healthonyx.demo' AND role = 'doctor'`).Scan(&docID)
+	if err != nil {
+		log.Printf("demo slot: doctor id: %v", err)
+	} else {
+		start := time.Now().UTC().Add(24 * time.Hour).Truncate(time.Hour)
+		start = time.Date(start.Year(), start.Month(), start.Day(), 14, 0, 0, 0, time.UTC)
+		end := start.Add(30 * time.Minute)
+		_, err = db.Pool.Exec(ctx, `
+			INSERT INTO doctor_slots (doctor_id, start_at, end_at)
+			VALUES ($1, $2, $3)
+			ON CONFLICT (doctor_id, start_at) DO NOTHING
+		`, docID, start, end)
+		if err != nil {
+			log.Printf("demo slot: %v", err)
+		} else {
+			fmt.Printf("Demo doctor slot: %s – %s (UTC)\n", start.Format(time.RFC3339), end.Format(time.RFC3339))
+		}
 	}
 
 	fmt.Println("Demo users seeded. Use these credentials to log in.")

--- a/backend/db/db.go
+++ b/backend/db/db.go
@@ -54,6 +54,39 @@ func Migrate(ctx context.Context) error {
 		);
 
 		CREATE INDEX IF NOT EXISTS idx_appointment_activities_appt ON appointment_activities(appointment_id);
+
+		CREATE TABLE IF NOT EXISTS hospitals (
+			id         UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+			name       TEXT NOT NULL,
+			city       TEXT NOT NULL DEFAULT '',
+			region     TEXT NOT NULL DEFAULT '',
+			latitude   DOUBLE PRECISION NOT NULL,
+			longitude  DOUBLE PRECISION NOT NULL
+		);
+
+		CREATE UNIQUE INDEX IF NOT EXISTS idx_hospitals_name_region ON hospitals(name, region);
+
+		ALTER TABLE users ADD COLUMN IF NOT EXISTS specialization TEXT NOT NULL DEFAULT '';
+		ALTER TABLE users ADD COLUMN IF NOT EXISTS hospital_id UUID REFERENCES hospitals(id) ON DELETE SET NULL;
+		ALTER TABLE users ADD COLUMN IF NOT EXISTS practice_latitude DOUBLE PRECISION;
+		ALTER TABLE users ADD COLUMN IF NOT EXISTS practice_longitude DOUBLE PRECISION;
+
+		CREATE INDEX IF NOT EXISTS idx_users_doctor_spec ON users(role, specialization) WHERE role = 'doctor';
+
+		CREATE TABLE IF NOT EXISTS doctor_slots (
+			id          UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+			doctor_id   UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+			start_at    TIMESTAMPTZ NOT NULL,
+			end_at      TIMESTAMPTZ NOT NULL,
+			patient_id  UUID REFERENCES users(id) ON DELETE SET NULL,
+			CONSTRAINT doctor_slots_time_order CHECK (end_at > start_at),
+			CONSTRAINT doctor_slots_unique_start UNIQUE (doctor_id, start_at)
+		);
+
+		CREATE INDEX IF NOT EXISTS idx_doctor_slots_doctor_time ON doctor_slots(doctor_id, start_at);
+		CREATE INDEX IF NOT EXISTS idx_doctor_slots_open ON doctor_slots(doctor_id) WHERE patient_id IS NULL;
+
+		ALTER TABLE appointments ADD COLUMN IF NOT EXISTS slot_id UUID UNIQUE REFERENCES doctor_slots(id) ON DELETE SET NULL;
 	`)
 	return err
 }

--- a/backend/handlers/geo_booking.go
+++ b/backend/handlers/geo_booking.go
@@ -1,0 +1,438 @@
+package handlers
+
+import (
+	"errors"
+	"math"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
+	"github.com/healthonyx/backend/db"
+	"github.com/healthonyx/backend/models"
+	"github.com/jackc/pgx/v5"
+)
+
+type GeoBookingHandler struct{}
+
+func NewGeoBookingHandler() *GeoBookingHandler {
+	return &GeoBookingHandler{}
+}
+
+// haversineKm returns great-circle distance in kilometers.
+func haversineKm(lat1, lon1, lat2, lon2 float64) float64 {
+	const earthR = 6371.0
+	const deg = math.Pi / 180
+	dlat := (lat2 - lat1) * deg
+	dlon := (lon2 - lon1) * deg
+	a := math.Sin(dlat/2)*math.Sin(dlat/2) +
+		math.Cos(lat1*deg)*math.Cos(lat2*deg)*math.Sin(dlon/2)*math.Sin(dlon/2)
+	c := 2 * math.Atan2(math.Sqrt(a), math.Sqrt(1-a))
+	return earthR * c
+}
+
+type hospitalNearJSON struct {
+	ID         string  `json:"id"`
+	Name       string  `json:"name"`
+	City       string  `json:"city"`
+	Region     string  `json:"region"`
+	Latitude   float64 `json:"latitude"`
+	Longitude  float64 `json:"longitude"`
+	DistanceKm float64 `json:"distance_km"`
+}
+
+// ListHospitalsNear returns hospitals whose coordinates fall within radius_km of (lat,lng).
+func (h *GeoBookingHandler) ListHospitalsNear(c *gin.Context) {
+	if _, ok := getClaims(c); !ok {
+		return
+	}
+
+	lat, lng, radiusKm, ok := parseLatLngRadius(c)
+	if !ok {
+		return
+	}
+
+	rows, err := db.Pool.Query(c.Request.Context(), `
+		SELECT id, name, city, region, latitude, longitude FROM hospitals
+	`)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Internal error"})
+		return
+	}
+	defer rows.Close()
+
+	out := make([]hospitalNearJSON, 0)
+	for rows.Next() {
+		var id uuid.UUID
+		var name, city, region string
+		var hLat, hLng float64
+		if err := rows.Scan(&id, &name, &city, &region, &hLat, &hLng); err != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "Internal error"})
+			return
+		}
+		d := haversineKm(lat, lng, hLat, hLng)
+		if d <= radiusKm {
+			out = append(out, hospitalNearJSON{
+				ID:         id.String(),
+				Name:       name,
+				City:       city,
+				Region:     region,
+				Latitude:   hLat,
+				Longitude:  hLng,
+				DistanceKm: math.Round(d*100) / 100,
+			})
+		}
+	}
+	if rows.Err() != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Internal error"})
+		return
+	}
+
+	c.JSON(http.StatusOK, gin.H{"hospitals": out})
+}
+
+func parseLatLngRadius(c *gin.Context) (lat, lng, radiusKm float64, ok bool) {
+	latStr := strings.TrimSpace(c.Query("lat"))
+	lngStr := strings.TrimSpace(c.Query("lng"))
+	rStr := strings.TrimSpace(c.Query("radius_km"))
+	if latStr == "" || lngStr == "" {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "lat and lng query parameters are required"})
+		return 0, 0, 0, false
+	}
+	var err error
+	lat, err = strconv.ParseFloat(latStr, 64)
+	if err != nil || lat < -90 || lat > 90 {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "lat must be a number between -90 and 90"})
+		return 0, 0, 0, false
+	}
+	lng, err = strconv.ParseFloat(lngStr, 64)
+	if err != nil || lng < -180 || lng > 180 {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "lng must be a number between -180 and 180"})
+		return 0, 0, 0, false
+	}
+	radiusKm = 25
+	if rStr != "" {
+		radiusKm, err = strconv.ParseFloat(rStr, 64)
+		if err != nil || radiusKm <= 0 || radiusKm > 500 {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "radius_km must be a positive number up to 500"})
+			return 0, 0, 0, false
+		}
+	}
+	return lat, lng, radiusKm, true
+}
+
+type doctorSearchJSON struct {
+	ID             string  `json:"id"`
+	Email          string  `json:"email"`
+	Specialization string  `json:"specialization"`
+	HospitalID     *string `json:"hospital_id,omitempty"`
+	DistanceKm     float64 `json:"distance_km"`
+}
+
+// SearchDoctors returns doctors in radius; optional specialization filters (substring match).
+func (h *GeoBookingHandler) SearchDoctors(c *gin.Context) {
+	if _, ok := getClaims(c); !ok {
+		return
+	}
+
+	lat, lng, radiusKm, ok := parseLatLngRadius(c)
+	if !ok {
+		return
+	}
+	spec := strings.TrimSpace(c.Query("specialization"))
+
+	rows, err := db.Pool.Query(c.Request.Context(), `
+		SELECT u.id, u.email, u.specialization, u.hospital_id,
+			h.latitude, h.longitude, u.practice_latitude, u.practice_longitude
+		FROM users u
+		LEFT JOIN hospitals h ON h.id = u.hospital_id
+		WHERE u.role = 'doctor'
+	`)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Internal error"})
+		return
+	}
+	defer rows.Close()
+
+	out := make([]doctorSearchJSON, 0)
+	for rows.Next() {
+		var id uuid.UUID
+		var email, specialization string
+		var hid *uuid.UUID
+		var hLat, hLng *float64
+		var pLat, pLng *float64
+		if err := rows.Scan(&id, &email, &specialization, &hid, &hLat, &hLng, &pLat, &pLng); err != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "Internal error"})
+			return
+		}
+		if spec != "" && !strings.Contains(strings.ToLower(specialization), strings.ToLower(spec)) {
+			continue
+		}
+
+		var effLat, effLng float64
+		var has bool
+		if hLat != nil && hLng != nil {
+			effLat, effLng, has = *hLat, *hLng, true
+		} else if pLat != nil && pLng != nil {
+			effLat, effLng, has = *pLat, *pLng, true
+		}
+		if !has {
+			continue
+		}
+
+		d := haversineKm(lat, lng, effLat, effLng)
+		if d > radiusKm {
+			continue
+		}
+
+		var hidStr *string
+		if hid != nil {
+			s := hid.String()
+			hidStr = &s
+		}
+		out = append(out, doctorSearchJSON{
+			ID:             id.String(),
+			Email:          email,
+			Specialization: specialization,
+			HospitalID:     hidStr,
+			DistanceKm:     math.Round(d*100) / 100,
+		})
+	}
+	if rows.Err() != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Internal error"})
+		return
+	}
+
+	c.JSON(http.StatusOK, gin.H{"doctors": out})
+}
+
+type slotJSON struct {
+	ID        string    `json:"id"`
+	DoctorID  string    `json:"doctor_id"`
+	StartAt   time.Time `json:"start_at"`
+	EndAt     time.Time `json:"end_at"`
+	Available bool      `json:"available"`
+}
+
+// ListOpenSlotsForDoctor returns slots for a doctor that are not yet booked.
+func (h *GeoBookingHandler) ListOpenSlotsForDoctor(c *gin.Context) {
+	if _, ok := getClaims(c); !ok {
+		return
+	}
+
+	doctorID, err := uuid.Parse(c.Param("id"))
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid doctor id"})
+		return
+	}
+
+	rows, err := db.Pool.Query(c.Request.Context(), `
+		SELECT id, doctor_id, start_at, end_at, patient_id
+		FROM doctor_slots
+		WHERE doctor_id = $1 AND start_at > NOW()
+		ORDER BY start_at ASC
+	`, doctorID)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Internal error"})
+		return
+	}
+	defer rows.Close()
+
+	slots := make([]slotJSON, 0)
+	for rows.Next() {
+		var id, docID uuid.UUID
+		var startAt, endAt time.Time
+		var patientID *uuid.UUID
+		if err := rows.Scan(&id, &docID, &startAt, &endAt, &patientID); err != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "Internal error"})
+			return
+		}
+		slots = append(slots, slotJSON{
+			ID:        id.String(),
+			DoctorID:  docID.String(),
+			StartAt:   startAt,
+			EndAt:     endAt,
+			Available: patientID == nil,
+		})
+	}
+	if rows.Err() != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Internal error"})
+		return
+	}
+
+	c.JSON(http.StatusOK, gin.H{"slots": slots})
+}
+
+type createSlotRequest struct {
+	StartAt time.Time `json:"start_at" binding:"required"`
+	EndAt   time.Time `json:"end_at" binding:"required"`
+}
+
+// CreateSlot lets a doctor add an availability window.
+func (h *GeoBookingHandler) CreateSlot(c *gin.Context) {
+	claims, ok := getClaims(c)
+	if !ok {
+		return
+	}
+	if claims.Role != "doctor" {
+		c.JSON(http.StatusForbidden, gin.H{"error": "Forbidden"})
+		return
+	}
+
+	var req createSlotRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid request body"})
+		return
+	}
+	if !req.EndAt.After(req.StartAt) {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "end_at must be after start_at"})
+		return
+	}
+
+	var id uuid.UUID
+	err := db.Pool.QueryRow(c.Request.Context(), `
+		INSERT INTO doctor_slots (doctor_id, start_at, end_at)
+		VALUES ($1, $2, $3)
+		RETURNING id
+	`, claims.UserID, req.StartAt, req.EndAt).Scan(&id)
+	if err != nil {
+		if strings.Contains(err.Error(), "unique") || strings.Contains(err.Error(), "duplicate") {
+			c.JSON(http.StatusConflict, gin.H{"error": "A slot with this start time already exists"})
+			return
+		}
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Internal error"})
+		return
+	}
+
+	c.JSON(http.StatusCreated, gin.H{"id": id.String()})
+}
+
+// DeleteOpenSlot removes a slot the doctor owns if it is still open.
+func (h *GeoBookingHandler) DeleteOpenSlot(c *gin.Context) {
+	claims, ok := getClaims(c)
+	if !ok {
+		return
+	}
+	if claims.Role != "doctor" {
+		c.JSON(http.StatusForbidden, gin.H{"error": "Forbidden"})
+		return
+	}
+
+	id, err := uuid.Parse(c.Param("id"))
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid slot id"})
+		return
+	}
+
+	cmd, err := db.Pool.Exec(c.Request.Context(), `
+		DELETE FROM doctor_slots
+		WHERE id = $1 AND doctor_id = $2 AND patient_id IS NULL
+	`, id, claims.UserID)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Internal error"})
+		return
+	}
+	if cmd.RowsAffected() == 0 {
+		c.JSON(http.StatusNotFound, gin.H{"error": "Open slot not found"})
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{"ok": true})
+}
+
+type bookSlotRequest struct {
+	SlotID string `json:"slot_id" binding:"required"`
+	Reason string `json:"reason" binding:"required"`
+}
+
+// BookSlot creates an appointment from an open slot and locks the slot.
+func (h *GeoBookingHandler) BookSlot(c *gin.Context) {
+	claims, ok := getClaims(c)
+	if !ok {
+		return
+	}
+	if claims.Role != "patient" {
+		c.JSON(http.StatusForbidden, gin.H{"error": "Forbidden"})
+		return
+	}
+
+	var req bookSlotRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid request body"})
+		return
+	}
+	slotID, err := uuid.Parse(strings.TrimSpace(req.SlotID))
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "slot_id must be a valid UUID"})
+		return
+	}
+	reason := strings.TrimSpace(req.Reason)
+	if reason == "" {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "reason is required"})
+		return
+	}
+
+	tx, err := db.Pool.Begin(c.Request.Context())
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Internal error"})
+		return
+	}
+	defer tx.Rollback(c.Request.Context())
+
+	var doctorID uuid.UUID
+	var startAt time.Time
+	var bookedBy *uuid.UUID
+	err = tx.QueryRow(c.Request.Context(), `
+		SELECT doctor_id, start_at, patient_id FROM doctor_slots
+		WHERE id = $1
+		FOR UPDATE
+	`, slotID).Scan(&doctorID, &startAt, &bookedBy)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			c.JSON(http.StatusNotFound, gin.H{"error": "Slot not found"})
+			return
+		}
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Internal error"})
+		return
+	}
+	if bookedBy != nil {
+		c.JSON(http.StatusConflict, gin.H{"error": "Slot is no longer available"})
+		return
+	}
+
+	if doctorID == claims.UserID {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid slot"})
+		return
+	}
+
+	var appt models.Appointment
+	err = tx.QueryRow(c.Request.Context(), `
+		INSERT INTO appointments (patient_id, doctor_id, scheduled_at, reason, status, slot_id)
+		VALUES ($1, $2, $3, $4, $5, $6)
+		RETURNING id, patient_id, doctor_id, scheduled_at, reason, status, created_at, updated_at
+	`, claims.UserID, doctorID, startAt, reason, models.AppointmentStatusPending, slotID).
+		Scan(&appt.ID, &appt.PatientID, &appt.DoctorID, &appt.ScheduledAt, &appt.Reason, &appt.Status, &appt.CreatedAt, &appt.UpdatedAt)
+	if err != nil {
+		if strings.Contains(err.Error(), "unique") && strings.Contains(err.Error(), "slot_id") {
+			c.JSON(http.StatusConflict, gin.H{"error": "This slot is already booked"})
+			return
+		}
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Internal error"})
+		return
+	}
+
+	_, err = tx.Exec(c.Request.Context(), `
+		UPDATE doctor_slots SET patient_id = $1 WHERE id = $2 AND patient_id IS NULL
+	`, claims.UserID, slotID)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Internal error"})
+		return
+	}
+	if err := tx.Commit(c.Request.Context()); err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Internal error"})
+		return
+	}
+
+	c.JSON(http.StatusCreated, appt)
+}

--- a/backend/main.go
+++ b/backend/main.go
@@ -34,6 +34,7 @@ func main() {
 
 	auth := handlers.NewAuthHandler(cfg.JWTSecret)
 	appointments := handlers.NewAppointmentHandler()
+	geo := handlers.NewGeoBookingHandler()
 	r := gin.Default()
 
 	// CORS: allow Angular dev server and any configured origins
@@ -70,6 +71,13 @@ func main() {
 		api.GET("/patient", auth.RequireAuth(), auth.RequireRole("patient"), func(c *gin.Context) {
 			c.JSON(http.StatusOK, gin.H{"message": "Patient only"})
 		})
+
+		api.GET("/hospitals/near", auth.RequireAuth(), auth.RequireRole("patient"), geo.ListHospitalsNear)
+		api.GET("/doctors/search", auth.RequireAuth(), auth.RequireRole("patient"), geo.SearchDoctors)
+		api.GET("/doctors/:id/slots", auth.RequireAuth(), auth.RequireRole("patient"), geo.ListOpenSlotsForDoctor)
+		api.POST("/doctor/slots", auth.RequireAuth(), auth.RequireRole("doctor"), geo.CreateSlot)
+		api.DELETE("/doctor/slots/:id", auth.RequireAuth(), auth.RequireRole("doctor"), geo.DeleteOpenSlot)
+		api.POST("/appointments/book-slot", auth.RequireAuth(), auth.RequireRole("patient"), geo.BookSlot)
 
 		api.POST("/appointments", auth.RequireAuth(), auth.RequireRole("patient"), appointments.Create)
 		api.GET("/appointments/patient", auth.RequireAuth(), auth.RequireRole("patient"), appointments.ListPatient)

--- a/docs/geo-specialty-booking.md
+++ b/docs/geo-specialty-booking.md
@@ -1,0 +1,34 @@
+# Geo, specialty, and slot-based booking
+
+## Goals
+
+1. **Patient** chooses a **location** (typed address / city or **browser geolocation** with consent).
+2. Patient sets a **search radius** (km) and sees **hospitals** within that radius (Haversine distance on stored lat/lng).
+3. Patient describes a **problem** (free text) or picks a **specialty**; the app lists **doctors** in range whose **specialization** matches, so they can open the right provider.
+4. **Doctors** publish **availability slots** (start/end). **Patients** book a slot; once booked, that slot is **locked** (no double booking) and an **appointment** row is created (still subject to existing approve/reject flow).
+
+## Data model (backend)
+
+- **`hospitals`**: `name`, `city`, `region`, `latitude`, `longitude`.
+- **`users`** (doctors): `specialization`, `hospital_id` (optional anchor), `practice_latitude`, `practice_longitude` (optional if not tied to a hospital row).
+- **`doctor_slots`**: `doctor_id`, `start_at`, `end_at`, `patient_id` (NULL = open), unique `(doctor_id, start_at)`.
+- **`appointments`**: optional **`slot_id`** FK to `doctor_slots` when booked via slot flow.
+
+## API (implemented on `s2/geo-specialty-slots-backend`)
+
+| Method | Path | Role | Purpose |
+| ------ | ---- | ---- | ------- |
+| GET | `/api/hospitals/near?lat=&lng=&radius_km=` | patient | Hospitals within radius |
+| GET | `/api/doctors/search?lat=&lng=&radius_km=&specialization=` | patient | Doctors in range + specialty filter |
+| GET | `/api/doctors/:id/slots` | patient | Open slots for a doctor |
+| POST | `/api/doctor/slots` | doctor | Create availability window |
+| DELETE | `/api/doctor/slots/:id` | doctor | Remove an open slot |
+| POST | `/api/appointments/book-slot` | patient | Book slot → creates appointment + locks slot |
+
+## Frontend branch (`s2/geo-specialty-slots-frontend`)
+
+Wire **Geolocation API**, map radius UI, hospital list, specialty/problem → doctor search, slot picker, and doctor availability management. See `docs/geo-specialty-booking-frontend.md`.
+
+## Merge notes
+
+Merge **backend** before **frontend** so APIs exist when the UI calls them. Alternatively develop against a running backend branch locally.


### PR DESCRIPTION
Adds the server-side foundation for location-based discovery, specialty filtering, doctor-published slots, and transactional booking so a slot cannot be double-booked.

What changed

Schema: hospitals (with lat/lng), optional doctor profile fields (specialization, hospital_id, practice coordinates), doctor_slots (open when patient_id is null), and optional appointments.slot_id linking a visit to a booked slot.
Distance: Haversine distance in km for hospitals and doctors (doctor uses hospital coordinates when linked, otherwise practice coordinates).
Endpoints:
GET /api/hospitals/near — hospitals within radius_km of lat/lng (patient)
GET /api/doctors/search — doctors in radius, optional specialization substring filter (patient)
GET /api/doctors/:id/slots — future slots for a doctor (patient)
POST /api/doctor/slots — create availability window (doctor)
DELETE /api/doctor/slots/:id — delete an open slot (doctor)
POST /api/appointments/book-slot — book an open slot → creates pending appointment + locks slot (patient, transactional)
Seed: Sample Florida hospitals, demo doctor with specialization + hospital, and a demo open slot.
Docs

docs/geo-specialty-booking.md — product + API overview.
How to test

Run migrations (app startup) and seed.
As patient: call hospitals/near and doctors/search with query params; list doctors/:id/slots; book-slot with { slot_id, reason } and confirm a second booking on the same slot returns conflict.
As doctor: POST /doctor/slots and DELETE an open slot.
Note for reviewers

Merge this before the frontend PR so the Angular app can call these routes on dev.