### PR TITLE
PR-18: async summary job pipeline

### DIFF
--- a/backend/db/db.go
+++ b/backend/db/db.go
@@ -143,6 +143,24 @@ func Migrate(ctx context.Context) error {
 		ALTER TABLE patient_documents ADD COLUMN IF NOT EXISTS summary_status TEXT NOT NULL DEFAULT 'none';
 		ALTER TABLE patient_documents ADD COLUMN IF NOT EXISTS summary_error TEXT;
 
+		CREATE TABLE IF NOT EXISTS document_summary_jobs (
+			id           UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+			document_id  UUID NOT NULL REFERENCES patient_documents(id) ON DELETE CASCADE,
+			status       TEXT NOT NULL DEFAULT 'pending' CHECK (status IN ('pending', 'processing', 'done', 'failed')),
+			attempts     INTEGER NOT NULL DEFAULT 0,
+			last_error   TEXT,
+			run_after    TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+			created_at   TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+			started_at   TIMESTAMPTZ,
+			finished_at  TIMESTAMPTZ
+		);
+
+		CREATE INDEX IF NOT EXISTS idx_doc_summary_jobs_status_run_after
+			ON document_summary_jobs(status, run_after, created_at);
+		CREATE UNIQUE INDEX IF NOT EXISTS idx_doc_summary_jobs_unique_open
+			ON document_summary_jobs(document_id)
+			WHERE status IN ('pending', 'processing');
+
 		CREATE TABLE IF NOT EXISTS message_threads (
 			id              UUID PRIMARY KEY DEFAULT gen_random_uuid(),
 			patient_id      UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,

--- a/backend/handlers/doctor_documents.go
+++ b/backend/handlers/doctor_documents.go
@@ -2,7 +2,6 @@ package handlers
 
 import (
 	"context"
-	"errors"
 	"net/http"
 	"strings"
 	"time"
@@ -161,15 +160,11 @@ func (h *DoctorDocumentsHandler) Summarize(c *gin.Context) {
 	}
 	ctx := c.Request.Context()
 	var patientID uuid.UUID
-	var filename string
-	var sizeBytes int64
-	var contentType string
-	var body []byte
 	err = db.Pool.QueryRow(ctx, `
-		SELECT patient_id, filename, size_bytes, content_type, body
+		SELECT patient_id
 		FROM patient_documents
 		WHERE id = $1
-	`, docID).Scan(&patientID, &filename, &sizeBytes, &contentType, &body)
+	`, docID).Scan(&patientID)
 	if err != nil {
 		if err == pgx.ErrNoRows {
 			c.JSON(http.StatusNotFound, gin.H{"error": "Document not found"})
@@ -189,44 +184,29 @@ func (h *DoctorDocumentsHandler) Summarize(c *gin.Context) {
 		WHERE id = $1
 	`, docID)
 
-	go h.completeStubSummary(docID, filename, sizeBytes, contentType, body)
-
-	c.JSON(http.StatusAccepted, gin.H{"status": "pending"})
-}
-
-func (h *DoctorDocumentsHandler) completeStubSummary(docID uuid.UUID, filename string, sizeBytes int64, contentType string, body []byte) {
-	time.Sleep(800 * time.Millisecond)
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-	defer cancel()
-
-	extracted, extractErr := extractDocumentText(contentType, filename, body)
-	if extractErr != nil {
-		msg := extractErr.Error()
-		switch {
-		case errors.Is(extractErr, errUnsupportedDocument):
-			msg = "summary extraction is only supported for PDF and image documents"
-		case errors.Is(extractErr, errNoExtractableText):
-			msg = "could not extract readable text from document"
+	var jobID uuid.UUID
+	err = db.Pool.QueryRow(ctx, `
+		WITH existing AS (
+			SELECT id
+			FROM document_summary_jobs
+			WHERE document_id = $1
+			  AND status IN ('pending', 'processing')
+			ORDER BY created_at DESC
+			LIMIT 1
+		)
+		INSERT INTO document_summary_jobs (document_id, status, run_after)
+		SELECT $1, 'pending', NOW()
+		WHERE NOT EXISTS (SELECT 1 FROM existing)
+		RETURNING id
+	`, docID).Scan(&jobID)
+	if err != nil {
+		if err == pgx.ErrNoRows {
+			c.JSON(http.StatusAccepted, gin.H{"status": "pending", "message": "summary job already queued"})
+			return
 		}
-		_, _ = db.Pool.Exec(ctx, `
-			UPDATE patient_documents
-			SET summary_status = 'failed', summary_error = $2
-			WHERE id = $1
-		`, docID, msg)
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Unable to enqueue summary job"})
 		return
 	}
 
-	text := buildSummaryFromExtractedText(filename, sizeBytes, extracted)
-	_, err := db.Pool.Exec(ctx, `
-		UPDATE patient_documents
-		SET summary = $2, summary_status = 'ready', summary_error = NULL
-		WHERE id = $1 AND summary_status = 'pending'
-	`, docID, text)
-	if err != nil {
-		_, _ = db.Pool.Exec(ctx, `
-			UPDATE patient_documents
-			SET summary_status = 'failed', summary_error = $2
-			WHERE id = $1
-		`, docID, err.Error())
-	}
+	c.JSON(http.StatusAccepted, gin.H{"status": "pending", "job_id": jobID.String()})
 }

--- a/backend/handlers/doctor_documents_test.go
+++ b/backend/handlers/doctor_documents_test.go
@@ -52,3 +52,34 @@ func TestDoctorDocuments_Get_Unauthorized(t *testing.T) {
 		t.Fatalf("expected 401, got %d", w.Code)
 	}
 }
+
+func TestDoctorDocuments_Summarize_Unauthorized(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest("POST", "/api/doctor/documents/"+uuid.New().String()+"/summarize", nil)
+	c.Params = gin.Params{{Key: "id", Value: uuid.New().String()}}
+
+	h := NewDoctorDocumentsHandler()
+	h.Summarize(c)
+
+	if w.Code != http.StatusUnauthorized {
+		t.Fatalf("expected 401, got %d", w.Code)
+	}
+}
+
+func TestDoctorDocuments_Summarize_InvalidID(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest("POST", "/api/doctor/documents/not-a-uuid/summarize", nil)
+	c.Params = gin.Params{{Key: "id", Value: "not-a-uuid"}}
+	c.Set("claims", &Claims{UserID: uuid.New(), Email: "d@b.com", Role: "doctor"})
+
+	h := NewDoctorDocumentsHandler()
+	h.Summarize(c)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d", w.Code)
+	}
+}

--- a/backend/handlers/document_text_extraction.go
+++ b/backend/handlers/document_text_extraction.go
@@ -49,6 +49,29 @@ func extractDocumentText(contentType, filename string, body []byte) (string, err
 	}
 }
 
+// Exported wrappers for worker package use without duplicating logic.
+func ExtractDocumentTextForWorker(contentType, filename string, body []byte) (string, error) {
+	return extractDocumentText(contentType, filename, body)
+}
+
+func BuildSummaryFromExtractedTextForWorker(filename string, sizeBytes int64, extracted string) string {
+	return buildSummaryFromExtractedText(filename, sizeBytes, extracted)
+}
+
+func NormalizeSummaryExtractionErrorForWorker(err error) string {
+	switch {
+	case errors.Is(err, errUnsupportedDocument):
+		return "summary extraction is only supported for PDF and image documents"
+	case errors.Is(err, errNoExtractableText):
+		return "could not extract readable text from document"
+	default:
+		return err.Error()
+	}
+}
+
+func ErrUnsupportedDocumentForWorker() error { return errUnsupportedDocument }
+func ErrNoExtractableTextForWorker() error   { return errNoExtractableText }
+
 func extractTextFromPDF(body []byte) (string, error) {
 	if len(body) == 0 {
 		return "", errors.New("empty pdf payload")

--- a/backend/main.go
+++ b/backend/main.go
@@ -6,12 +6,14 @@ import (
 	"log"
 	"net/http"
 	"strings"
+	"time"
 
 	"github.com/gin-gonic/gin"
 	"github.com/healthonyx/backend/config"
 	"github.com/healthonyx/backend/db"
 	"github.com/healthonyx/backend/handlers"
 	"github.com/healthonyx/backend/middleware"
+	"github.com/healthonyx/backend/workers"
 )
 
 func main() {
@@ -147,6 +149,7 @@ func main() {
 	}
 
 	addr := fmt.Sprintf(":%s", cfg.Port)
+	go workers.NewDocumentSummaryWorker(2 * time.Second).Run(context.Background())
 	log.Printf("Listening on %s", addr)
 	if err := r.Run(addr); err != nil {
 		log.Fatal(err)

--- a/backend/workers/document_summary_worker.go
+++ b/backend/workers/document_summary_worker.go
@@ -1,0 +1,161 @@
+package workers
+
+import (
+	"context"
+	"log"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/healthonyx/backend/db"
+	"github.com/healthonyx/backend/handlers"
+	"github.com/jackc/pgx/v5"
+)
+
+type DocumentSummaryWorker struct {
+	interval time.Duration
+	process  func(context.Context) (int64, error)
+}
+
+func NewDocumentSummaryWorker(interval time.Duration) *DocumentSummaryWorker {
+	if interval <= 0 {
+		interval = 2 * time.Second
+	}
+	return &DocumentSummaryWorker{interval: interval}
+}
+
+func (w *DocumentSummaryWorker) Run(ctx context.Context) {
+	ticker := time.NewTicker(w.interval)
+	defer ticker.Stop()
+
+	if _, err := w.processPending(ctx); err != nil {
+		log.Printf("document summary worker initial process error: %v", err)
+	}
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			if _, err := w.processPending(ctx); err != nil {
+				log.Printf("document summary worker process error: %v", err)
+			}
+		}
+	}
+}
+
+func (w *DocumentSummaryWorker) processPending(ctx context.Context) (int64, error) {
+	if w.process != nil {
+		return w.process(ctx)
+	}
+	return w.ProcessPending(ctx)
+}
+
+func (w *DocumentSummaryWorker) ProcessPending(ctx context.Context) (int64, error) {
+	var processed int64
+	for {
+		ok, err := processSingleSummaryJob(ctx)
+		if err != nil {
+			return processed, err
+		}
+		if !ok {
+			return processed, nil
+		}
+		processed++
+	}
+}
+
+func processSingleSummaryJob(ctx context.Context) (bool, error) {
+	var jobID, docID uuid.UUID
+	err := db.Pool.QueryRow(ctx, `
+		WITH next_job AS (
+			SELECT id, document_id
+			FROM document_summary_jobs
+			WHERE status = 'pending'
+			  AND run_after <= NOW()
+			ORDER BY created_at
+			LIMIT 1
+			FOR UPDATE SKIP LOCKED
+		)
+		UPDATE document_summary_jobs j
+		SET status = 'processing',
+			started_at = NOW(),
+			finished_at = NULL,
+			last_error = NULL,
+			attempts = j.attempts + 1
+		FROM next_job
+		WHERE j.id = next_job.id
+		RETURNING j.id, j.document_id
+	`).Scan(&jobID, &docID)
+	if err != nil {
+		if err == pgx.ErrNoRows {
+			return false, nil
+		}
+		return false, err
+	}
+
+	var filename, contentType string
+	var sizeBytes int64
+	var body []byte
+	err = db.Pool.QueryRow(ctx, `
+		SELECT filename, content_type, size_bytes, body
+		FROM patient_documents
+		WHERE id = $1
+	`, docID).Scan(&filename, &contentType, &sizeBytes, &body)
+	if err != nil {
+		if err == pgx.ErrNoRows {
+			_, _ = db.Pool.Exec(ctx, `
+				UPDATE document_summary_jobs
+				SET status = 'failed', finished_at = NOW(), last_error = 'document not found'
+				WHERE id = $1
+			`, jobID)
+			return true, nil
+		}
+		return false, err
+	}
+
+	extracted, exErr := handlers.ExtractDocumentTextForWorker(contentType, filename, body)
+	if exErr != nil {
+		msg := handlers.NormalizeSummaryExtractionErrorForWorker(exErr)
+		_, _ = db.Pool.Exec(ctx, `
+			UPDATE patient_documents
+			SET summary_status = 'failed', summary_error = $2
+			WHERE id = $1
+		`, docID, msg)
+		_, _ = db.Pool.Exec(ctx, `
+			UPDATE document_summary_jobs
+			SET status = 'failed', finished_at = NOW(), last_error = $2
+			WHERE id = $1
+		`, jobID, msg)
+		return true, nil
+	}
+
+	summary := handlers.BuildSummaryFromExtractedTextForWorker(filename, sizeBytes, extracted)
+	_, err = db.Pool.Exec(ctx, `
+		UPDATE patient_documents
+		SET summary = $2, summary_status = 'ready', summary_error = NULL
+		WHERE id = $1
+	`, docID, summary)
+	if err != nil {
+		_, _ = db.Pool.Exec(ctx, `
+			UPDATE patient_documents
+			SET summary_status = 'failed', summary_error = $2
+			WHERE id = $1
+		`, docID, err.Error())
+		_, _ = db.Pool.Exec(ctx, `
+			UPDATE document_summary_jobs
+			SET status = 'failed', finished_at = NOW(), last_error = $2
+			WHERE id = $1
+		`, jobID, err.Error())
+		return true, nil
+	}
+
+	_, err = db.Pool.Exec(ctx, `
+		UPDATE document_summary_jobs
+		SET status = 'done', finished_at = NOW(), last_error = NULL
+		WHERE id = $1
+	`, jobID)
+	if err != nil {
+		return false, err
+	}
+	return true, nil
+}

--- a/backend/workers/document_summary_worker_test.go
+++ b/backend/workers/document_summary_worker_test.go
@@ -1,0 +1,82 @@
+package workers
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+)
+
+func TestNewDocumentSummaryWorker_DefaultInterval(t *testing.T) {
+	w := NewDocumentSummaryWorker(0)
+	if w == nil {
+		t.Fatal("worker should not be nil")
+	}
+	if w.interval != 2*time.Second {
+		t.Fatalf("expected default interval 2s, got %v", w.interval)
+	}
+}
+
+func TestNewDocumentSummaryWorker_UsesProvidedInterval(t *testing.T) {
+	want := 5 * time.Second
+	w := NewDocumentSummaryWorker(want)
+	if w.interval != want {
+		t.Fatalf("expected interval %v, got %v", want, w.interval)
+	}
+}
+
+func TestDocumentSummaryWorker_ProcessPendingUsesInjectedProcess(t *testing.T) {
+	w := NewDocumentSummaryWorker(50 * time.Millisecond)
+	calls := 0
+	w.process = func(context.Context) (int64, error) {
+		calls++
+		return 3, nil
+	}
+	got, err := w.processPending(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != 3 {
+		t.Fatalf("expected processed 3, got %d", got)
+	}
+	if calls != 1 {
+		t.Fatalf("expected one injected call, got %d", calls)
+	}
+}
+
+func TestDocumentSummaryWorker_RunHonorsContextCancel(t *testing.T) {
+	w := NewDocumentSummaryWorker(10 * time.Millisecond)
+	calls := 0
+	w.process = func(context.Context) (int64, error) {
+		calls++
+		return 0, nil
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go func() {
+		w.Run(ctx)
+		close(done)
+	}()
+	time.Sleep(25 * time.Millisecond)
+	cancel()
+
+	select {
+	case <-done:
+	case <-time.After(300 * time.Millisecond):
+		t.Fatal("worker did not stop after context cancel")
+	}
+	if calls == 0 {
+		t.Fatal("expected at least one process call")
+	}
+}
+
+func TestDocumentSummaryWorker_ProcessPendingPropagatesError(t *testing.T) {
+	w := NewDocumentSummaryWorker(10 * time.Millisecond)
+	wantErr := errors.New("boom")
+	w.process = func(context.Context) (int64, error) { return 0, wantErr }
+	_, err := w.processPending(context.Background())
+	if !errors.Is(err, wantErr) {
+		t.Fatalf("expected propagated error, got %v", err)
+	}
+}


### PR DESCRIPTION
## Summary
- replace inline document summarize execution with queued `document_summary_jobs`
- add `DocumentSummaryWorker` to process queued jobs and update summary states asynchronously
- add migration/schema updates and tests for summarize endpoint validation plus worker lifecycle behavior

## Test plan
- [x] go test ./...
- [x] npm run test:ci
- [x] npm run build
- [x] npm run cypress:e2e

Made with [Cursor](https://cursor.com)