### PR TITLE
S4 PR08: add admin notification log UI

### DIFF
--- a/frontend/src/app/app.routes.ts
+++ b/frontend/src/app/app.routes.ts
@@ -6,6 +6,7 @@ import { AppShellComponent } from './components/app-shell/app-shell.component';
 import { DashboardPlaceholderComponent } from './components/dashboard-placeholder/dashboard-placeholder.component';
 import { AdminShellComponent } from './components/admin-shell/admin-shell.component';
 import { AdminAuditComponent } from './components/admin-audit/admin-audit.component';
+import { AdminNotificationsLogComponent } from './components/admin-notifications-log/admin-notifications-log.component';
 import { AdminKnowledgeComponent } from './components/admin-knowledge/admin-knowledge.component';
 import { PatientAppointmentsComponent } from './components/patient-appointments/patient-appointments.component';
 import { PatientAppointmentDetailComponent } from './components/patient-appointment-detail/patient-appointment-detail.component';
@@ -180,6 +181,12 @@ export const routes: Routes = [
             path: 'audit',
             component: AdminAuditComponent,
             data: { title: 'Audit log', roles: ['admin'] },
+            canActivate: [roleGuard]
+          },
+          {
+            path: 'notifications',
+            component: AdminNotificationsLogComponent,
+            data: { title: 'Notifications', roles: ['admin'] },
             canActivate: [roleGuard]
           },
           {

--- a/frontend/src/app/components/admin-notifications-log/admin-notifications-log.component.spec.ts
+++ b/frontend/src/app/components/admin-notifications-log/admin-notifications-log.component.spec.ts
@@ -1,0 +1,51 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { provideHttpClient } from '@angular/common/http';
+import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
+import { AdminNotificationsLogComponent } from './admin-notifications-log.component';
+
+describe('AdminNotificationsLogComponent', () => {
+  let fixture: ComponentFixture<AdminNotificationsLogComponent>;
+  let httpMock: HttpTestingController;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [AdminNotificationsLogComponent],
+      providers: [provideHttpClient(), provideHttpClientTesting()]
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(AdminNotificationsLogComponent);
+    httpMock = TestBed.inject(HttpTestingController);
+    fixture.detectChanges();
+  });
+
+  afterEach(() => httpMock.verify());
+
+  it('shows empty state', () => {
+    httpMock.expectOne('/api/notifications').flush({ notifications: [] });
+    fixture.detectChanges();
+    expect(
+      (fixture.nativeElement as HTMLElement).querySelector('[data-cy="admin-notifications-empty"]')
+    ).toBeTruthy();
+  });
+
+  it('renders table rows', () => {
+    httpMock.expectOne('/api/notifications').flush({
+      notifications: [
+        {
+          id: '1',
+          title: 'Test',
+          body: 'Hello',
+          channel: 'in_app',
+          status: 'sent',
+          created_at: 'now'
+        }
+      ]
+    });
+    fixture.detectChanges();
+    expect(
+      (fixture.nativeElement as HTMLElement).querySelectorAll('[data-cy="admin-notifications-row"]')
+        .length
+    ).toBe(1);
+  });
+});
+

--- a/frontend/src/app/components/admin-notifications-log/admin-notifications-log.component.ts
+++ b/frontend/src/app/components/admin-notifications-log/admin-notifications-log.component.ts
@@ -1,0 +1,72 @@
+import { Component, OnInit } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { NotificationsInboxService, NotificationRow } from '../../services/notifications.service';
+
+@Component({
+  selector: 'app-admin-notifications-log',
+  standalone: true,
+  imports: [CommonModule],
+  template: `
+    <section data-cy="admin-notifications-page">
+      <h1>Notification log</h1>
+      <p *ngIf="error" class="err">{{ error }}</p>
+      <table *ngIf="rows.length" data-cy="admin-notifications-table">
+        <thead>
+          <tr>
+            <th>When</th>
+            <th>Title</th>
+            <th>Channel</th>
+            <th>Status</th>
+            <th>Scheduled</th>
+            <th>Body</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr *ngFor="let r of rows" data-cy="admin-notifications-row">
+            <td>{{ r.created_at }}</td>
+            <td>{{ r.title }}</td>
+            <td>{{ r.channel }}</td>
+            <td>{{ r.status }}</td>
+            <td>{{ r.scheduled_for || '—' }}</td>
+            <td>{{ r.body }}</td>
+          </tr>
+        </tbody>
+      </table>
+      <p *ngIf="!error && !rows.length" data-cy="admin-notifications-empty">
+        No notifications yet.
+      </p>
+    </section>
+  `,
+  styles: [
+    `
+      table {
+        width: 100%;
+        border-collapse: collapse;
+        font-size: 0.85rem;
+      }
+      th,
+      td {
+        border-bottom: 1px solid rgba(148, 163, 184, 0.25);
+        padding: 0.4rem;
+        text-align: left;
+      }
+      .err {
+        color: #f87171;
+      }
+    `
+  ]
+})
+export class AdminNotificationsLogComponent implements OnInit {
+  rows: NotificationRow[] = [];
+  error: string | null = null;
+
+  constructor(private api: NotificationsInboxService) {}
+
+  ngOnInit(): void {
+    this.api.listMine().subscribe({
+      next: (r) => (this.rows = r.notifications ?? []),
+      error: () => (this.error = 'Could not load notification log')
+    });
+  }
+}
+

--- a/frontend/src/app/components/admin-shell/admin-shell.component.ts
+++ b/frontend/src/app/components/admin-shell/admin-shell.component.ts
@@ -9,6 +9,7 @@ import { RouterLink, RouterLinkActive, RouterOutlet } from '@angular/router';
     <nav class="subnav">
       <a routerLink="/admin" routerLinkActive="active" [routerLinkActiveOptions]="{ exact: true }">Overview</a>
       <a routerLink="/admin/audit" routerLinkActive="active">Audit log</a>
+      <a routerLink="/admin/notifications" routerLinkActive="active">Notifications</a>
       <a routerLink="/admin/knowledge" routerLinkActive="active">Knowledge</a>
     </nav>
     <router-outlet />


### PR DESCRIPTION
## Summary
- add new admin notifications log page with table and empty state
- wire admin notifications page into admin shell nav and routes
- keep styling and structure consistent with existing admin audit UI
- add component tests for empty and populated states

## Test plan
- [x] Run 
pm run test:ci in rontend
- [x] Run 
pm run build in rontend
- [x] Run go test ./... in ackend (combined regression)
- [ ] Run 
pm run cypress:e2e (blocked: local Docker engine/Postgres unavailable on this machine)

Made with [Cursor](https://cursor.com)