### PR TITLE
S4 PR04: align frontend services with API contract

### DIFF
--- a/frontend/src/app/services/admin-audit.service.ts
+++ b/frontend/src/app/services/admin-audit.service.ts
@@ -1,6 +1,7 @@
 import { Injectable } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
 import { Observable } from 'rxjs';
+import { ApiContract } from './api-contract';
 
 export interface AuditLogEntry {
   id: string;
@@ -17,6 +18,6 @@ export class AdminAuditService {
   constructor(private http: HttpClient) {}
 
   list(): Observable<{ entries: AuditLogEntry[] }> {
-    return this.http.get<{ entries: AuditLogEntry[] }>('/api/admin/audit-log');
+    return this.http.get<{ entries: AuditLogEntry[] }>(ApiContract.admin.auditLog);
   }
 }

--- a/frontend/src/app/services/api-contract.ts
+++ b/frontend/src/app/services/api-contract.ts
@@ -1,0 +1,72 @@
+const API = '/api';
+
+export const ApiContract = {
+  health: '/health',
+  auth: {
+    register: `${API}/register`,
+    login: `${API}/login`,
+    me: `${API}/me`
+  },
+  bootstrap: {
+    get: `${API}/bootstrap`
+  },
+  notifications: {
+    listMine: `${API}/notifications`
+  },
+  dashboard: {
+    patientSummary: `${API}/patient/dashboard/summary`,
+    doctorSummary: `${API}/doctor/dashboard/summary`
+  },
+  geoBooking: {
+    geocode: `${API}/geocode`,
+    hospitalsNear: `${API}/hospitals/near`,
+    doctorsSearch: `${API}/doctors/search`,
+    doctorSlots: (doctorId: string): string => `${API}/doctors/${doctorId}/slots`,
+    createDoctorSlot: `${API}/doctor/slots`,
+    deleteDoctorSlot: (slotId: string): string => `${API}/doctor/slots/${slotId}`,
+    bookSlot: `${API}/appointments/book-slot`,
+    doctors: `${API}/doctors`
+  },
+  appointments: {
+    base: `${API}/appointments`,
+    listPatient: `${API}/appointments/patient`,
+    listDoctor: `${API}/appointments/doctor`,
+    byId: (id: string): string => `${API}/appointments/${id}`,
+    comments: (id: string): string => `${API}/appointments/${id}/comments`,
+    activity: (id: string): string => `${API}/appointments/${id}/activity`,
+    updateStatus: (id: string): string => `${API}/appointments/${id}/status`,
+    patientCancel: (id: string): string => `${API}/patient/appointments/${id}/cancel`
+  },
+  documents: {
+    base: `${API}/documents`,
+    download: (id: string): string => `${API}/documents/${id}/download`
+  },
+  doctorDocuments: {
+    base: `${API}/doctor/documents`,
+    byId: (id: string): string => `${API}/doctor/documents/${id}`,
+    summarize: (id: string): string => `${API}/doctor/documents/${id}/summarize`
+  },
+  patientFiles: {
+    list: (patientId: string): string => `${API}/patients/${patientId}/files`,
+    upload: (patientId: string): string => `${API}/patients/${patientId}/files`,
+    download: (fileId: string): string => `${API}/files/${fileId}`
+  },
+  prescriptions: {
+    listByPatient: (patientId: string): string => `${API}/patients/${patientId}/prescriptions`,
+    createForPatient: (patientId: string): string => `${API}/patients/${patientId}/prescriptions`,
+    revoke: (id: string): string => `${API}/prescriptions/${id}/revoke`
+  },
+  messaging: {
+    unread: `${API}/messages/unread`,
+    threads: `${API}/messages/threads`,
+    threadMessages: (threadId: string): string => `${API}/messages/threads/${threadId}`,
+    sendMessage: (threadId: string): string => `${API}/messages/threads/${threadId}/messages`,
+    markRead: (threadId: string): string => `${API}/messages/threads/${threadId}/read`
+  },
+  admin: {
+    auditLog: `${API}/admin/audit-log`,
+    knowledgeDocs: `${API}/admin/knowledge-docs`,
+    knowledgeDocById: (id: string): string => `${API}/admin/knowledge-docs/${id}`
+  }
+} as const;
+

--- a/frontend/src/app/services/appointments.service.ts
+++ b/frontend/src/app/services/appointments.service.ts
@@ -1,6 +1,7 @@
 import { Injectable } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
 import { Observable } from 'rxjs';
+import { ApiContract } from './api-contract';
 
 export interface Appointment {
   id: string;
@@ -28,46 +29,43 @@ export interface DoctorListResponse {
 
 @Injectable({ providedIn: 'root' })
 export class AppointmentsService {
-  private readonly API = '/api/appointments';
-  private readonly CoreAPI = '/api';
-
   constructor(private http: HttpClient) {}
 
   create(input: { doctor_id: string; scheduled_at: string; reason: string }): Observable<Appointment> {
-    return this.http.post<Appointment>(this.API, input);
+    return this.http.post<Appointment>(ApiContract.appointments.base, input);
   }
 
   getById(id: string): Observable<Appointment> {
-    return this.http.get<Appointment>(`${this.API}/${id}`);
+    return this.http.get<Appointment>(ApiContract.appointments.byId(id));
   }
 
   listPatient(): Observable<AppointmentListResponse> {
-    return this.http.get<AppointmentListResponse>(`${this.API}/patient`);
+    return this.http.get<AppointmentListResponse>(ApiContract.appointments.listPatient);
   }
 
   listDoctor(): Observable<AppointmentListResponse> {
-    return this.http.get<AppointmentListResponse>(`${this.API}/doctor`);
+    return this.http.get<AppointmentListResponse>(ApiContract.appointments.listDoctor);
   }
 
   listDoctors(): Observable<DoctorListResponse> {
-    return this.http.get<DoctorListResponse>(`${this.CoreAPI}/doctors`);
+    return this.http.get<DoctorListResponse>(ApiContract.geoBooking.doctors);
   }
 
   listComments(appointmentId: string): Observable<{ comments: { id: string; author_user_id: string; body: string; created_at: string }[] }> {
     return this.http.get<{ comments: { id: string; author_user_id: string; body: string; created_at: string }[] }>(
-      `${this.CoreAPI}/appointments/${appointmentId}/comments`
+      ApiContract.appointments.comments(appointmentId)
     );
   }
 
   postComment(appointmentId: string, body: string): Observable<{ id: string }> {
-    return this.http.post<{ id: string }>(`${this.CoreAPI}/appointments/${appointmentId}/comments`, { body });
+    return this.http.post<{ id: string }>(ApiContract.appointments.comments(appointmentId), { body });
   }
 
   updateStatus(id: string, status: string): Observable<Appointment> {
-    return this.http.patch<Appointment>(`${this.API}/${id}/status`, { status });
+    return this.http.patch<Appointment>(ApiContract.appointments.updateStatus(id), { status });
   }
 
   cancelAsPatient(id: string): Observable<Appointment> {
-    return this.http.post<Appointment>(`${this.CoreAPI}/patient/appointments/${id}/cancel`, {});
+    return this.http.post<Appointment>(ApiContract.appointments.patientCancel(id), {});
   }
 }

--- a/frontend/src/app/services/auth.service.ts
+++ b/frontend/src/app/services/auth.service.ts
@@ -2,6 +2,7 @@ import { Injectable } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
 import { Router } from '@angular/router';
 import { Observable, tap } from 'rxjs';
+import { ApiContract } from './api-contract';
 
 export interface UserProfile {
   id: string;
@@ -16,8 +17,6 @@ export interface AuthResponse {
 
 @Injectable({ providedIn: 'root' })
 export class AuthService {
-  private readonly API = '/api';
-
   constructor(
     private http: HttpClient,
     private router: Router
@@ -38,13 +37,13 @@ export class AuthService {
 
   register(email: string, password: string, role: string): Observable<AuthResponse> {
     return this.http
-      .post<AuthResponse>(`${this.API}/register`, { email, password, role })
+      .post<AuthResponse>(ApiContract.auth.register, { email, password, role })
       .pipe(tap((res) => this.setSession(res)));
   }
 
   login(email: string, password: string): Observable<AuthResponse> {
     return this.http
-      .post<AuthResponse>(`${this.API}/login`, { email, password })
+      .post<AuthResponse>(ApiContract.auth.login, { email, password })
       .pipe(tap((res) => this.setSession(res)));
   }
 

--- a/frontend/src/app/services/bootstrap.service.ts
+++ b/frontend/src/app/services/bootstrap.service.ts
@@ -1,6 +1,7 @@
 import { Injectable } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
 import { Observable } from 'rxjs';
+import { ApiContract } from './api-contract';
 
 export interface BootstrapPayload {
   app_name: string;
@@ -13,7 +14,7 @@ export class BootstrapService {
   constructor(private http: HttpClient) {}
 
   get(): Observable<BootstrapPayload> {
-    return this.http.get<BootstrapPayload>('/api/bootstrap');
+    return this.http.get<BootstrapPayload>(ApiContract.bootstrap.get);
   }
 }
 

--- a/frontend/src/app/services/dashboard.service.ts
+++ b/frontend/src/app/services/dashboard.service.ts
@@ -1,6 +1,7 @@
 import { Injectable } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
 import { Observable } from 'rxjs';
+import { ApiContract } from './api-contract';
 
 export interface PatientDashboardSummary {
   role: string;
@@ -19,10 +20,10 @@ export class DashboardService {
   constructor(private http: HttpClient) {}
 
   patientSummary(): Observable<PatientDashboardSummary> {
-    return this.http.get<PatientDashboardSummary>('/api/patient/dashboard/summary');
+    return this.http.get<PatientDashboardSummary>(ApiContract.dashboard.patientSummary);
   }
 
   doctorSummary(): Observable<DoctorDashboardSummary> {
-    return this.http.get<DoctorDashboardSummary>('/api/doctor/dashboard/summary');
+    return this.http.get<DoctorDashboardSummary>(ApiContract.dashboard.doctorSummary);
   }
 }

--- a/frontend/src/app/services/doctor-documents.service.ts
+++ b/frontend/src/app/services/doctor-documents.service.ts
@@ -1,6 +1,7 @@
 import { Injectable } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
 import { Observable, catchError, map, of } from 'rxjs';
+import { ApiContract } from './api-contract';
 
 /**
  * Doctor view of patient-uploaded documents + AI summary (Sprint 3 feature 4).
@@ -36,19 +37,19 @@ export interface DoctorDocumentsListResponse {
 
 @Injectable({ providedIn: 'root' })
 export class DoctorDocumentsService {
-  private readonly API = '/api/doctor/documents';
-
   constructor(private http: HttpClient) {}
 
   list(): Observable<DoctorDocumentListItem[]> {
-    return this.http.get<DoctorDocumentsListResponse>(this.API).pipe(
+    return this.http.get<DoctorDocumentsListResponse>(ApiContract.doctorDocuments.base).pipe(
       map((r) => r.documents ?? []),
       catchError(() => of([]))
     );
   }
 
   getDetail(documentId: string): Observable<DoctorDocumentDetail | null> {
-    return this.http.get<DoctorDocumentDetail>(`${this.API}/${encodeURIComponent(documentId)}`).pipe(
+    return this.http
+      .get<DoctorDocumentDetail>(ApiContract.doctorDocuments.byId(encodeURIComponent(documentId)))
+      .pipe(
       catchError(() => of(null))
     );
   }
@@ -56,7 +57,10 @@ export class DoctorDocumentsService {
   /** Triggers async summarization; poll getDetail until ready/failed. */
   requestSummary(documentId: string): Observable<{ status?: string } | null> {
     return this.http
-      .post<{ status?: string }>(`${this.API}/${encodeURIComponent(documentId)}/summarize`, {})
+      .post<{ status?: string }>(
+        ApiContract.doctorDocuments.summarize(encodeURIComponent(documentId)),
+        {}
+      )
       .pipe(catchError(() => of(null)));
   }
 }

--- a/frontend/src/app/services/documents.service.ts
+++ b/frontend/src/app/services/documents.service.ts
@@ -1,6 +1,7 @@
 import { Injectable } from '@angular/core';
 import { HttpClient, HttpEvent, HttpEventType } from '@angular/common/http';
 import { Observable, catchError, filter, map, of } from 'rxjs';
+import { ApiContract } from './api-contract';
 
 /**
  * Patient medical documents — aligns with Sprint 3 backend Kaushik:
@@ -21,12 +22,10 @@ export interface DocumentsListResponse {
 
 @Injectable({ providedIn: 'root' })
 export class DocumentsService {
-  private readonly API = '/api/documents';
-
   constructor(private http: HttpClient) {}
 
   list(): Observable<PatientDocument[]> {
-    return this.http.get<DocumentsListResponse>(this.API).pipe(
+    return this.http.get<DocumentsListResponse>(ApiContract.documents.base).pipe(
       map((r) => r.documents ?? []),
       catchError(() => of([]))
     );
@@ -43,7 +42,7 @@ export class DocumentsService {
     fd.append('file', file, file.name);
 
     return this.http
-      .post<PatientDocument>(this.API, fd, {
+      .post<PatientDocument>(ApiContract.documents.base, fd, {
         reportProgress: true,
         observe: 'events'
       })
@@ -68,7 +67,7 @@ export class DocumentsService {
 
   /** GET file stream; opens in new tab via blob URL in the component. */
   downloadBlob(id: string): Observable<Blob> {
-    return this.http.get(`${this.API}/${encodeURIComponent(id)}/download`, {
+    return this.http.get(ApiContract.documents.download(encodeURIComponent(id)), {
       responseType: 'blob'
     });
   }

--- a/frontend/src/app/services/geo-booking.service.ts
+++ b/frontend/src/app/services/geo-booking.service.ts
@@ -1,6 +1,7 @@
 import { Injectable } from '@angular/core';
 import { HttpClient, HttpParams } from '@angular/common/http';
 import { Observable } from 'rxjs';
+import { ApiContract } from './api-contract';
 
 export interface HospitalNear {
   id: string;
@@ -37,20 +38,18 @@ export interface GeocodeHit {
 
 @Injectable({ providedIn: 'root' })
 export class GeoBookingService {
-  private readonly api = '/api';
-
   constructor(private http: HttpClient) {}
 
   /** Text/address search → coordinates (backend proxies Nominatim; ~1 req/s policy on public OSM). */
   geocodeSearch(query: string, limit = 5): Observable<{ results: GeocodeHit[] }> {
     const q = query?.trim() ?? '';
     let p = new HttpParams().set('q', q).set('limit', String(limit));
-    return this.http.get<{ results: GeocodeHit[] }>(`${this.api}/geocode`, { params: p });
+    return this.http.get<{ results: GeocodeHit[] }>(ApiContract.geoBooking.geocode, { params: p });
   }
 
   hospitalsNear(lat: number, lng: number, radiusKm: number): Observable<{ hospitals: HospitalNear[] }> {
     let p = new HttpParams().set('lat', String(lat)).set('lng', String(lng)).set('radius_km', String(radiusKm));
-    return this.http.get<{ hospitals: HospitalNear[] }>(`${this.api}/hospitals/near`, { params: p });
+    return this.http.get<{ hospitals: HospitalNear[] }>(ApiContract.geoBooking.hospitalsNear, { params: p });
   }
 
   searchDoctors(lat: number, lng: number, radiusKm: number, specialization: string): Observable<{ doctors: DoctorSearchRow[] }> {
@@ -59,22 +58,22 @@ export class GeoBookingService {
     if (spec) {
       p = p.set('specialization', spec);
     }
-    return this.http.get<{ doctors: DoctorSearchRow[] }>(`${this.api}/doctors/search`, { params: p });
+    return this.http.get<{ doctors: DoctorSearchRow[] }>(ApiContract.geoBooking.doctorsSearch, { params: p });
   }
 
   listDoctorSlots(doctorId: string): Observable<{ slots: DoctorSlotRow[] }> {
-    return this.http.get<{ slots: DoctorSlotRow[] }>(`${this.api}/doctors/${doctorId}/slots`);
+    return this.http.get<{ slots: DoctorSlotRow[] }>(ApiContract.geoBooking.doctorSlots(doctorId));
   }
 
   createSlot(body: { start_at: string; end_at: string }): Observable<{ id: string }> {
-    return this.http.post<{ id: string }>(`${this.api}/doctor/slots`, body);
+    return this.http.post<{ id: string }>(ApiContract.geoBooking.createDoctorSlot, body);
   }
 
   deleteSlot(slotId: string): Observable<{ ok: boolean }> {
-    return this.http.delete<{ ok: boolean }>(`${this.api}/doctor/slots/${slotId}`);
+    return this.http.delete<{ ok: boolean }>(ApiContract.geoBooking.deleteDoctorSlot(slotId));
   }
 
   bookSlot(slotId: string, reason: string): Observable<unknown> {
-    return this.http.post(`${this.api}/appointments/book-slot`, { slot_id: slotId, reason });
+    return this.http.post(ApiContract.geoBooking.bookSlot, { slot_id: slotId, reason });
   }
 }

--- a/frontend/src/app/services/messaging.service.ts
+++ b/frontend/src/app/services/messaging.service.ts
@@ -1,6 +1,7 @@
 import { Injectable } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
 import { BehaviorSubject, Observable, catchError, map, of, tap } from 'rxjs';
+import { ApiContract } from './api-contract';
 
 /** Aligns with Sprint 3 backend: GET/POST /api/messages/... */
 export interface MessageThread {
@@ -34,7 +35,6 @@ export interface UnreadResponse {
 
 @Injectable({ providedIn: 'root' })
 export class MessagingService {
-  private readonly API = '/api/messages';
   private readonly unreadSubject = new BehaviorSubject<number>(0);
   readonly unread$ = this.unreadSubject.asObservable();
 
@@ -46,7 +46,7 @@ export class MessagingService {
 
   /** Preferred when backend exposes aggregate unread. */
   refreshUnread(): Observable<number> {
-    return this.http.get<UnreadResponse>(`${this.API}/unread`).pipe(
+    return this.http.get<UnreadResponse>(ApiContract.messaging.unread).pipe(
       map((r) => r.unread_total ?? 0),
       tap((n) => this.unreadSubject.next(n)),
       catchError(() => {
@@ -63,7 +63,7 @@ export class MessagingService {
   }
 
   listThreads(): Observable<MessageThread[]> {
-    return this.http.get<ThreadsResponse>(`${this.API}/threads`).pipe(
+    return this.http.get<ThreadsResponse>(ApiContract.messaging.threads).pipe(
       map((r) => r.threads ?? []),
       tap((threads) => this.applyUnreadFromThreads(threads)),
       catchError(() => {
@@ -75,7 +75,7 @@ export class MessagingService {
 
   listMessages(threadId: string): Observable<ChatMessage[]> {
     return this.http
-      .get<MessagesResponse>(`${this.API}/threads/${encodeURIComponent(threadId)}`)
+      .get<MessagesResponse>(ApiContract.messaging.threadMessages(encodeURIComponent(threadId)))
       .pipe(
         map((r) => r.messages ?? []),
         catchError(() => of([]))
@@ -83,18 +83,18 @@ export class MessagingService {
   }
 
   sendMessage(threadId: string, body: string): Observable<ChatMessage> {
-    return this.http.post<ChatMessage>(`${this.API}/threads/${encodeURIComponent(threadId)}/messages`, {
+    return this.http.post<ChatMessage>(ApiContract.messaging.sendMessage(encodeURIComponent(threadId)), {
       body
     });
   }
 
   createThread(peerUserId: string, body: string): Observable<MessageThread> {
-    return this.http.post<MessageThread>(`${this.API}/threads`, { peer_user_id: peerUserId, body });
+    return this.http.post<MessageThread>(ApiContract.messaging.threads, { peer_user_id: peerUserId, body });
   }
 
   markThreadRead(threadId: string): Observable<void> {
     return this.http
-      .post<void>(`${this.API}/threads/${encodeURIComponent(threadId)}/read`, {})
+      .post<void>(ApiContract.messaging.markRead(encodeURIComponent(threadId)), {})
       .pipe(catchError(() => of(undefined)));
   }
 }

--- a/frontend/src/app/services/notifications.service.ts
+++ b/frontend/src/app/services/notifications.service.ts
@@ -1,6 +1,7 @@
 import { Injectable } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
 import { Observable } from 'rxjs';
+import { ApiContract } from './api-contract';
 
 export interface NotificationRow {
   id: string;
@@ -14,11 +15,9 @@ export interface NotificationRow {
 
 @Injectable({ providedIn: 'root' })
 export class NotificationsInboxService {
-  private readonly API = '/api';
-
   constructor(private http: HttpClient) {}
 
   listMine(): Observable<{ notifications: NotificationRow[] }> {
-    return this.http.get<{ notifications: NotificationRow[] }>(`${this.API}/notifications`);
+    return this.http.get<{ notifications: NotificationRow[] }>(ApiContract.notifications.listMine);
   }
 }

--- a/frontend/src/app/services/patient-files.service.ts
+++ b/frontend/src/app/services/patient-files.service.ts
@@ -1,6 +1,7 @@
 import { Injectable } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
 import { Observable } from 'rxjs';
+import { ApiContract } from './api-contract';
 
 export interface PatientFileRow {
   id: string;
@@ -15,22 +16,20 @@ export interface PatientFileRow {
 
 @Injectable({ providedIn: 'root' })
 export class PatientFilesService {
-  private readonly API = '/api';
-
   constructor(private http: HttpClient) {}
 
   list(patientId: string): Observable<{ files: PatientFileRow[] }> {
-    return this.http.get<{ files: PatientFileRow[] }>(`${this.API}/patients/${patientId}/files`);
+    return this.http.get<{ files: PatientFileRow[] }>(ApiContract.patientFiles.list(patientId));
   }
 
   upload(patientId: string, file: File, description: string): Observable<unknown> {
     const fd = new FormData();
     fd.append('file', file);
     fd.append('description', description);
-    return this.http.post(`${this.API}/patients/${patientId}/files`, fd);
+    return this.http.post(ApiContract.patientFiles.upload(patientId), fd);
   }
 
   download(fileId: string): Observable<Blob> {
-    return this.http.get(`${this.API}/files/${fileId}`, { responseType: 'blob' });
+    return this.http.get(ApiContract.patientFiles.download(fileId), { responseType: 'blob' });
   }
 }

--- a/frontend/src/app/services/prescriptions.service.ts
+++ b/frontend/src/app/services/prescriptions.service.ts
@@ -1,6 +1,7 @@
 import { Injectable } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
 import { Observable } from 'rxjs';
+import { ApiContract } from './api-contract';
 
 export interface PrescriptionRow {
   id: string;
@@ -17,13 +18,11 @@ export interface PrescriptionRow {
 
 @Injectable({ providedIn: 'root' })
 export class PrescriptionsService {
-  private readonly API = '/api';
-
   constructor(private http: HttpClient) {}
 
   listByPatient(patientId: string): Observable<{ prescriptions: PrescriptionRow[] }> {
     return this.http.get<{ prescriptions: PrescriptionRow[] }>(
-      `${this.API}/patients/${patientId}/prescriptions`
+      ApiContract.prescriptions.listByPatient(patientId)
     );
   }
 }


### PR DESCRIPTION
## Summary
- add rontend/src/app/services/api-contract.ts as centralized endpoint contract map
- refactor frontend services to consume contract constants instead of scattered inline paths
- keep route usage aligned with backend OpenAPI baseline and reduce drift risk

## Test plan
- [x] Run 
pm run test:ci in rontend
- [x] Run 
pm run build in rontend
- [x] Run go test ./... in ackend for regression

Made with [Cursor](https://cursor.com)