### PR TITLE
S4 PR07: add notification worker scheduler

### DIFF
--- a/backend/workers/notification_worker.go
+++ b/backend/workers/notification_worker.go
@@ -1,0 +1,73 @@
+package workers
+
+import (
+	"context"
+	"log"
+	"time"
+
+	"github.com/healthonyx/backend/db"
+)
+
+// NotificationWorker marks due pending notifications as sent.
+// This is an in-app scheduler foundation; channel adapters (email/sms) can
+// plug into this worker in later PRs without changing scheduling semantics.
+type NotificationWorker struct {
+	interval time.Duration
+	now      func() time.Time
+	process  func(context.Context) (int64, error)
+}
+
+func NewNotificationWorker(interval time.Duration) *NotificationWorker {
+	if interval <= 0 {
+		interval = time.Minute
+	}
+	return &NotificationWorker{
+		interval: interval,
+		now:      time.Now,
+		process:  nil,
+	}
+}
+
+// Run starts a ticker loop and continues until context cancellation.
+func (w *NotificationWorker) Run(ctx context.Context) {
+	ticker := time.NewTicker(w.interval)
+	defer ticker.Stop()
+
+	// Run once on startup to catch existing due jobs.
+	if _, err := w.processDue(ctx); err != nil {
+		log.Printf("notification worker initial process error: %v", err)
+	}
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			if _, err := w.processDue(ctx); err != nil {
+				log.Printf("notification worker process error: %v", err)
+			}
+		}
+	}
+}
+
+// ProcessDue marks notifications as sent when they are pending and due now.
+func (w *NotificationWorker) ProcessDue(ctx context.Context) (int64, error) {
+	res, err := db.Pool.Exec(ctx, `
+		UPDATE notifications
+		SET status = 'sent'
+		WHERE status = 'pending'
+		  AND (scheduled_for IS NULL OR scheduled_for <= $1)
+	`, w.now().UTC())
+	if err != nil {
+		return 0, err
+	}
+	return res.RowsAffected(), nil
+}
+
+func (w *NotificationWorker) processDue(ctx context.Context) (int64, error) {
+	if w.process != nil {
+		return w.process(ctx)
+	}
+	return w.ProcessDue(ctx)
+}
+

--- a/backend/workers/notification_worker_test.go
+++ b/backend/workers/notification_worker_test.go
@@ -1,0 +1,50 @@
+package workers
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+func TestNewNotificationWorker_DefaultInterval(t *testing.T) {
+	w := NewNotificationWorker(0)
+	if w == nil {
+		t.Fatal("expected worker, got nil")
+	}
+	if w.interval != time.Minute {
+		t.Fatalf("expected default interval %v, got %v", time.Minute, w.interval)
+	}
+}
+
+func TestNewNotificationWorker_UsesProvidedInterval(t *testing.T) {
+	want := 15 * time.Second
+	w := NewNotificationWorker(want)
+	if w.interval != want {
+		t.Fatalf("expected interval %v, got %v", want, w.interval)
+	}
+}
+
+func TestNotificationWorker_RunStopsOnContextCancel(t *testing.T) {
+	w := NewNotificationWorker(10 * time.Millisecond)
+	// Avoid DB dependency in this unit test; worker should still stop gracefully.
+	w.process = func(context.Context) (int64, error) { return 0, nil }
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+
+	go func() {
+		defer close(done)
+		w.Run(ctx)
+	}()
+
+	time.Sleep(15 * time.Millisecond)
+	cancel()
+
+	select {
+	case <-done:
+		// ok
+	case <-time.After(200 * time.Millisecond):
+		t.Fatal("worker did not stop after context cancellation")
+	}
+}
+


### PR DESCRIPTION
## Summary
- add backend notification worker package for scheduler processing
- run due pending notifications on startup and fixed ticker interval
- include unit tests for default interval behavior and context-cancel stop semantics

## Test plan
- [x] Run go test ./... in ackend
- [x] Run go build ./... in ackend
- [x] Run 
pm run test:ci in rontend (combined regression)
- [x] Run 
pm run build in rontend (combined regression)

Made with [Cursor](https://cursor.com)