### PR TITLE
S4 PR13: add prescriptions v2 status/history UI

### DIFF
--- a/frontend/src/app/components/patient-prescriptions/patient-prescriptions.component.spec.ts
+++ b/frontend/src/app/components/patient-prescriptions/patient-prescriptions.component.spec.ts
@@ -35,4 +35,44 @@ describe('PatientPrescriptionsComponent', () => {
       (fixture.nativeElement as HTMLElement).querySelector('[data-cy="patient-prescriptions-empty"]')
     ).toBeTruthy();
   });
+
+  it('renders active and history sections', () => {
+    fixture = TestBed.createComponent(PatientPrescriptionsComponent);
+    httpMock = TestBed.inject(HttpTestingController);
+    fixture.detectChanges();
+    httpMock.expectOne('/api/patients/p1/prescriptions').flush({
+      prescriptions: [
+        {
+          id: 'rx1',
+          patient_id: 'p1',
+          doctor_id: 'd1',
+          medication_name: 'Atenolol',
+          dosage: '25mg',
+          frequency: 'daily',
+          duration_days: 30,
+          instructions: 'after food',
+          status: 'active',
+          created_at: '2026-04-20T10:00:00Z'
+        },
+        {
+          id: 'rx2',
+          patient_id: 'p1',
+          doctor_id: 'd1',
+          medication_name: 'Statin',
+          dosage: '10mg',
+          frequency: 'nightly',
+          duration_days: 14,
+          instructions: '',
+          status: 'revoked',
+          created_at: '2026-03-20T10:00:00Z'
+        }
+      ]
+    });
+    fixture.detectChanges();
+
+    const el = fixture.nativeElement as HTMLElement;
+    expect(el.querySelectorAll('[data-cy="patient-prescriptions-row"]').length).toBe(1);
+    expect(el.querySelectorAll('[data-cy="patient-prescriptions-history-row"]').length).toBe(1);
+    expect(el.querySelector('[data-cy="patient-prescriptions-summary"]')).toBeTruthy();
+  });
 });

--- a/frontend/src/app/components/patient-prescriptions/patient-prescriptions.component.ts
+++ b/frontend/src/app/components/patient-prescriptions/patient-prescriptions.component.ts
@@ -11,12 +11,48 @@ import { AuthService } from '../../services/auth.service';
     <section data-cy="patient-prescriptions-page">
       <h1>My prescriptions</h1>
       <p class="err" *ngIf="error">{{ error }}</p>
-      <ul *ngIf="rows.length" data-cy="patient-prescriptions-list">
-        <li *ngFor="let r of rows" data-cy="patient-prescriptions-row">
-          <strong>{{ r.medication_name }}</strong> — {{ r.dosage }}, {{ r.frequency }}
-          <span class="st">{{ r.status }}</span>
+
+      <div class="summary" *ngIf="rows.length" data-cy="patient-prescriptions-summary">
+        <div class="card">
+          <span class="k">Active</span>
+          <strong>{{ activeRows.length }}</strong>
+        </div>
+        <div class="card">
+          <span class="k">History</span>
+          <strong>{{ pastRows.length }}</strong>
+        </div>
+        <div class="card">
+          <span class="k">Total</span>
+          <strong>{{ rows.length }}</strong>
+        </div>
+      </div>
+
+      <h2 *ngIf="activeRows.length">Active prescriptions</h2>
+      <ul *ngIf="activeRows.length" data-cy="patient-prescriptions-list">
+        <li *ngFor="let r of activeRows" data-cy="patient-prescriptions-row">
+          <div class="head">
+            <strong>{{ r.medication_name }}</strong>
+            <span class="st st-active">{{ formatStatus(r.status) }}</span>
+          </div>
+          <div class="meta">{{ r.dosage }} · {{ r.frequency }} · {{ r.duration_days }} days</div>
+          <div class="ins" *ngIf="r.instructions">{{ r.instructions }}</div>
+          <small>Prescribed {{ r.created_at }}</small>
         </li>
       </ul>
+
+      <h2 *ngIf="pastRows.length" class="mt">Prescription history</h2>
+      <ul *ngIf="pastRows.length" data-cy="patient-prescriptions-history-list">
+        <li *ngFor="let r of pastRows" data-cy="patient-prescriptions-history-row">
+          <div class="head">
+            <strong>{{ r.medication_name }}</strong>
+            <span class="st st-past">{{ formatStatus(r.status) }}</span>
+          </div>
+          <div class="meta">{{ r.dosage }} · {{ r.frequency }} · {{ r.duration_days }} days</div>
+          <div class="ins" *ngIf="r.instructions">{{ r.instructions }}</div>
+          <small>Prescribed {{ r.created_at }}</small>
+        </li>
+      </ul>
+
       <p *ngIf="!error && !rows.length" data-cy="patient-prescriptions-empty">No prescriptions yet.</p>
     </section>
   `,
@@ -25,16 +61,72 @@ import { AuthService } from '../../services/auth.service';
       .err {
         color: #b00020;
       }
+      .summary {
+        display: grid;
+        grid-template-columns: repeat(3, minmax(100px, 1fr));
+        gap: 0.75rem;
+        margin: 0.75rem 0 1rem;
+      }
+      .card {
+        border: 1px solid rgba(148, 163, 184, 0.35);
+        border-radius: 0.5rem;
+        padding: 0.65rem 0.75rem;
+      }
+      .k {
+        display: block;
+        color: #64748b;
+        font-size: 0.8rem;
+      }
+      ul {
+        list-style: none;
+        padding: 0;
+        margin: 0;
+        display: grid;
+        gap: 0.6rem;
+      }
+      li {
+        border: 1px solid rgba(148, 163, 184, 0.25);
+        border-radius: 0.5rem;
+        padding: 0.65rem 0.75rem;
+      }
+      .head {
+        display: flex;
+        justify-content: space-between;
+        gap: 0.75rem;
+        align-items: center;
+      }
+      .meta {
+        color: #64748b;
+        margin-top: 0.2rem;
+      }
+      .ins {
+        margin-top: 0.25rem;
+      }
       .st {
-        margin-left: 0.5rem;
         text-transform: uppercase;
-        font-size: 0.75rem;
+        letter-spacing: 0.02em;
+        font-size: 0.72rem;
+        border-radius: 9999px;
+        padding: 0.1rem 0.5rem;
+      }
+      .st-active {
+        background: rgba(34, 197, 94, 0.15);
+        color: #16a34a;
+      }
+      .st-past {
+        background: rgba(148, 163, 184, 0.18);
+        color: #475569;
+      }
+      .mt {
+        margin-top: 1rem;
       }
     `
   ]
 })
 export class PatientPrescriptionsComponent implements OnInit {
   rows: PrescriptionRow[] = [];
+  activeRows: PrescriptionRow[] = [];
+  pastRows: PrescriptionRow[] = [];
   error: string | null = null;
 
   constructor(
@@ -49,8 +141,18 @@ export class PatientPrescriptionsComponent implements OnInit {
       return;
     }
     this.rx.listByPatient(u.id).subscribe({
-      next: (res) => (this.rows = res.prescriptions ?? []),
+      next: (res) => {
+        this.rows = [...(res.prescriptions ?? [])].sort(
+          (a, b) => new Date(b.created_at).getTime() - new Date(a.created_at).getTime()
+        );
+        this.activeRows = this.rows.filter((r) => r.status === 'active');
+        this.pastRows = this.rows.filter((r) => r.status !== 'active');
+      },
       error: () => (this.error = 'Could not load prescriptions')
     });
+  }
+
+  formatStatus(status: string): string {
+    return (status || 'unknown').replace(/_/g, ' ');
   }
 }


### PR DESCRIPTION
## Summary
- upgrade patient prescriptions UI with v2 status and history sections
- add active/history grouping and summary cards for prescription counts
- render richer prescription metadata (frequency, duration, instructions, created time)
- add test coverage for status/history rendering behavior

## Test plan
- [x] Run 
pm run test:ci in rontend
- [x] Run 
pm run build in rontend
- [x] Run go test ./... in ackend (combined regression)
- [x] Run 
pm run cypress:e2e in rontend (full E2E regression)

Made with [Cursor](https://cursor.com)