### PR TITLE
PR-17: document text extraction (PDF + OCR fallback)

### DIFF
--- a/backend/handlers/doctor_documents.go
+++ b/backend/handlers/doctor_documents.go
@@ -2,7 +2,7 @@ package handlers
 
 import (
 	"context"
-	"fmt"
+	"errors"
 	"net/http"
 	"strings"
 	"time"
@@ -163,9 +163,13 @@ func (h *DoctorDocumentsHandler) Summarize(c *gin.Context) {
 	var patientID uuid.UUID
 	var filename string
 	var sizeBytes int64
+	var contentType string
+	var body []byte
 	err = db.Pool.QueryRow(ctx, `
-		SELECT patient_id, filename, size_bytes FROM patient_documents WHERE id = $1
-	`, docID).Scan(&patientID, &filename, &sizeBytes)
+		SELECT patient_id, filename, size_bytes, content_type, body
+		FROM patient_documents
+		WHERE id = $1
+	`, docID).Scan(&patientID, &filename, &sizeBytes, &contentType, &body)
 	if err != nil {
 		if err == pgx.ErrNoRows {
 			c.JSON(http.StatusNotFound, gin.H{"error": "Document not found"})
@@ -185,23 +189,34 @@ func (h *DoctorDocumentsHandler) Summarize(c *gin.Context) {
 		WHERE id = $1
 	`, docID)
 
-	go h.completeStubSummary(docID, filename, sizeBytes)
+	go h.completeStubSummary(docID, filename, sizeBytes, contentType, body)
 
 	c.JSON(http.StatusAccepted, gin.H{"status": "pending"})
 }
 
-func (h *DoctorDocumentsHandler) completeStubSummary(docID uuid.UUID, filename string, sizeBytes int64) {
+func (h *DoctorDocumentsHandler) completeStubSummary(docID uuid.UUID, filename string, sizeBytes int64, contentType string, body []byte) {
 	time.Sleep(800 * time.Millisecond)
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
-	kb := sizeBytes / 1024
-	if kb < 1 {
-		kb = 1
+
+	extracted, extractErr := extractDocumentText(contentType, filename, body)
+	if extractErr != nil {
+		msg := extractErr.Error()
+		switch {
+		case errors.Is(extractErr, errUnsupportedDocument):
+			msg = "summary extraction is only supported for PDF and image documents"
+		case errors.Is(extractErr, errNoExtractableText):
+			msg = "could not extract readable text from document"
+		}
+		_, _ = db.Pool.Exec(ctx, `
+			UPDATE patient_documents
+			SET summary_status = 'failed', summary_error = $2
+			WHERE id = $1
+		`, docID, msg)
+		return
 	}
-	text := fmt.Sprintf(
-		"AI summary (stub, non-diagnostic): Document %q (~%d KB). Review source file for clinical decisions. This text is generated locally without a cloud LLM.",
-		filename, kb,
-	)
+
+	text := buildSummaryFromExtractedText(filename, sizeBytes, extracted)
 	_, err := db.Pool.Exec(ctx, `
 		UPDATE patient_documents
 		SET summary = $2, summary_status = 'ready', summary_error = NULL

--- a/backend/handlers/document_text_extraction.go
+++ b/backend/handlers/document_text_extraction.go
@@ -1,0 +1,146 @@
+package handlers
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"unicode"
+)
+
+var (
+	errUnsupportedDocument = errors.New("unsupported document type for text extraction")
+	errNoExtractableText   = errors.New("no extractable text found")
+)
+
+var pdfLiteralRegex = regexp.MustCompile(`\(([^()]*)\)`)
+
+// OCR runner is a variable to allow deterministic unit tests.
+var imageOCRExtractor = runTesseractOCR
+
+func extractDocumentText(contentType, filename string, body []byte) (string, error) {
+	ct := strings.ToLower(strings.TrimSpace(contentType))
+	switch {
+	case ct == "application/pdf" || strings.HasSuffix(strings.ToLower(filename), ".pdf"):
+		text, err := extractTextFromPDF(body)
+		if err != nil {
+			return "", err
+		}
+		if text == "" {
+			return "", errNoExtractableText
+		}
+		return text, nil
+	case strings.HasPrefix(ct, "image/"):
+		text, err := imageOCRExtractor(body)
+		if err != nil {
+			return "", fmt.Errorf("ocr extraction failed: %w", err)
+		}
+		text = normalizeExtractedText(text)
+		if text == "" {
+			return "", errNoExtractableText
+		}
+		return text, nil
+	default:
+		return "", errUnsupportedDocument
+	}
+}
+
+func extractTextFromPDF(body []byte) (string, error) {
+	if len(body) == 0 {
+		return "", errors.New("empty pdf payload")
+	}
+	if !bytes.HasPrefix(body, []byte("%PDF")) {
+		return "", errors.New("invalid pdf header")
+	}
+
+	matches := pdfLiteralRegex.FindAllSubmatch(body, -1)
+	parts := make([]string, 0, len(matches))
+	for _, m := range matches {
+		if len(m) < 2 {
+			continue
+		}
+		text := decodePDFLiteral(string(m[1]))
+		text = normalizeExtractedText(text)
+		if text != "" {
+			parts = append(parts, text)
+		}
+	}
+	return strings.Join(parts, " "), nil
+}
+
+func decodePDFLiteral(s string) string {
+	s = strings.ReplaceAll(s, `\(`, "(")
+	s = strings.ReplaceAll(s, `\)`, ")")
+	s = strings.ReplaceAll(s, `\\`, `\`)
+	s = strings.ReplaceAll(s, `\n`, " ")
+	s = strings.ReplaceAll(s, `\r`, " ")
+	s = strings.ReplaceAll(s, `\t`, " ")
+	return s
+}
+
+func normalizeExtractedText(s string) string {
+	var b strings.Builder
+	b.Grow(len(s))
+	lastSpace := false
+	for _, r := range s {
+		if unicode.IsSpace(r) {
+			if !lastSpace {
+				b.WriteRune(' ')
+				lastSpace = true
+			}
+			continue
+		}
+		b.WriteRune(r)
+		lastSpace = false
+	}
+	return strings.TrimSpace(b.String())
+}
+
+func runTesseractOCR(body []byte) (string, error) {
+	if len(body) == 0 {
+		return "", errors.New("empty image payload")
+	}
+
+	tmpDir, err := os.MkdirTemp("", "hx-ocr-*")
+	if err != nil {
+		return "", err
+	}
+	defer os.RemoveAll(tmpDir)
+
+	inFile := filepath.Join(tmpDir, "input-image")
+	if err := os.WriteFile(inFile, body, 0o600); err != nil {
+		return "", err
+	}
+
+	cmd := exec.Command("tesseract", inFile, "stdout", "-l", "eng")
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		msg := strings.TrimSpace(string(out))
+		if msg == "" {
+			msg = err.Error()
+		}
+		return "", fmt.Errorf("tesseract command failed: %s", msg)
+	}
+	return string(out), nil
+}
+
+func buildSummaryFromExtractedText(filename string, sizeBytes int64, extracted string) string {
+	kb := sizeBytes / 1024
+	if kb < 1 {
+		kb = 1
+	}
+	preview := extracted
+	if len(preview) > 380 {
+		preview = preview[:380] + "..."
+	}
+	return fmt.Sprintf(
+		"AI summary (local extraction, non-diagnostic): Document %q (~%d KB). Extracted text highlights: %s",
+		filename,
+		kb,
+		preview,
+	)
+}

--- a/backend/handlers/document_text_extraction_test.go
+++ b/backend/handlers/document_text_extraction_test.go
@@ -1,0 +1,82 @@
+package handlers
+
+import (
+	"errors"
+	"strings"
+	"testing"
+)
+
+func TestExtractTextFromPDF_Success(t *testing.T) {
+	pdf := []byte("%PDF-1.4\n1 0 obj\n<<>>\nstream\nBT (Patient has mild cough) Tj ET\nendstream\nendobj\n%%EOF")
+	got, err := extractTextFromPDF(pdf)
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if !strings.Contains(got, "Patient has mild cough") {
+		t.Fatalf("expected extracted text, got %q", got)
+	}
+}
+
+func TestExtractTextFromPDF_InvalidHeader(t *testing.T) {
+	_, err := extractTextFromPDF([]byte("not-a-pdf"))
+	if err == nil {
+		t.Fatal("expected error for invalid pdf header")
+	}
+}
+
+func TestExtractDocumentText_UnsupportedType(t *testing.T) {
+	_, err := extractDocumentText("text/csv", "a.csv", []byte("x,y"))
+	if !errors.Is(err, errUnsupportedDocument) {
+		t.Fatalf("expected unsupported type error, got %v", err)
+	}
+}
+
+func TestExtractDocumentText_ImageUsesOCRHook(t *testing.T) {
+	orig := imageOCRExtractor
+	t.Cleanup(func() { imageOCRExtractor = orig })
+	imageOCRExtractor = func(_ []byte) (string, error) {
+		return " BP 110 over 70 ", nil
+	}
+
+	got, err := extractDocumentText("image/png", "scan.png", []byte{1, 2, 3})
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if got != "BP 110 over 70" {
+		t.Fatalf("unexpected normalized OCR text: %q", got)
+	}
+}
+
+func TestExtractDocumentText_ImageOCRFailure(t *testing.T) {
+	orig := imageOCRExtractor
+	t.Cleanup(func() { imageOCRExtractor = orig })
+	imageOCRExtractor = func(_ []byte) (string, error) {
+		return "", errors.New("ocr engine unavailable")
+	}
+
+	_, err := extractDocumentText("image/jpeg", "scan.jpg", []byte{1, 2, 3})
+	if err == nil || !strings.Contains(err.Error(), "ocr extraction failed") {
+		t.Fatalf("expected wrapped ocr failure, got %v", err)
+	}
+}
+
+func TestBuildSummaryFromExtractedText(t *testing.T) {
+	out := buildSummaryFromExtractedText("lab.pdf", 2048, "Hemoglobin normal")
+	if !strings.Contains(out, "lab.pdf") || !strings.Contains(out, "Hemoglobin normal") {
+		t.Fatalf("unexpected summary output: %s", out)
+	}
+}
+
+func TestNormalizeExtractedText(t *testing.T) {
+	if got := normalizeExtractedText("a\t b\n c\r\n"); got != "a b c" {
+		t.Fatalf("unexpected normalized text: %q", got)
+	}
+}
+
+func TestBuildSummaryPreviewTruncation(t *testing.T) {
+	long := strings.Repeat("x", 500)
+	out := buildSummaryFromExtractedText("doc.pdf", 15*1024, long)
+	if !strings.Contains(out, "...") {
+		t.Fatalf("expected truncated preview, got %q", out)
+	}
+}


### PR DESCRIPTION
## Summary
- add backend text extraction pipeline for doctor document summarization
- support PDF text parsing and image OCR fallback with clear failure handling
- add unit tests for PDF parsing, OCR hook behavior, unsupported types, and summary generation

## Error handling highlights
- unsupported content types return explicit extraction failure reason
- unreadable or empty extracted text marks summary as failed with actionable message
- OCR execution errors are wrapped and persisted in summary error state

## Test plan
- [x] go test ./...
- [x] npm run test:ci
- [x] npm run build
- [x] npm run cypress:e2e

Made with [Cursor](https://cursor.com)