### PR TITLE
S4 PR11: add prescription update and audit API

### DIFF
--- a/backend/handlers/prescriptions.go
+++ b/backend/handlers/prescriptions.go
@@ -1,12 +1,14 @@
 package handlers
 
 import (
+	"fmt"
 	"net/http"
 	"strings"
 
 	"github.com/gin-gonic/gin"
 	"github.com/google/uuid"
 	"github.com/healthonyx/backend/db"
+	"github.com/jackc/pgx/v5"
 )
 
 type PrescriptionsHandler struct{}
@@ -93,6 +95,14 @@ type createPrescriptionBody struct {
 	Instructions   string `json:"instructions"`
 }
 
+type updatePrescriptionBody struct {
+	MedicationName *string `json:"medication_name"`
+	Dosage         *string `json:"dosage"`
+	Frequency      *string `json:"frequency"`
+	DurationDays   *int    `json:"duration_days"`
+	Instructions   *string `json:"instructions"`
+}
+
 func (h *PrescriptionsHandler) Create(c *gin.Context) {
 	claims, ok := getClaims(c)
 	if !ok {
@@ -129,6 +139,133 @@ func (h *PrescriptionsHandler) Create(c *gin.Context) {
 		return
 	}
 	c.JSON(http.StatusCreated, gin.H{"id": id})
+}
+
+func (h *PrescriptionsHandler) Update(c *gin.Context) {
+	claims, ok := getClaims(c)
+	if !ok {
+		return
+	}
+	if claims.Role != "doctor" && claims.Role != "admin" {
+		c.JSON(http.StatusForbidden, gin.H{"error": "Forbidden"})
+		return
+	}
+	id, err := uuid.Parse(strings.TrimSpace(c.Param("id")))
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid id"})
+		return
+	}
+
+	var body updatePrescriptionBody
+	if err := c.ShouldBindJSON(&body); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid request body"})
+		return
+	}
+	if body.MedicationName == nil && body.Dosage == nil && body.Frequency == nil &&
+		body.DurationDays == nil && body.Instructions == nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "At least one field must be provided"})
+		return
+	}
+
+	tx, err := db.Pool.Begin(c.Request.Context())
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Internal error"})
+		return
+	}
+	defer func() { _ = tx.Rollback(c.Request.Context()) }()
+
+	var doctorID, patientID uuid.UUID
+	var medication, dosage, frequency, instructions, status string
+	var duration int
+	err = tx.QueryRow(c.Request.Context(), `
+		SELECT doctor_id, patient_id, medication_name, dosage, frequency, duration_days, instructions, status
+		FROM prescriptions
+		WHERE id = $1
+	`, id).Scan(&doctorID, &patientID, &medication, &dosage, &frequency, &duration, &instructions, &status)
+	if err != nil {
+		if err == pgx.ErrNoRows {
+			c.JSON(http.StatusNotFound, gin.H{"error": "Not found"})
+			return
+		}
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Internal error"})
+		return
+	}
+	if claims.Role == "doctor" && doctorID != claims.UserID {
+		c.JSON(http.StatusForbidden, gin.H{"error": "Forbidden"})
+		return
+	}
+	if status != "active" {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "Only active prescriptions can be updated"})
+		return
+	}
+
+	newMedication := strings.TrimSpace(medication)
+	newDosage := strings.TrimSpace(dosage)
+	newFrequency := strings.TrimSpace(frequency)
+	newInstructions := strings.TrimSpace(instructions)
+	newDuration := duration
+
+	if body.MedicationName != nil {
+		newMedication = strings.TrimSpace(*body.MedicationName)
+	}
+	if body.Dosage != nil {
+		newDosage = strings.TrimSpace(*body.Dosage)
+	}
+	if body.Frequency != nil {
+		newFrequency = strings.TrimSpace(*body.Frequency)
+	}
+	if body.DurationDays != nil {
+		newDuration = *body.DurationDays
+	}
+	if body.Instructions != nil {
+		newInstructions = strings.TrimSpace(*body.Instructions)
+	}
+
+	if newMedication == "" || newDosage == "" || newFrequency == "" {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "medication_name, dosage, and frequency must be non-empty"})
+		return
+	}
+	if newDuration < 0 {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "duration_days must be >= 0"})
+		return
+	}
+
+	_, err = tx.Exec(c.Request.Context(), `
+		UPDATE prescriptions
+		SET medication_name = $2,
+			dosage = $3,
+			frequency = $4,
+			duration_days = $5,
+			instructions = $6
+		WHERE id = $1
+	`, id, newMedication, newDosage, newFrequency, newDuration, newInstructions)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Internal error"})
+		return
+	}
+
+	detail := fmt.Sprintf("Prescription updated: med=%s dosage=%s frequency=%s duration_days=%d",
+		newMedication, newDosage, newFrequency, newDuration)
+	if err := writeAudit(c.Request.Context(), tx, claims.UserID, "prescription_updated", "prescription", id.String(), detail); err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Internal error"})
+		return
+	}
+
+	if err := tx.Commit(c.Request.Context()); err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Internal error"})
+		return
+	}
+
+	c.JSON(http.StatusOK, gin.H{
+		"id":              id,
+		"patient_id":      patientID,
+		"medication_name": newMedication,
+		"dosage":          newDosage,
+		"frequency":       newFrequency,
+		"duration_days":   newDuration,
+		"instructions":    newInstructions,
+		"status":          "active",
+	})
 }
 
 func (h *PrescriptionsHandler) Revoke(c *gin.Context) {

--- a/backend/handlers/prescriptions_test.go
+++ b/backend/handlers/prescriptions_test.go
@@ -3,6 +3,7 @@ package handlers
 import (
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/gin-gonic/gin"
@@ -21,5 +22,57 @@ func TestPrescriptions_List_Unauthorized(t *testing.T) {
 
 	if w.Code != http.StatusUnauthorized {
 		t.Fatalf("expected 401, got %d", w.Code)
+	}
+}
+
+func TestPrescriptions_Update_Unauthorized(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest("PUT", "/api/prescriptions/"+uuid.New().String(), strings.NewReader(`{}`))
+	c.Request.Header.Set("Content-Type", "application/json")
+	c.Params = gin.Params{{Key: "id", Value: uuid.New().String()}}
+
+	h := NewPrescriptionsHandler()
+	h.Update(c)
+
+	if w.Code != http.StatusUnauthorized {
+		t.Fatalf("expected 401, got %d", w.Code)
+	}
+}
+
+func TestPrescriptions_Update_InvalidID(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Set("claims", &Claims{Role: "doctor"})
+	c.Request = httptest.NewRequest("PUT", "/api/prescriptions/not-a-uuid", strings.NewReader(`{}`))
+	c.Request.Header.Set("Content-Type", "application/json")
+	c.Params = gin.Params{{Key: "id", Value: "not-a-uuid"}}
+
+	h := NewPrescriptionsHandler()
+	h.Update(c)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d", w.Code)
+	}
+}
+
+func TestPrescriptions_Update_RequiresAtLeastOneField(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Set("claims", &Claims{Role: "doctor", UserID: uuid.New()})
+	c.Request = httptest.NewRequest("PUT", "/api/prescriptions/"+uuid.New().String(), strings.NewReader(`{}`))
+	c.Request.Header.Set("Content-Type", "application/json")
+	c.Params = gin.Params{{Key: "id", Value: uuid.New().String()}}
+
+	h := NewPrescriptionsHandler()
+	h.Update(c)
+
+	// If DB not available, endpoint may return 500 after auth checks; we only
+	// enforce that it does not return success for empty payload.
+	if w.Code == http.StatusOK {
+		t.Fatalf("expected non-200 for empty update payload, got %d", w.Code)
 	}
 }

--- a/backend/main.go
+++ b/backend/main.go
@@ -131,6 +131,7 @@ func main() {
 
 		api.GET("/patients/:patientId/prescriptions", auth.RequireAuth(), prescriptions.ListByPatient)
 		api.POST("/patients/:patientId/prescriptions", auth.RequireAuth(), auth.RequireRole("doctor"), prescriptions.Create)
+		api.PUT("/prescriptions/:id", auth.RequireAuth(), auth.RequireRole("doctor", "admin"), prescriptions.Update)
 		api.PATCH("/prescriptions/:id/revoke", auth.RequireAuth(), auth.RequireRole("doctor", "admin"), prescriptions.Revoke)
 
 		msg := api.Group("/messages", auth.RequireAuth(), auth.RequireRole("patient", "doctor"))


### PR DESCRIPTION
## Summary
- add PUT /api/prescriptions/:id for doctor/admin prescription updates
- enforce role ownership checks and active-only update behavior
- write audit log entry in the same transaction as prescription update
- add handler tests for unauthorized, invalid id, and empty update payload paths

## Test plan
- [x] Run go test ./... in ackend
- [x] Run go build ./... in ackend
- [x] Run 
pm run test:ci in rontend (combined regression)
- [x] Run 
pm run build in rontend (combined regression)
- [x] Run 
pm run cypress:e2e in rontend (full E2E regression)

Made with [Cursor](https://cursor.com)