### PR TITLE
PR-15: prescription PDF UI flow

### DIFF
--- a/frontend/src/app/components/patient-prescriptions/patient-prescriptions.component.spec.ts
+++ b/frontend/src/app/components/patient-prescriptions/patient-prescriptions.component.spec.ts
@@ -109,4 +109,79 @@ describe('PatientPrescriptionsComponent', () => {
     const statusAfter = (fixture.nativeElement as HTMLElement).querySelector('.rem-status')?.textContent ?? '';
     expect(statusAfter).toContain('Off');
   });
+
+  it('downloads prescription pdf from active row action', () => {
+    fixture = TestBed.createComponent(PatientPrescriptionsComponent);
+    httpMock = TestBed.inject(HttpTestingController);
+    fixture.detectChanges();
+    httpMock.expectOne('/api/patients/p1/prescriptions').flush({
+      prescriptions: [
+        {
+          id: 'rx1',
+          patient_id: 'p1',
+          doctor_id: 'd1',
+          medication_name: 'Atenolol',
+          dosage: '25mg',
+          frequency: 'daily',
+          duration_days: 30,
+          instructions: 'after food',
+          status: 'active',
+          created_at: '2026-04-20T10:00:00Z'
+        }
+      ]
+    });
+    fixture.detectChanges();
+
+    spyOn(window.URL, 'createObjectURL').and.returnValue('blob:test');
+    const revokeSpy = spyOn(window.URL, 'revokeObjectURL');
+
+    const el = fixture.nativeElement as HTMLElement;
+    const btn = el.querySelector('[data-cy="patient-prescriptions-download-pdf"]') as HTMLButtonElement;
+    btn.click();
+
+    const req = httpMock.expectOne('/api/prescriptions/rx1/pdf');
+    expect(req.request.method).toBe('GET');
+    expect(req.request.responseType).toBe('blob');
+    req.flush(new Blob(['pdf-bytes'], { type: 'application/pdf' }));
+    fixture.detectChanges();
+
+    expect(window.URL.createObjectURL).toHaveBeenCalled();
+    expect(revokeSpy).toHaveBeenCalledWith('blob:test');
+  });
+
+  it('shows an error when pdf download fails', () => {
+    fixture = TestBed.createComponent(PatientPrescriptionsComponent);
+    httpMock = TestBed.inject(HttpTestingController);
+    fixture.detectChanges();
+    httpMock.expectOne('/api/patients/p1/prescriptions').flush({
+      prescriptions: [
+        {
+          id: 'rx1',
+          patient_id: 'p1',
+          doctor_id: 'd1',
+          medication_name: 'Atenolol',
+          dosage: '25mg',
+          frequency: 'daily',
+          duration_days: 30,
+          instructions: 'after food',
+          status: 'active',
+          created_at: '2026-04-20T10:00:00Z'
+        }
+      ]
+    });
+    fixture.detectChanges();
+
+    const el = fixture.nativeElement as HTMLElement;
+    const btn = el.querySelector('[data-cy="patient-prescriptions-download-pdf"]') as HTMLButtonElement;
+    btn.click();
+
+    const req = httpMock.expectOne('/api/prescriptions/rx1/pdf');
+    req.error(new ProgressEvent('error'), { status: 500, statusText: 'Server error' });
+    fixture.detectChanges();
+
+    expect(
+      (fixture.nativeElement as HTMLElement).querySelector('[data-cy="patient-prescriptions-pdf-error"]')
+        ?.textContent
+    ).toContain('Could not download prescription PDF');
+  });
 });

--- a/frontend/src/app/components/patient-prescriptions/patient-prescriptions.component.ts
+++ b/frontend/src/app/components/patient-prescriptions/patient-prescriptions.component.ts
@@ -49,6 +49,18 @@ import { AuthService } from '../../services/auth.service';
               {{ remindersEnabled(r.id) ? 'Turn off reminders' : 'Turn on reminders' }}
             </button>
           </div>
+          <div class="toggle-row">
+            <small class="rem-status">Prescription PDF</small>
+            <button
+              type="button"
+              class="toggle-btn"
+              (click)="downloadPrescriptionPdf(r)"
+              [disabled]="isDownloading(r.id)"
+              data-cy="patient-prescriptions-download-pdf"
+            >
+              {{ isDownloading(r.id) ? 'Preparing PDF...' : 'Download PDF' }}
+            </button>
+          </div>
           <small>Prescribed {{ r.created_at }}</small>
         </li>
       </ul>
@@ -62,10 +74,23 @@ import { AuthService } from '../../services/auth.service';
           </div>
           <div class="meta">{{ r.dosage }} · {{ r.frequency }} · {{ r.duration_days }} days</div>
           <div class="ins" *ngIf="r.instructions">{{ r.instructions }}</div>
+          <div class="toggle-row">
+            <small class="rem-status">Prescription PDF</small>
+            <button
+              type="button"
+              class="toggle-btn"
+              (click)="downloadPrescriptionPdf(r)"
+              [disabled]="isDownloading(r.id)"
+              data-cy="patient-prescriptions-history-download-pdf"
+            >
+              {{ isDownloading(r.id) ? 'Preparing PDF...' : 'Download PDF' }}
+            </button>
+          </div>
           <small>Prescribed {{ r.created_at }}</small>
         </li>
       </ul>
 
+      <p class="err" *ngIf="pdfError" data-cy="patient-prescriptions-pdf-error">{{ pdfError }}</p>
       <p *ngIf="!error && !rows.length" data-cy="patient-prescriptions-empty">No prescriptions yet.</p>
     </section>
   `,
@@ -137,6 +162,10 @@ import { AuthService } from '../../services/auth.service';
       .toggle-btn:hover {
         background: rgba(148, 163, 184, 0.1);
       }
+      .toggle-btn:disabled {
+        opacity: 0.6;
+        cursor: not-allowed;
+      }
       .st {
         text-transform: uppercase;
         letter-spacing: 0.02em;
@@ -164,6 +193,8 @@ export class PatientPrescriptionsComponent implements OnInit {
   activeRows: PrescriptionRow[] = [];
   pastRows: PrescriptionRow[] = [];
   error: string | null = null;
+  pdfError: string | null = null;
+  downloading: Record<string, boolean> = {};
   reminderToggles: Record<string, boolean> = {};
 
   constructor(
@@ -204,6 +235,36 @@ export class PatientPrescriptionsComponent implements OnInit {
       [id]: !this.remindersEnabled(id)
     };
     this.saveReminderToggles();
+  }
+
+  isDownloading(id: string): boolean {
+    return this.downloading[id] ?? false;
+  }
+
+  downloadPrescriptionPdf(row: PrescriptionRow): void {
+    this.pdfError = null;
+    this.downloading = { ...this.downloading, [row.id]: true };
+    this.rx.downloadPdf(row.id).subscribe({
+      next: (blob) => {
+        const safeMedication = (row.medication_name || 'prescription')
+          .toLowerCase()
+          .replace(/[^a-z0-9]+/g, '-')
+          .replace(/^-+|-+$/g, '');
+        const url = window.URL.createObjectURL(blob);
+        const a = document.createElement('a');
+        a.href = url;
+        a.download = `${safeMedication || 'prescription'}-${row.id}.pdf`;
+        document.body.appendChild(a);
+        a.click();
+        a.remove();
+        window.URL.revokeObjectURL(url);
+        this.downloading = { ...this.downloading, [row.id]: false };
+      },
+      error: () => {
+        this.downloading = { ...this.downloading, [row.id]: false };
+        this.pdfError = 'Could not download prescription PDF';
+      }
+    });
   }
 
   private loadReminderToggles(): Record<string, boolean> {

--- a/frontend/src/app/services/api-contract.ts
+++ b/frontend/src/app/services/api-contract.ts
@@ -56,6 +56,7 @@ export const ApiContract = {
   prescriptions: {
     listByPatient: (patientId: string): string => `${API}/patients/${patientId}/prescriptions`,
     createForPatient: (patientId: string): string => `${API}/patients/${patientId}/prescriptions`,
+    pdf: (id: string): string => `${API}/prescriptions/${id}/pdf`,
     revoke: (id: string): string => `${API}/prescriptions/${id}/revoke`
   },
   messaging: {

--- a/frontend/src/app/services/prescriptions.service.ts
+++ b/frontend/src/app/services/prescriptions.service.ts
@@ -25,4 +25,10 @@ export class PrescriptionsService {
       ApiContract.prescriptions.listByPatient(patientId)
     );
   }
+
+  downloadPdf(id: string): Observable<Blob> {
+    return this.http.get(ApiContract.prescriptions.pdf(id), {
+      responseType: 'blob'
+    });
+  }
 }


### PR DESCRIPTION
## Summary
- add frontend API contract and service support for prescription PDF download
- add download actions for both active and history prescription cards
- add UI loading/error states and unit tests for PDF success/failure flow

## Test plan
- [x] npm run test:ci
- [x] npm run build
- [x] go test ./...
- [x] npm run cypress:e2e

Made with [Cursor](https://cursor.com)