### PR TITLE
S4 PR10: add retries/failures admin monitoring APIs

### DIFF
--- a/backend/handlers/notifications.go
+++ b/backend/handlers/notifications.go
@@ -7,7 +7,9 @@ import (
 	"strings"
 
 	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
 	"github.com/healthonyx/backend/db"
+	"github.com/jackc/pgx/v5"
 )
 
 type NotificationsHandler struct{}
@@ -146,6 +148,109 @@ func (h *NotificationsHandler) ListMine(c *gin.Context) {
 		out = []row{}
 	}
 	c.JSON(http.StatusOK, gin.H{"notifications": out})
+}
+
+// AdminList GET /api/admin/notifications
+func (h *NotificationsHandler) AdminList(c *gin.Context) {
+	if _, ok := getClaims(c); !ok {
+		return
+	}
+	rows, err := db.Pool.Query(c.Request.Context(), `
+		SELECT id::text, user_id::text, title, body, channel, status, scheduled_for::text, created_at::text
+		FROM notifications
+		ORDER BY created_at DESC
+		LIMIT 300
+	`)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Internal error"})
+		return
+	}
+	defer rows.Close()
+
+	type row struct {
+		ID           string  `json:"id"`
+		UserID       string  `json:"user_id"`
+		Title        string  `json:"title"`
+		Body         string  `json:"body"`
+		Channel      string  `json:"channel"`
+		Status       string  `json:"status"`
+		ScheduledFor *string `json:"scheduled_for"`
+		CreatedAt    string  `json:"created_at"`
+	}
+	var out []row
+	for rows.Next() {
+		var r row
+		var sched sql.NullString
+		if err := rows.Scan(&r.ID, &r.UserID, &r.Title, &r.Body, &r.Channel, &r.Status, &sched, &r.CreatedAt); err != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "Internal error"})
+			return
+		}
+		if sched.Valid {
+			s := sched.String
+			r.ScheduledFor = &s
+		}
+		out = append(out, r)
+	}
+	if out == nil {
+		out = []row{}
+	}
+	c.JSON(http.StatusOK, gin.H{"notifications": out})
+}
+
+// AdminSummary GET /api/admin/notifications/summary
+func (h *NotificationsHandler) AdminSummary(c *gin.Context) {
+	if _, ok := getClaims(c); !ok {
+		return
+	}
+	var pending, sent, failed int64
+	err := db.Pool.QueryRow(c.Request.Context(), `
+		SELECT
+			COUNT(*) FILTER (WHERE status = 'pending'),
+			COUNT(*) FILTER (WHERE status = 'sent'),
+			COUNT(*) FILTER (WHERE status = 'failed')
+		FROM notifications
+	`).Scan(&pending, &sent, &failed)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Internal error"})
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{
+		"pending_count": pending,
+		"sent_count":    sent,
+		"failed_count":  failed,
+	})
+}
+
+// RetryFailed POST /api/admin/notifications/:id/retry
+func (h *NotificationsHandler) RetryFailed(c *gin.Context) {
+	if _, ok := getClaims(c); !ok {
+		return
+	}
+	id, err := uuid.Parse(strings.TrimSpace(c.Param("id")))
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid notification id"})
+		return
+	}
+	var prevStatus string
+	err = db.Pool.QueryRow(c.Request.Context(), `
+		UPDATE notifications
+		SET status = 'pending', scheduled_for = NOW()
+		WHERE id = $1
+		  AND status = 'failed'
+		RETURNING status
+	`, id).Scan(&prevStatus)
+	if err != nil {
+		if err == pgx.ErrNoRows {
+			c.JSON(http.StatusNotFound, gin.H{"error": "Failed notification not found"})
+			return
+		}
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Internal error"})
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{
+		"id":     id.String(),
+		"status": "pending",
+	})
 }
 
 // ListPreferences GET /api/notifications/preferences

--- a/backend/handlers/notifications_test.go
+++ b/backend/handlers/notifications_test.go
@@ -72,3 +72,62 @@ func TestNormalizeNotificationPreference_ValidAndInvalid(t *testing.T) {
 		t.Fatal("expected invalid category error")
 	}
 }
+
+func TestNotifications_AdminList_Unauthorized(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest("GET", "/api/admin/notifications", nil)
+
+	h := NewNotificationsHandler()
+	h.AdminList(c)
+
+	if w.Code != http.StatusUnauthorized {
+		t.Fatalf("expected 401, got %d", w.Code)
+	}
+}
+
+func TestNotifications_AdminSummary_Unauthorized(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest("GET", "/api/admin/notifications/summary", nil)
+
+	h := NewNotificationsHandler()
+	h.AdminSummary(c)
+
+	if w.Code != http.StatusUnauthorized {
+		t.Fatalf("expected 401, got %d", w.Code)
+	}
+}
+
+func TestNotifications_RetryFailed_Unauthorized(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Params = gin.Params{{Key: "id", Value: "d2517c5c-c9aa-40d2-b5ce-60d5bcb3f978"}}
+	c.Request = httptest.NewRequest("POST", "/api/admin/notifications/d2517c5c-c9aa-40d2-b5ce-60d5bcb3f978/retry", nil)
+
+	h := NewNotificationsHandler()
+	h.RetryFailed(c)
+
+	if w.Code != http.StatusUnauthorized {
+		t.Fatalf("expected 401, got %d", w.Code)
+	}
+}
+
+func TestNotifications_RetryFailed_InvalidID(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Set("claims", &Claims{})
+	c.Params = gin.Params{{Key: "id", Value: "not-a-uuid"}}
+	c.Request = httptest.NewRequest("POST", "/api/admin/notifications/not-a-uuid/retry", strings.NewReader(""))
+
+	h := NewNotificationsHandler()
+	h.RetryFailed(c)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d", w.Code)
+	}
+}

--- a/backend/main.go
+++ b/backend/main.go
@@ -73,6 +73,8 @@ func main() {
 		// Protected: requires valid JWT
 		api.GET("/me", auth.RequireAuth(), auth.Me)
 		api.GET("/notifications", auth.RequireAuth(), notifications.ListMine)
+		api.GET("/notifications/preferences", auth.RequireAuth(), notifications.ListPreferences)
+		api.PUT("/notifications/preferences", auth.RequireAuth(), notifications.UpsertPreferences)
 		api.GET("/bootstrap", auth.RequireAuth(), bootstrap.Get)
 		api.GET("/patient/dashboard/summary", auth.RequireAuth(), auth.RequireRole("patient"), dashboard.PatientSummary)
 		api.GET("/doctor/dashboard/summary", auth.RequireAuth(), auth.RequireRole("doctor"), dashboard.DoctorSummary)
@@ -87,6 +89,9 @@ func main() {
 			c.JSON(http.StatusOK, gin.H{"message": "Admin only"})
 		})
 		api.GET("/admin/audit-log", auth.RequireAuth(), auth.RequireRole("admin"), adminAudit.List)
+		api.GET("/admin/notifications", auth.RequireAuth(), auth.RequireRole("admin"), notifications.AdminList)
+		api.GET("/admin/notifications/summary", auth.RequireAuth(), auth.RequireRole("admin"), notifications.AdminSummary)
+		api.POST("/admin/notifications/:id/retry", auth.RequireAuth(), auth.RequireRole("admin"), notifications.RetryFailed)
 		api.GET("/admin/knowledge-docs", auth.RequireAuth(), auth.RequireRole("admin"), knowledge.List)
 		api.POST("/admin/knowledge-docs", auth.RequireAuth(), auth.RequireRole("admin"), knowledge.Create)
 		api.GET("/admin/knowledge-docs/:id", auth.RequireAuth(), auth.RequireRole("admin"), knowledge.Get)


### PR DESCRIPTION
## Summary
- add admin notifications monitoring endpoints: list and summary
- add failed-notification retry endpoint to requeue failed rows
- wire missing notification preferences routes in backend API
- extend notification handler tests for admin auth and invalid retry id behavior

## Test plan
- [x] Run go test ./... in ackend
- [x] Run go build ./... in ackend
- [x] Run 
pm run test:ci in rontend (combined regression)
- [x] Run 
pm run build in rontend (combined regression)
- [x] Run 
pm run cypress:e2e in rontend (full E2E regression)

Made with [Cursor](https://cursor.com)