### PR TITLE
S4 PR06: add notification preferences UI

### DIFF
--- a/frontend/src/app/components/notifications-inbox/notifications-inbox.component.spec.ts
+++ b/frontend/src/app/components/notifications-inbox/notifications-inbox.component.spec.ts
@@ -16,6 +16,17 @@ describe('NotificationsInboxComponent', () => {
     fixture = TestBed.createComponent(NotificationsInboxComponent);
     httpMock = TestBed.inject(HttpTestingController);
     fixture.detectChanges();
+    httpMock.expectOne('/api/notifications/preferences').flush({
+      preferences: [
+        {
+          category: 'appointment_reminders',
+          enabled: true,
+          email_enabled: true,
+          sms_enabled: false,
+          in_app_enabled: true
+        }
+      ]
+    });
     httpMock.expectOne('/api/notifications').flush({ notifications: [] });
     fixture.detectChanges();
   });
@@ -26,5 +37,15 @@ describe('NotificationsInboxComponent', () => {
     expect(
       (fixture.nativeElement as HTMLElement).querySelector('[data-cy="notifications-empty"]')
     ).toBeTruthy();
+  });
+
+  it('shows notification preferences section', () => {
+    expect(
+      (fixture.nativeElement as HTMLElement).querySelector('[data-cy="notification-preferences"]')
+    ).toBeTruthy();
+    expect(
+      (fixture.nativeElement as HTMLElement).querySelectorAll('[data-cy="notification-pref-row"]')
+        .length
+    ).toBe(1);
   });
 });

--- a/frontend/src/app/components/notifications-inbox/notifications-inbox.component.ts
+++ b/frontend/src/app/components/notifications-inbox/notifications-inbox.component.ts
@@ -1,6 +1,10 @@
 import { Component, OnInit } from '@angular/core';
 import { CommonModule } from '@angular/common';
-import { NotificationsInboxService, NotificationRow } from '../../services/notifications.service';
+import {
+  NotificationsInboxService,
+  NotificationPreferenceRow,
+  NotificationRow
+} from '../../services/notifications.service';
 
 @Component({
   selector: 'app-notifications-inbox',
@@ -9,7 +13,36 @@ import { NotificationsInboxService, NotificationRow } from '../../services/notif
   template: `
     <section data-cy="notifications-inbox-page">
       <h1>Notifications</h1>
+      <p class="ok" *ngIf="prefsSaved">{{ prefsSaved }}</p>
       <p class="err" *ngIf="error">{{ error }}</p>
+
+      <section class="prefs" data-cy="notification-preferences">
+        <h2>Preferences</h2>
+        <p class="muted">Choose how you receive reminders and alerts.</p>
+        <div class="prefs-table" *ngIf="preferences.length; else prefsFallback">
+          <div class="prefs-head">
+            <span>Category</span>
+            <span>Enabled</span>
+            <span>Email</span>
+            <span>SMS</span>
+            <span>In-app</span>
+          </div>
+          <div class="prefs-row" *ngFor="let p of preferences; let i = index" data-cy="notification-pref-row">
+            <span>{{ labelFor(p.category) }}</span>
+            <input type="checkbox" [checked]="p.enabled" (change)="toggle(i, 'enabled', $event)" />
+            <input type="checkbox" [checked]="p.email_enabled" (change)="toggle(i, 'email_enabled', $event)" />
+            <input type="checkbox" [checked]="p.sms_enabled" (change)="toggle(i, 'sms_enabled', $event)" />
+            <input type="checkbox" [checked]="p.in_app_enabled" (change)="toggle(i, 'in_app_enabled', $event)" />
+          </div>
+        </div>
+        <ng-template #prefsFallback>
+          <p class="muted">Preferences are unavailable right now.</p>
+        </ng-template>
+        <button type="button" (click)="savePreferences()" [disabled]="saving || !preferences.length" data-cy="notification-pref-save">
+          {{ saving ? 'Saving...' : 'Save preferences' }}
+        </button>
+      </section>
+
       <ul *ngIf="rows.length" data-cy="notifications-list">
         <li *ngFor="let r of rows" data-cy="notifications-row">
           <strong>{{ r.title }}</strong>
@@ -25,22 +58,110 @@ import { NotificationsInboxService, NotificationRow } from '../../services/notif
       .err {
         color: #b00020;
       }
+      .ok {
+        color: #166534;
+      }
       .body {
         margin: 0.25rem 0;
+      }
+      .prefs {
+        margin: 1rem 0 1.25rem;
+        padding: 0.75rem;
+        border: 1px solid #e5e7eb;
+        border-radius: 0.5rem;
+      }
+      .muted {
+        color: #6b7280;
+      }
+      .prefs-table {
+        display: grid;
+        gap: 0.5rem;
+      }
+      .prefs-head,
+      .prefs-row {
+        display: grid;
+        grid-template-columns: 2fr repeat(4, minmax(64px, 0.5fr));
+        align-items: center;
+        gap: 0.5rem;
+      }
+      .prefs-head {
+        font-weight: 600;
+      }
+      button {
+        margin-top: 0.75rem;
       }
     `
   ]
 })
 export class NotificationsInboxComponent implements OnInit {
   rows: NotificationRow[] = [];
+  preferences: NotificationPreferenceRow[] = [];
   error: string | null = null;
+  prefsSaved: string | null = null;
+  saving = false;
 
   constructor(private api: NotificationsInboxService) {}
 
   ngOnInit(): void {
+    this.loadPreferences();
     this.api.listMine().subscribe({
       next: (res) => (this.rows = res.notifications ?? []),
       error: () => (this.error = 'Could not load notifications')
+    });
+  }
+
+  private loadPreferences(): void {
+    this.api.listPreferences().subscribe({
+      next: (res) => (this.preferences = res.preferences ?? []),
+      error: () => {
+        this.preferences = [];
+      }
+    });
+  }
+
+  labelFor(category: string): string {
+    switch (category) {
+      case 'appointment_reminders':
+        return 'Appointment reminders';
+      case 'medication_reminders':
+        return 'Medication reminders';
+      case 'lab_result_alerts':
+        return 'Lab result alerts';
+      case 'announcements':
+        return 'Announcements';
+      default:
+        return category;
+    }
+  }
+
+  toggle(
+    index: number,
+    key: 'enabled' | 'email_enabled' | 'sms_enabled' | 'in_app_enabled',
+    event: Event
+  ): void {
+    const input = event.target as HTMLInputElement | null;
+    if (!input || !this.preferences[index]) {
+      return;
+    }
+    this.preferences[index] = { ...this.preferences[index], [key]: input.checked };
+    this.prefsSaved = null;
+  }
+
+  savePreferences(): void {
+    if (!this.preferences.length || this.saving) {
+      return;
+    }
+    this.error = null;
+    this.saving = true;
+    this.api.savePreferences(this.preferences).subscribe({
+      next: () => {
+        this.saving = false;
+        this.prefsSaved = 'Preferences saved.';
+      },
+      error: () => {
+        this.saving = false;
+        this.error = 'Could not save notification preferences';
+      }
     });
   }
 }

--- a/frontend/src/app/services/api-contract.ts
+++ b/frontend/src/app/services/api-contract.ts
@@ -11,7 +11,9 @@ export const ApiContract = {
     get: `${API}/bootstrap`
   },
   notifications: {
-    listMine: `${API}/notifications`
+    listMine: `${API}/notifications`,
+    listPreferences: `${API}/notifications/preferences`,
+    upsertPreferences: `${API}/notifications/preferences`
   },
   dashboard: {
     patientSummary: `${API}/patient/dashboard/summary`,

--- a/frontend/src/app/services/notifications.service.ts
+++ b/frontend/src/app/services/notifications.service.ts
@@ -13,11 +13,31 @@ export interface NotificationRow {
   created_at: string;
 }
 
+export interface NotificationPreferenceRow {
+  category: string;
+  enabled: boolean;
+  email_enabled: boolean;
+  sms_enabled: boolean;
+  in_app_enabled: boolean;
+}
+
 @Injectable({ providedIn: 'root' })
 export class NotificationsInboxService {
   constructor(private http: HttpClient) {}
 
   listMine(): Observable<{ notifications: NotificationRow[] }> {
     return this.http.get<{ notifications: NotificationRow[] }>(ApiContract.notifications.listMine);
+  }
+
+  listPreferences(): Observable<{ preferences: NotificationPreferenceRow[] }> {
+    return this.http.get<{ preferences: NotificationPreferenceRow[] }>(
+      ApiContract.notifications.listPreferences
+    );
+  }
+
+  savePreferences(preferences: NotificationPreferenceRow[]): Observable<{ updated: number }> {
+    return this.http.put<{ updated: number }>(ApiContract.notifications.upsertPreferences, {
+      preferences
+    });
   }
 }


### PR DESCRIPTION
## Summary
- add notification preferences API methods in frontend notifications service
- extend notifications inbox with editable preferences panel (category + channel toggles)
- add save flow and success/error handling in UI
- update component tests to cover preferences rendering

## Test plan
- [x] Run 
pm run test:ci in rontend
- [x] Run 
pm run build in rontend
- [x] Run go test ./... in ackend for combined regression

Made with [Cursor](https://cursor.com)