### PR TITLE
S4 PR03: add migration versioning framework

### DIFF
--- a/backend/db/migration_versioning.go
+++ b/backend/db/migration_versioning.go
@@ -1,0 +1,122 @@
+package db
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sort"
+	"strings"
+)
+
+// Migration is a single ordered schema/data change unit.
+// ID should be sortable (for example: "202604271500_add_indexes").
+type Migration struct {
+	ID          string
+	Description string
+	Apply       func(context.Context) error
+}
+
+// VersionStore tracks which migrations were applied.
+type VersionStore interface {
+	Ensure(ctx context.Context) error
+	IsApplied(ctx context.Context, migrationID string) (bool, error)
+	MarkApplied(ctx context.Context, migration Migration) error
+}
+
+// SQLVersionStore persists migration versions in Postgres.
+type SQLVersionStore struct{}
+
+func (s SQLVersionStore) Ensure(ctx context.Context) error {
+	if Pool == nil {
+		return errors.New("db pool not initialized")
+	}
+	_, err := Pool.Exec(ctx, `
+		CREATE TABLE IF NOT EXISTS schema_migrations (
+			migration_id TEXT PRIMARY KEY,
+			description  TEXT NOT NULL DEFAULT '',
+			applied_at   TIMESTAMPTZ NOT NULL DEFAULT NOW()
+		)
+	`)
+	return err
+}
+
+func (s SQLVersionStore) IsApplied(ctx context.Context, migrationID string) (bool, error) {
+	if Pool == nil {
+		return false, errors.New("db pool not initialized")
+	}
+	var found bool
+	err := Pool.QueryRow(ctx, `
+		SELECT EXISTS(SELECT 1 FROM schema_migrations WHERE migration_id = $1)
+	`, migrationID).Scan(&found)
+	return found, err
+}
+
+func (s SQLVersionStore) MarkApplied(ctx context.Context, migration Migration) error {
+	if Pool == nil {
+		return errors.New("db pool not initialized")
+	}
+	_, err := Pool.Exec(ctx, `
+		INSERT INTO schema_migrations (migration_id, description)
+		VALUES ($1, $2)
+		ON CONFLICT (migration_id) DO NOTHING
+	`, migration.ID, migration.Description)
+	return err
+}
+
+// ApplyPendingMigrations runs all unapplied migrations in deterministic order.
+// It returns the IDs that were applied during this run.
+func ApplyPendingMigrations(ctx context.Context, store VersionStore, migrations []Migration) ([]string, error) {
+	if store == nil {
+		return nil, errors.New("version store is required")
+	}
+	if err := store.Ensure(ctx); err != nil {
+		return nil, fmt.Errorf("ensure version store: %w", err)
+	}
+
+	ordered, err := normalizeMigrations(migrations)
+	if err != nil {
+		return nil, err
+	}
+
+	appliedNow := make([]string, 0, len(ordered))
+	for _, m := range ordered {
+		alreadyApplied, err := store.IsApplied(ctx, m.ID)
+		if err != nil {
+			return nil, fmt.Errorf("check migration %s: %w", m.ID, err)
+		}
+		if alreadyApplied {
+			continue
+		}
+		if err := m.Apply(ctx); err != nil {
+			return appliedNow, fmt.Errorf("apply migration %s: %w", m.ID, err)
+		}
+		if err := store.MarkApplied(ctx, m); err != nil {
+			return appliedNow, fmt.Errorf("mark migration %s: %w", m.ID, err)
+		}
+		appliedNow = append(appliedNow, m.ID)
+	}
+	return appliedNow, nil
+}
+
+func normalizeMigrations(migrations []Migration) ([]Migration, error) {
+	out := make([]Migration, len(migrations))
+	copy(out, migrations)
+	sort.Slice(out, func(i, j int) bool {
+		return out[i].ID < out[j].ID
+	})
+
+	seen := map[string]struct{}{}
+	for _, m := range out {
+		if strings.TrimSpace(m.ID) == "" {
+			return nil, errors.New("migration id is required")
+		}
+		if m.Apply == nil {
+			return nil, fmt.Errorf("migration %s has nil apply function", m.ID)
+		}
+		if _, exists := seen[m.ID]; exists {
+			return nil, fmt.Errorf("duplicate migration id: %s", m.ID)
+		}
+		seen[m.ID] = struct{}{}
+	}
+	return out, nil
+}

--- a/backend/db/migration_versioning_test.go
+++ b/backend/db/migration_versioning_test.go
@@ -1,0 +1,135 @@
+package db
+
+import (
+	"context"
+	"errors"
+	"slices"
+	"testing"
+)
+
+type memoryVersionStore struct {
+	applied map[string]Migration
+}
+
+func (m *memoryVersionStore) Ensure(context.Context) error {
+	if m.applied == nil {
+		m.applied = map[string]Migration{}
+	}
+	return nil
+}
+
+func (m *memoryVersionStore) IsApplied(_ context.Context, migrationID string) (bool, error) {
+	_, ok := m.applied[migrationID]
+	return ok, nil
+}
+
+func (m *memoryVersionStore) MarkApplied(_ context.Context, migration Migration) error {
+	m.applied[migration.ID] = migration
+	return nil
+}
+
+func TestApplyPendingMigrations_SortsAndAppliesOnlyPending(t *testing.T) {
+	store := &memoryVersionStore{
+		applied: map[string]Migration{
+			"202604270100_existing": {ID: "202604270100_existing"},
+		},
+	}
+	var applyOrder []string
+	migrations := []Migration{
+		{
+			ID: "202604270300_third",
+			Apply: func(context.Context) error {
+				applyOrder = append(applyOrder, "202604270300_third")
+				return nil
+			},
+		},
+		{
+			ID: "202604270100_existing",
+			Apply: func(context.Context) error {
+				applyOrder = append(applyOrder, "202604270100_existing")
+				return nil
+			},
+		},
+		{
+			ID: "202604270200_second",
+			Apply: func(context.Context) error {
+				applyOrder = append(applyOrder, "202604270200_second")
+				return nil
+			},
+		},
+	}
+
+	applied, err := ApplyPendingMigrations(context.Background(), store, migrations)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	wantApplyOrder := []string{"202604270200_second", "202604270300_third"}
+	if !slices.Equal(applyOrder, wantApplyOrder) {
+		t.Fatalf("apply order mismatch: got %v want %v", applyOrder, wantApplyOrder)
+	}
+	if !slices.Equal(applied, wantApplyOrder) {
+		t.Fatalf("applied result mismatch: got %v want %v", applied, wantApplyOrder)
+	}
+}
+
+func TestApplyPendingMigrations_StopsOnApplyError(t *testing.T) {
+	store := &memoryVersionStore{}
+	migrations := []Migration{
+		{
+			ID: "202604270100_first",
+			Apply: func(context.Context) error {
+				return nil
+			},
+		},
+		{
+			ID: "202604270200_failing",
+			Apply: func(context.Context) error {
+				return errors.New("boom")
+			},
+		},
+		{
+			ID: "202604270300_never_runs",
+			Apply: func(context.Context) error {
+				t.Fatal("expected third migration not to run")
+				return nil
+			},
+		},
+	}
+
+	applied, err := ApplyPendingMigrations(context.Background(), store, migrations)
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if len(applied) != 1 || applied[0] != "202604270100_first" {
+		t.Fatalf("unexpected applied list before failure: %v", applied)
+	}
+	if _, ok := store.applied["202604270100_first"]; !ok {
+		t.Fatal("expected successful migration to be marked applied")
+	}
+	if _, ok := store.applied["202604270200_failing"]; ok {
+		t.Fatal("did not expect failing migration to be marked applied")
+	}
+}
+
+func TestApplyPendingMigrations_ValidatesDuplicateIDs(t *testing.T) {
+	store := &memoryVersionStore{}
+	migrations := []Migration{
+		{
+			ID: "202604270100_dup",
+			Apply: func(context.Context) error {
+				return nil
+			},
+		},
+		{
+			ID: "202604270100_dup",
+			Apply: func(context.Context) error {
+				return nil
+			},
+		},
+	}
+
+	if _, err := ApplyPendingMigrations(context.Background(), store, migrations); err == nil {
+		t.Fatal("expected duplicate id error")
+	}
+}


### PR DESCRIPTION
## Summary
- add a migration versioning framework in ackend/db with ordered execution
- add SQLVersionStore using schema_migrations table to track applied migrations
- add unit tests for ordering, skip logic, duplicate detection, and apply-failure stop behavior

## Test plan
- [x] Run go test ./... in ackend
- [x] Run go build ./... in ackend
- [x] Verify PR contains only migration framework files

Made with [Cursor](https://cursor.com)