### PR TITLE
S4 PR05: add notification preferences schema API

### DIFF
--- a/backend/handlers/notifications.go
+++ b/backend/handlers/notifications.go
@@ -2,7 +2,9 @@ package handlers
 
 import (
 	"database/sql"
+	"errors"
 	"net/http"
+	"strings"
 
 	"github.com/gin-gonic/gin"
 	"github.com/healthonyx/backend/db"
@@ -12,6 +14,90 @@ type NotificationsHandler struct{}
 
 func NewNotificationsHandler() *NotificationsHandler {
 	return &NotificationsHandler{}
+}
+
+type NotificationPreference struct {
+	Category     string `json:"category"`
+	Enabled      bool   `json:"enabled"`
+	EmailEnabled bool   `json:"email_enabled"`
+	SmsEnabled   bool   `json:"sms_enabled"`
+	InAppEnabled bool   `json:"in_app_enabled"`
+}
+
+type upsertNotificationPreferencesBody struct {
+	Preferences []NotificationPreference `json:"preferences"`
+}
+
+var defaultNotificationPreferences = []NotificationPreference{
+	{Category: "appointment_reminders", Enabled: true, EmailEnabled: true, SmsEnabled: false, InAppEnabled: true},
+	{Category: "medication_reminders", Enabled: true, EmailEnabled: true, SmsEnabled: false, InAppEnabled: true},
+	{Category: "lab_result_alerts", Enabled: true, EmailEnabled: true, SmsEnabled: false, InAppEnabled: true},
+	{Category: "announcements", Enabled: true, EmailEnabled: true, SmsEnabled: false, InAppEnabled: true},
+}
+
+func validNotificationCategory(category string) bool {
+	switch category {
+	case "appointment_reminders", "medication_reminders", "lab_result_alerts", "announcements":
+		return true
+	default:
+		return false
+	}
+}
+
+func normalizeNotificationPreference(input NotificationPreference) (NotificationPreference, error) {
+	category := strings.TrimSpace(strings.ToLower(input.Category))
+	if !validNotificationCategory(category) {
+		return NotificationPreference{}, errors.New("invalid category")
+	}
+	return NotificationPreference{
+		Category:     category,
+		Enabled:      input.Enabled,
+		EmailEnabled: input.EmailEnabled,
+		SmsEnabled:   input.SmsEnabled,
+		InAppEnabled: input.InAppEnabled,
+	}, nil
+}
+
+func (h *NotificationsHandler) ensurePreferencesSchema(c *gin.Context) error {
+	_, err := db.Pool.Exec(c.Request.Context(), `
+		CREATE TABLE IF NOT EXISTS notification_preferences (
+			user_id        UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+			category       TEXT NOT NULL,
+			enabled        BOOLEAN NOT NULL DEFAULT TRUE,
+			email_enabled  BOOLEAN NOT NULL DEFAULT TRUE,
+			sms_enabled    BOOLEAN NOT NULL DEFAULT FALSE,
+			in_app_enabled BOOLEAN NOT NULL DEFAULT TRUE,
+			updated_at     TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+			PRIMARY KEY (user_id, category),
+			CONSTRAINT notification_preferences_category_check CHECK (
+				category IN ('appointment_reminders', 'medication_reminders', 'lab_result_alerts', 'announcements')
+			)
+		)
+	`)
+	return err
+}
+
+func (h *NotificationsHandler) seedDefaultsIfMissing(c *gin.Context, userID string) error {
+	var count int
+	if err := db.Pool.QueryRow(c.Request.Context(),
+		`SELECT COUNT(*) FROM notification_preferences WHERE user_id = $1`, userID,
+	).Scan(&count); err != nil {
+		return err
+	}
+	if count > 0 {
+		return nil
+	}
+	for _, pref := range defaultNotificationPreferences {
+		_, err := db.Pool.Exec(c.Request.Context(), `
+			INSERT INTO notification_preferences (user_id, category, enabled, email_enabled, sms_enabled, in_app_enabled)
+			VALUES ($1, $2, $3, $4, $5, $6)
+			ON CONFLICT (user_id, category) DO NOTHING
+		`, userID, pref.Category, pref.Enabled, pref.EmailEnabled, pref.SmsEnabled, pref.InAppEnabled)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 func (h *NotificationsHandler) ListMine(c *gin.Context) {
@@ -60,4 +146,93 @@ func (h *NotificationsHandler) ListMine(c *gin.Context) {
 		out = []row{}
 	}
 	c.JSON(http.StatusOK, gin.H{"notifications": out})
+}
+
+// ListPreferences GET /api/notifications/preferences
+func (h *NotificationsHandler) ListPreferences(c *gin.Context) {
+	claims, ok := getClaims(c)
+	if !ok {
+		return
+	}
+	if err := h.ensurePreferencesSchema(c); err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Internal error"})
+		return
+	}
+	if err := h.seedDefaultsIfMissing(c, claims.UserID.String()); err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Internal error"})
+		return
+	}
+
+	rows, err := db.Pool.Query(c.Request.Context(), `
+		SELECT category, enabled, email_enabled, sms_enabled, in_app_enabled
+		FROM notification_preferences
+		WHERE user_id = $1
+		ORDER BY category ASC
+	`, claims.UserID)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Internal error"})
+		return
+	}
+	defer rows.Close()
+
+	out := make([]NotificationPreference, 0, 8)
+	for rows.Next() {
+		var row NotificationPreference
+		if err := rows.Scan(&row.Category, &row.Enabled, &row.EmailEnabled, &row.SmsEnabled, &row.InAppEnabled); err != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "Internal error"})
+			return
+		}
+		out = append(out, row)
+	}
+	if out == nil {
+		out = []NotificationPreference{}
+	}
+	c.JSON(http.StatusOK, gin.H{"preferences": out})
+}
+
+// UpsertPreferences PUT /api/notifications/preferences
+func (h *NotificationsHandler) UpsertPreferences(c *gin.Context) {
+	claims, ok := getClaims(c)
+	if !ok {
+		return
+	}
+	if err := h.ensurePreferencesSchema(c); err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Internal error"})
+		return
+	}
+
+	var body upsertNotificationPreferencesBody
+	if err := c.ShouldBindJSON(&body); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid request body"})
+		return
+	}
+	if len(body.Preferences) == 0 {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "preferences are required"})
+		return
+	}
+
+	for _, raw := range body.Preferences {
+		pref, err := normalizeNotificationPreference(raw)
+		if err != nil {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid category in preferences"})
+			return
+		}
+		_, err = db.Pool.Exec(c.Request.Context(), `
+			INSERT INTO notification_preferences (user_id, category, enabled, email_enabled, sms_enabled, in_app_enabled, updated_at)
+			VALUES ($1, $2, $3, $4, $5, $6, NOW())
+			ON CONFLICT (user_id, category)
+			DO UPDATE SET
+				enabled = EXCLUDED.enabled,
+				email_enabled = EXCLUDED.email_enabled,
+				sms_enabled = EXCLUDED.sms_enabled,
+				in_app_enabled = EXCLUDED.in_app_enabled,
+				updated_at = NOW()
+		`, claims.UserID, pref.Category, pref.Enabled, pref.EmailEnabled, pref.SmsEnabled, pref.InAppEnabled)
+		if err != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "Internal error"})
+			return
+		}
+	}
+
+	c.JSON(http.StatusOK, gin.H{"updated": len(body.Preferences)})
 }

--- a/backend/handlers/notifications_test.go
+++ b/backend/handlers/notifications_test.go
@@ -3,6 +3,7 @@ package handlers
 import (
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/gin-gonic/gin"
@@ -19,5 +20,55 @@ func TestNotifications_ListMine_Unauthorized(t *testing.T) {
 
 	if w.Code != http.StatusUnauthorized {
 		t.Fatalf("expected 401, got %d", w.Code)
+	}
+}
+
+func TestNotifications_ListPreferences_Unauthorized(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest("GET", "/api/notifications/preferences", nil)
+
+	h := NewNotificationsHandler()
+	h.ListPreferences(c)
+
+	if w.Code != http.StatusUnauthorized {
+		t.Fatalf("expected 401, got %d", w.Code)
+	}
+}
+
+func TestNotifications_UpsertPreferences_Unauthorized(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest("PUT", "/api/notifications/preferences", strings.NewReader(`{}`))
+	c.Request.Header.Set("Content-Type", "application/json")
+
+	h := NewNotificationsHandler()
+	h.UpsertPreferences(c)
+
+	if w.Code != http.StatusUnauthorized {
+		t.Fatalf("expected 401, got %d", w.Code)
+	}
+}
+
+func TestNormalizeNotificationPreference_ValidAndInvalid(t *testing.T) {
+	ok, err := normalizeNotificationPreference(NotificationPreference{
+		Category:     "Appointment_Reminders",
+		Enabled:      true,
+		EmailEnabled: true,
+		SmsEnabled:   false,
+		InAppEnabled: true,
+	})
+	if err != nil {
+		t.Fatalf("expected valid pref, got error: %v", err)
+	}
+	if ok.Category != "appointment_reminders" {
+		t.Fatalf("expected normalized category appointment_reminders, got %s", ok.Category)
+	}
+
+	_, err = normalizeNotificationPreference(NotificationPreference{Category: "unknown"})
+	if err == nil {
+		t.Fatal("expected invalid category error")
 	}
 }


### PR DESCRIPTION
## Summary
- extend notifications handler with notification preference APIs (ListPreferences, UpsertPreferences)
- add schema bootstrap for 
otification_preferences table with category constraints and per-channel toggles
- add defaults seeding and normalization helpers for supported preference categories
- add unit tests for auth paths and preference normalization validation

## Test plan
- [x] Run go test ./... in ackend
- [x] Run go build ./... in ackend
- [x] Run 
pm run test:ci in rontend (combined regression)
- [x] Run 
pm run build in rontend (combined regression)

Made with [Cursor](https://cursor.com)