### PR TITLE
S4 PR09: add SendGrid and Twilio provider adapters

### DIFF
--- a/backend/providers/notification_adapters.go
+++ b/backend/providers/notification_adapters.go
@@ -1,0 +1,169 @@
+package providers
+
+import (
+	"bytes"
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+)
+
+type DeliveryRequest struct {
+	To      string
+	Subject string
+	Body    string
+}
+
+type EmailProvider interface {
+	Send(ctx context.Context, req DeliveryRequest) error
+}
+
+type SMSProvider interface {
+	Send(ctx context.Context, req DeliveryRequest) error
+}
+
+type SendGridAdapter struct {
+	APIKey  string
+	From    string
+	BaseURL string
+	Client  *http.Client
+}
+
+func NewSendGridAdapter(apiKey, from string) *SendGridAdapter {
+	return &SendGridAdapter{
+		APIKey:  strings.TrimSpace(apiKey),
+		From:    strings.TrimSpace(from),
+		BaseURL: "https://api.sendgrid.com",
+		Client:  &http.Client{Timeout: 10 * time.Second},
+	}
+}
+
+func (s *SendGridAdapter) Send(ctx context.Context, req DeliveryRequest) error {
+	if strings.TrimSpace(req.To) == "" {
+		return errors.New("sendgrid: recipient is required")
+	}
+	if strings.TrimSpace(req.Body) == "" {
+		return errors.New("sendgrid: body is required")
+	}
+	if s.APIKey == "" {
+		return errors.New("sendgrid: api key is required")
+	}
+	if s.From == "" {
+		return errors.New("sendgrid: from address is required")
+	}
+	client := s.Client
+	if client == nil {
+		client = &http.Client{Timeout: 10 * time.Second}
+	}
+	baseURL := strings.TrimRight(s.BaseURL, "/")
+	if baseURL == "" {
+		baseURL = "https://api.sendgrid.com"
+	}
+
+	payload := map[string]any{
+		"personalizations": []map[string]any{
+			{
+				"to": []map[string]string{
+					{"email": strings.TrimSpace(req.To)},
+				},
+				"subject": strings.TrimSpace(req.Subject),
+			},
+		},
+		"from": map[string]string{"email": s.From},
+		"content": []map[string]string{
+			{"type": "text/plain", "value": req.Body},
+		},
+	}
+	body, _ := json.Marshal(payload)
+	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, baseURL+"/v3/mail/send", bytes.NewReader(body))
+	if err != nil {
+		return err
+	}
+	httpReq.Header.Set("Authorization", "Bearer "+s.APIKey)
+	httpReq.Header.Set("Content-Type", "application/json")
+
+	res, err := client.Do(httpReq)
+	if err != nil {
+		return err
+	}
+	defer res.Body.Close()
+
+	if res.StatusCode < 200 || res.StatusCode >= 300 {
+		b, _ := io.ReadAll(io.LimitReader(res.Body, 4096))
+		return fmt.Errorf("sendgrid: status %d: %s", res.StatusCode, string(b))
+	}
+	return nil
+}
+
+type TwilioAdapter struct {
+	AccountSID string
+	AuthToken  string
+	From       string
+	BaseURL    string
+	Client     *http.Client
+}
+
+func NewTwilioAdapter(accountSID, authToken, from string) *TwilioAdapter {
+	return &TwilioAdapter{
+		AccountSID: strings.TrimSpace(accountSID),
+		AuthToken:  strings.TrimSpace(authToken),
+		From:       strings.TrimSpace(from),
+		BaseURL:    "https://api.twilio.com",
+		Client:     &http.Client{Timeout: 10 * time.Second},
+	}
+}
+
+func (t *TwilioAdapter) Send(ctx context.Context, req DeliveryRequest) error {
+	if strings.TrimSpace(req.To) == "" {
+		return errors.New("twilio: recipient is required")
+	}
+	if strings.TrimSpace(req.Body) == "" {
+		return errors.New("twilio: body is required")
+	}
+	if t.AccountSID == "" || t.AuthToken == "" {
+		return errors.New("twilio: account credentials are required")
+	}
+	if t.From == "" {
+		return errors.New("twilio: from number is required")
+	}
+	client := t.Client
+	if client == nil {
+		client = &http.Client{Timeout: 10 * time.Second}
+	}
+	baseURL := strings.TrimRight(t.BaseURL, "/")
+	if baseURL == "" {
+		baseURL = "https://api.twilio.com"
+	}
+
+	form := url.Values{}
+	form.Set("To", req.To)
+	form.Set("From", t.From)
+	form.Set("Body", req.Body)
+
+	endpoint := fmt.Sprintf("%s/2010-04-01/Accounts/%s/Messages.json", baseURL, url.PathEscape(t.AccountSID))
+	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, strings.NewReader(form.Encode()))
+	if err != nil {
+		return err
+	}
+	httpReq.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	encoded := base64.StdEncoding.EncodeToString([]byte(t.AccountSID + ":" + t.AuthToken))
+	httpReq.Header.Set("Authorization", "Basic "+encoded)
+
+	res, err := client.Do(httpReq)
+	if err != nil {
+		return err
+	}
+	defer res.Body.Close()
+	if res.StatusCode < 200 || res.StatusCode >= 300 {
+		b, _ := io.ReadAll(io.LimitReader(res.Body, 4096))
+		return fmt.Errorf("twilio: status %d: %s", res.StatusCode, string(b))
+	}
+	return nil
+}
+

--- a/backend/providers/notification_adapters_test.go
+++ b/backend/providers/notification_adapters_test.go
@@ -1,0 +1,123 @@
+package providers
+
+import (
+	"context"
+	"encoding/base64"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestSendGridAdapter_Send_Success(t *testing.T) {
+	var gotAuth string
+	var gotBody string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v3/mail/send" {
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+		gotAuth = r.Header.Get("Authorization")
+		b, _ := io.ReadAll(r.Body)
+		gotBody = string(b)
+		w.WriteHeader(http.StatusAccepted)
+	}))
+	defer srv.Close()
+
+	adapter := NewSendGridAdapter("sg-key", "noreply@example.com")
+	adapter.BaseURL = srv.URL
+	if err := adapter.Send(context.Background(), DeliveryRequest{
+		To:      "user@example.com",
+		Subject: "Hello",
+		Body:    "Test body",
+	}); err != nil {
+		t.Fatalf("expected success, got %v", err)
+	}
+
+	if gotAuth != "Bearer sg-key" {
+		t.Fatalf("unexpected auth header: %q", gotAuth)
+	}
+	if !strings.Contains(gotBody, `"user@example.com"`) || !strings.Contains(gotBody, `"Test body"`) {
+		t.Fatalf("unexpected request body: %s", gotBody)
+	}
+}
+
+func TestSendGridAdapter_Send_ErrorResponse(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "bad request", http.StatusBadRequest)
+	}))
+	defer srv.Close()
+
+	adapter := NewSendGridAdapter("sg-key", "noreply@example.com")
+	adapter.BaseURL = srv.URL
+	err := adapter.Send(context.Background(), DeliveryRequest{
+		To:      "user@example.com",
+		Subject: "Hello",
+		Body:    "Test body",
+	})
+	if err == nil || !strings.Contains(err.Error(), "status 400") {
+		t.Fatalf("expected status error, got %v", err)
+	}
+}
+
+func TestTwilioAdapter_Send_Success(t *testing.T) {
+	var gotAuth string
+	var gotBody string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !strings.HasSuffix(r.URL.Path, "/Messages.json") {
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+		gotAuth = r.Header.Get("Authorization")
+		b, _ := io.ReadAll(r.Body)
+		gotBody = string(b)
+		w.WriteHeader(http.StatusCreated)
+	}))
+	defer srv.Close()
+
+	adapter := NewTwilioAdapter("AC123", "tok123", "+15551112222")
+	adapter.BaseURL = srv.URL
+	if err := adapter.Send(context.Background(), DeliveryRequest{
+		To:   "+15550001111",
+		Body: "Reminder",
+	}); err != nil {
+		t.Fatalf("expected success, got %v", err)
+	}
+
+	wantAuth := "Basic " + base64.StdEncoding.EncodeToString([]byte("AC123:tok123"))
+	if gotAuth != wantAuth {
+		t.Fatalf("unexpected auth header: got %q want %q", gotAuth, wantAuth)
+	}
+	if !strings.Contains(gotBody, "To=%2B15550001111") || !strings.Contains(gotBody, "Body=Reminder") {
+		t.Fatalf("unexpected twilio body: %s", gotBody)
+	}
+}
+
+func TestTwilioAdapter_Send_ErrorResponse(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "unauthorized", http.StatusUnauthorized)
+	}))
+	defer srv.Close()
+
+	adapter := NewTwilioAdapter("AC123", "tok123", "+15551112222")
+	adapter.BaseURL = srv.URL
+	err := adapter.Send(context.Background(), DeliveryRequest{
+		To:   "+15550001111",
+		Body: "Reminder",
+	})
+	if err == nil || !strings.Contains(err.Error(), "status 401") {
+		t.Fatalf("expected status error, got %v", err)
+	}
+}
+
+func TestAdapters_ValidateRequiredFields(t *testing.T) {
+	sg := NewSendGridAdapter("", "")
+	if err := sg.Send(context.Background(), DeliveryRequest{To: "x", Body: "y"}); err == nil {
+		t.Fatal("expected sendgrid validation error")
+	}
+
+	tw := NewTwilioAdapter("", "", "")
+	if err := tw.Send(context.Background(), DeliveryRequest{To: "x", Body: "y"}); err == nil {
+		t.Fatal("expected twilio validation error")
+	}
+}
+


### PR DESCRIPTION
## Summary
- add provider adapter package for notification delivery integrations
- implement SendGrid email adapter with API-key auth and payload mapping
- implement Twilio SMS adapter with basic auth and form body mapping
- add unit tests for success/error paths and required field validation

## Test plan
- [x] Run go test ./... in ackend
- [x] Run go build ./... in ackend
- [x] Run 
pm run test:ci in rontend (combined regression)
- [x] Run 
pm run build in rontend (combined regression)
- [x] Run 
pm run cypress:e2e in rontend (full E2E regression)

Made with [Cursor](https://cursor.com)