### PR TITLE
S4 PR12: add prescription reminder scheduling

### DIFF
--- a/backend/handlers/prescriptions.go
+++ b/backend/handlers/prescriptions.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"net/http"
 	"strings"
+	"time"
 
 	"github.com/gin-gonic/gin"
 	"github.com/google/uuid"
@@ -103,6 +104,54 @@ type updatePrescriptionBody struct {
 	Instructions   *string `json:"instructions"`
 }
 
+func reminderTimesForFrequency(frequency string) []string {
+	f := strings.ToLower(strings.TrimSpace(frequency))
+	switch {
+	case strings.Contains(f, "3"), strings.Contains(f, "thrice"), strings.Contains(f, "three"):
+		return []string{"08:00", "14:00", "20:00"}
+	case strings.Contains(f, "2"), strings.Contains(f, "twice"), strings.Contains(f, "two"):
+		return []string{"08:00", "20:00"}
+	default:
+		return []string{"08:00"}
+	}
+}
+
+func buildReminderSchedule(start time.Time, durationDays int, times []string) []time.Time {
+	if durationDays <= 0 {
+		durationDays = 1
+	}
+	if len(times) == 0 {
+		times = []string{"08:00"}
+	}
+	base := time.Date(start.Year(), start.Month(), start.Day(), 0, 0, 0, 0, time.UTC)
+	out := make([]time.Time, 0, durationDays*len(times))
+	for day := 0; day < durationDays; day++ {
+		for _, hhmm := range times {
+			h, m := 8, 0
+			_, _ = fmt.Sscanf(hhmm, "%d:%d", &h, &m)
+			out = append(out, base.AddDate(0, 0, day).Add(time.Duration(h)*time.Hour).Add(time.Duration(m)*time.Minute))
+		}
+	}
+	return out
+}
+
+func schedulePrescriptionReminders(ctx *gin.Context, patientID uuid.UUID, medication, dosage, frequency string, durationDays int) error {
+	times := reminderTimesForFrequency(frequency)
+	schedule := buildReminderSchedule(time.Now().UTC(), durationDays, times)
+	title := fmt.Sprintf("Medication reminder: %s", medication)
+	body := fmt.Sprintf("Take %s %s as prescribed (%s).", dosage, medication, frequency)
+	for _, at := range schedule {
+		_, err := db.Pool.Exec(ctx.Request.Context(), `
+			INSERT INTO notifications (user_id, title, body, channel, status, scheduled_for)
+			VALUES ($1, $2, $3, 'in_app', 'pending', $4)
+		`, patientID, title, body, at)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 func (h *PrescriptionsHandler) Create(c *gin.Context) {
 	claims, ok := getClaims(c)
 	if !ok {
@@ -138,6 +187,7 @@ func (h *PrescriptionsHandler) Create(c *gin.Context) {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "Internal error"})
 		return
 	}
+	_ = schedulePrescriptionReminders(c, pid, strings.TrimSpace(body.MedicationName), strings.TrimSpace(body.Dosage), strings.TrimSpace(body.Frequency), body.DurationDays)
 	c.JSON(http.StatusCreated, gin.H{"id": id})
 }
 
@@ -255,6 +305,11 @@ func (h *PrescriptionsHandler) Update(c *gin.Context) {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "Internal error"})
 		return
 	}
+	_, _ = db.Pool.Exec(c.Request.Context(), `
+		INSERT INTO notifications (user_id, title, body, channel, status, scheduled_for)
+		VALUES ($1, $2, $3, 'in_app', 'pending', NOW())
+	`, patientID, "Prescription updated", fmt.Sprintf("Your prescription for %s has been updated.", newMedication))
+	_ = schedulePrescriptionReminders(c, patientID, newMedication, newDosage, newFrequency, newDuration)
 
 	c.JSON(http.StatusOK, gin.H{
 		"id":              id,
@@ -299,5 +354,9 @@ func (h *PrescriptionsHandler) Revoke(c *gin.Context) {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "Internal error"})
 		return
 	}
+	_, _ = db.Pool.Exec(c.Request.Context(), `
+		INSERT INTO notifications (user_id, title, body, channel, status, scheduled_for)
+		VALUES ($1, $2, $3, 'in_app', 'pending', NOW())
+	`, patientID, "Prescription revoked", "One of your prescriptions has been revoked by your care team.")
 	c.JSON(http.StatusOK, gin.H{"id": id, "patient_id": patientID, "status": "revoked"})
 }

--- a/backend/handlers/prescriptions_test.go
+++ b/backend/handlers/prescriptions_test.go
@@ -3,8 +3,10 @@ package handlers
 import (
 	"net/http"
 	"net/http/httptest"
+	"slices"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/gin-gonic/gin"
 	"github.com/google/uuid"
@@ -74,5 +76,31 @@ func TestPrescriptions_Update_RequiresAtLeastOneField(t *testing.T) {
 	// enforce that it does not return success for empty payload.
 	if w.Code == http.StatusOK {
 		t.Fatalf("expected non-200 for empty update payload, got %d", w.Code)
+	}
+}
+
+func TestReminderTimesForFrequency(t *testing.T) {
+	if got := reminderTimesForFrequency("twice daily"); !slices.Equal(got, []string{"08:00", "20:00"}) {
+		t.Fatalf("unexpected twice-daily times: %v", got)
+	}
+	if got := reminderTimesForFrequency("3x"); !slices.Equal(got, []string{"08:00", "14:00", "20:00"}) {
+		t.Fatalf("unexpected thrice-daily times: %v", got)
+	}
+	if got := reminderTimesForFrequency("once daily"); !slices.Equal(got, []string{"08:00"}) {
+		t.Fatalf("unexpected default times: %v", got)
+	}
+}
+
+func TestBuildReminderSchedule(t *testing.T) {
+	start := time.Date(2026, 4, 27, 17, 30, 0, 0, time.UTC)
+	got := buildReminderSchedule(start, 2, []string{"08:00", "20:00"})
+	if len(got) != 4 {
+		t.Fatalf("expected 4 reminder times, got %d", len(got))
+	}
+	if got[0].Hour() != 8 || got[0].Minute() != 0 {
+		t.Fatalf("unexpected first reminder time: %v", got[0])
+	}
+	if got[2].Day() != 28 {
+		t.Fatalf("expected day rollover to 28, got %v", got[2])
 	}
 }


### PR DESCRIPTION
## Summary
- add reminder scheduling helpers based on prescription frequency/duration
- enqueue pending medication reminder notifications on prescription create and update
- enqueue immediate patient notifications for prescription update/revoke events
- add unit tests for frequency-to-time mapping and schedule generation

## Test plan
- [x] Run go test ./... in ackend
- [x] Run go build ./... in ackend
- [x] Run 
pm run test:ci in rontend (combined regression)
- [x] Run 
pm run build in rontend (combined regression)
- [x] Run 
pm run cypress:e2e in rontend (full E2E regression)

Made with [Cursor](https://cursor.com)