### PR TITLE
PR-19: upload security malware scan hook

### DIFF
--- a/backend/handlers/documents.go
+++ b/backend/handlers/documents.go
@@ -1,6 +1,7 @@
 package handlers
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -105,6 +106,14 @@ func (h *DocumentsHandler) Upload(c *gin.Context) {
 	}
 	if int64(len(data)) > maxDocumentBytes {
 		c.JSON(http.StatusBadRequest, gin.H{"error": fmt.Sprintf("file too large (max %d bytes)", maxDocumentBytes)})
+		return
+	}
+	if err := scanForMalware(data); err != nil {
+		if errors.Is(err, errMalwareDetected) {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "File rejected by malware scanner"})
+			return
+		}
+		c.JSON(http.StatusServiceUnavailable, gin.H{"error": "Malware scanning unavailable. Please try again"})
 		return
 	}
 

--- a/backend/handlers/malware_scanner.go
+++ b/backend/handlers/malware_scanner.go
@@ -1,0 +1,53 @@
+package handlers
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+var errMalwareDetected = errors.New("malware detected")
+
+// scanCommandRunner is injectable for tests.
+var scanCommandRunner = func(data []byte) ([]byte, error) {
+	cmd := exec.Command("clamscan", "--no-summary", "-")
+	cmd.Stdin = bytes.NewReader(data)
+	out, err := cmd.CombinedOutput()
+	return out, err
+}
+
+func malwareScanEnabled() bool {
+	return strings.EqualFold(strings.TrimSpace(os.Getenv("MALWARE_SCAN_ENABLED")), "true")
+}
+
+func malwareFailClosed() bool {
+	return strings.EqualFold(strings.TrimSpace(os.Getenv("MALWARE_SCAN_FAIL_CLOSED")), "true")
+}
+
+func scanForMalware(data []byte) error {
+	if !malwareScanEnabled() {
+		return nil
+	}
+	out, err := scanCommandRunner(data)
+	output := strings.ToUpper(string(out))
+	if strings.Contains(output, "FOUND") {
+		return errMalwareDetected
+	}
+	if err != nil {
+		if errors.Is(err, exec.ErrNotFound) {
+			if malwareFailClosed() {
+				return fmt.Errorf("malware scanner unavailable: %w", err)
+			}
+			return nil
+		}
+		// If scanner exits non-zero but no infection signature, treat as service failure.
+		if malwareFailClosed() {
+			return fmt.Errorf("malware scanner failed: %w", err)
+		}
+		return nil
+	}
+	return nil
+}

--- a/backend/handlers/malware_scanner_test.go
+++ b/backend/handlers/malware_scanner_test.go
@@ -1,0 +1,58 @@
+package handlers
+
+import (
+	"errors"
+	"os/exec"
+	"testing"
+)
+
+func TestScanForMalware_DisabledByDefault(t *testing.T) {
+	t.Setenv("MALWARE_SCAN_ENABLED", "false")
+	orig := scanCommandRunner
+	t.Cleanup(func() { scanCommandRunner = orig })
+	scanCommandRunner = func(_ []byte) ([]byte, error) {
+		t.Fatal("scanner should not be called when disabled")
+		return nil, nil
+	}
+	if err := scanForMalware([]byte("hello")); err != nil {
+		t.Fatalf("expected nil error, got %v", err)
+	}
+}
+
+func TestScanForMalware_Detected(t *testing.T) {
+	t.Setenv("MALWARE_SCAN_ENABLED", "true")
+	orig := scanCommandRunner
+	t.Cleanup(func() { scanCommandRunner = orig })
+	scanCommandRunner = func(_ []byte) ([]byte, error) {
+		return []byte("stdin: Eicar-Test-Signature FOUND"), errors.New("exit status 1")
+	}
+	if err := scanForMalware([]byte("infected")); !errors.Is(err, errMalwareDetected) {
+		t.Fatalf("expected malware detected error, got %v", err)
+	}
+}
+
+func TestScanForMalware_ScannerMissingFailOpen(t *testing.T) {
+	t.Setenv("MALWARE_SCAN_ENABLED", "true")
+	t.Setenv("MALWARE_SCAN_FAIL_CLOSED", "false")
+	orig := scanCommandRunner
+	t.Cleanup(func() { scanCommandRunner = orig })
+	scanCommandRunner = func(_ []byte) ([]byte, error) {
+		return nil, exec.ErrNotFound
+	}
+	if err := scanForMalware([]byte("x")); err != nil {
+		t.Fatalf("expected nil error in fail-open mode, got %v", err)
+	}
+}
+
+func TestScanForMalware_ScannerMissingFailClosed(t *testing.T) {
+	t.Setenv("MALWARE_SCAN_ENABLED", "true")
+	t.Setenv("MALWARE_SCAN_FAIL_CLOSED", "true")
+	orig := scanCommandRunner
+	t.Cleanup(func() { scanCommandRunner = orig })
+	scanCommandRunner = func(_ []byte) ([]byte, error) {
+		return nil, exec.ErrNotFound
+	}
+	if err := scanForMalware([]byte("x")); err == nil {
+		t.Fatal("expected scanner unavailable error in fail-closed mode")
+	}
+}


### PR DESCRIPTION
## Summary
- add a malware scan hook to document uploads before persistence
- reject files flagged by scanner and return service-unavailable when fail-closed scanner checks cannot run
- add unit tests for scan disabled mode, malware detection, and scanner missing fail-open/fail-closed behavior

## Runtime flags
- `MALWARE_SCAN_ENABLED=true` to enable scanning
- `MALWARE_SCAN_FAIL_CLOSED=true` to reject uploads when scanner is unavailable

## Test plan
- [x] go test ./...
- [x] npm run test:ci
- [x] npm run build
- [x] npm run cypress:e2e

Made with [Cursor](https://cursor.com)