### PR TITLE
PR-20: document preview and summary status UI

### DIFF
--- a/frontend/src/app/components/doctor-document-detail/doctor-document-detail.component.html
+++ b/frontend/src/app/components/doctor-document-detail/doctor-document-detail.component.html
@@ -31,6 +31,25 @@
         <span class="meta-label">Type</span>
         <span class="meta-value">{{ d.content_type || '—' }}</span>
       </div>
+      <div class="meta-card glass">
+        <span class="meta-label">Summary status</span>
+        <span [class]="statusClass(d.summary_status)" data-cy="doctor-document-summary-status">
+          {{ statusLabel(d.summary_status) }}
+        </span>
+      </div>
+    </div>
+
+    <div class="preview-section glass" data-cy="doctor-document-preview-section">
+      <div class="preview-head">
+        <h2>Document preview</h2>
+        <span class="preview-type">{{ d.content_type || 'unknown type' }}</span>
+      </div>
+      <div class="preview-frame" [class.preview-disabled]="!canInlinePreview(d)">
+        <div class="preview-placeholder" data-cy="doctor-document-preview-placeholder">
+          <span class="preview-icon" aria-hidden="true">{{ canInlinePreview(d) ? '👁️' : '🔒' }}</span>
+          <p>{{ previewCaption(d) }}</p>
+        </div>
+      </div>
     </div>
 
     <div
@@ -64,6 +83,8 @@
         <span class="spinner" aria-hidden="true"></span>
         Generating summary… This may take a few seconds.
       </div>
+
+      <p *ngIf="summarizeInfo" class="muted hint" data-cy="doctor-document-summary-info">{{ summarizeInfo }}</p>
 
       <div *ngIf="d.summary_status === 'failed'" class="failed-box" data-cy="doctor-document-summary-failed">
         <strong>Summary could not be generated.</strong>

--- a/frontend/src/app/components/doctor-document-detail/doctor-document-detail.component.scss
+++ b/frontend/src/app/components/doctor-document-detail/doctor-document-detail.component.scss
@@ -111,6 +111,56 @@
   border-radius: var(--radius-lg);
 }
 
+.preview-section {
+  padding: var(--space-lg);
+  border-radius: var(--radius-lg);
+  margin-bottom: var(--space-lg);
+}
+
+.preview-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-sm);
+  margin-bottom: var(--space-sm);
+
+  h2 {
+    margin: 0;
+    font-size: 1.1rem;
+  }
+}
+
+.preview-type {
+  font-size: 0.78rem;
+  color: var(--text-muted);
+}
+
+.preview-frame {
+  border: 1px dashed rgba(0, 240, 255, 0.3);
+  border-radius: var(--radius-md);
+  min-height: 150px;
+  display: grid;
+  place-items: center;
+  background: rgba(0, 0, 0, 0.2);
+}
+
+.preview-disabled {
+  border-color: rgba(148, 163, 184, 0.35);
+}
+
+.preview-placeholder {
+  text-align: center;
+  padding: var(--space-md);
+  color: var(--text-secondary);
+  max-width: 34rem;
+}
+
+.preview-icon {
+  display: inline-block;
+  font-size: 1.4rem;
+  margin-bottom: 0.4rem;
+}
+
 .summary-head {
   display: flex;
   flex-wrap: wrap;
@@ -194,4 +244,33 @@
 .hint {
   margin: 0;
   font-size: 0.9rem;
+}
+
+.pill {
+  display: inline-flex;
+  align-items: center;
+  border-radius: 999px;
+  padding: 0.2rem 0.55rem;
+  font-size: 0.76rem;
+  color: var(--text-muted);
+  border: 1px solid rgba(148, 163, 184, 0.35);
+  width: fit-content;
+}
+
+.pill-pending {
+  color: #a16207;
+  border-color: rgba(245, 158, 11, 0.45);
+  background: rgba(245, 158, 11, 0.12);
+}
+
+.pill-ready {
+  color: #15803d;
+  border-color: rgba(34, 197, 94, 0.45);
+  background: rgba(34, 197, 94, 0.12);
+}
+
+.pill-failed {
+  color: #b91c1c;
+  border-color: rgba(248, 113, 113, 0.5);
+  background: rgba(248, 113, 113, 0.12);
 }

--- a/frontend/src/app/components/doctor-document-detail/doctor-document-detail.component.spec.ts
+++ b/frontend/src/app/components/doctor-document-detail/doctor-document-detail.component.spec.ts
@@ -1,0 +1,57 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { ActivatedRoute, convertToParamMap, provideRouter } from '@angular/router';
+import { of } from 'rxjs';
+import { DoctorDocumentDetailComponent } from './doctor-document-detail.component';
+import { DoctorDocumentsService } from '../../services/doctor-documents.service';
+
+describe('DoctorDocumentDetailComponent', () => {
+  let fixture: ComponentFixture<DoctorDocumentDetailComponent>;
+  let component: DoctorDocumentDetailComponent;
+  const serviceMock = {
+    getDetail: jasmine.createSpy('getDetail').and.returnValue(
+      of({
+        id: 'd1',
+        filename: 'lab.pdf',
+        patient_id: 'p1',
+        patient_email: 'p@test.com',
+        size_bytes: 1024,
+        content_type: 'application/pdf',
+        created_at: '2026-01-01T00:00:00Z',
+        summary: null,
+        summary_status: 'pending'
+      })
+    ),
+    requestSummary: jasmine.createSpy('requestSummary').and.returnValue(of({ status: 'pending', job_id: 'j1' }))
+  };
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [DoctorDocumentDetailComponent],
+      providers: [
+        provideRouter([]),
+        {
+          provide: ActivatedRoute,
+          useValue: { paramMap: of(convertToParamMap({ documentId: 'd1' })) }
+        },
+        { provide: DoctorDocumentsService, useValue: serviceMock }
+      ]
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(DoctorDocumentDetailComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('renders summary status pill', () => {
+    const el = fixture.nativeElement as HTMLElement;
+    expect(el.querySelector('[data-cy="doctor-document-summary-status"]')?.textContent).toContain(
+      'Summary pending'
+    );
+  });
+
+  it('renders preview section', () => {
+    const el = fixture.nativeElement as HTMLElement;
+    expect(el.querySelector('[data-cy="doctor-document-preview-section"]')).toBeTruthy();
+    expect(el.querySelector('[data-cy="doctor-document-preview-placeholder"]')).toBeTruthy();
+  });
+});

--- a/frontend/src/app/components/doctor-document-detail/doctor-document-detail.component.ts
+++ b/frontend/src/app/components/doctor-document-detail/doctor-document-detail.component.ts
@@ -18,6 +18,7 @@ export class DoctorDocumentDetailComponent implements OnInit, OnDestroy {
   loading = true;
   summarizeLoading = false;
   error = '';
+  summarizeInfo = '';
   private documentId = '';
   private pollSub?: Subscription;
 
@@ -47,6 +48,7 @@ export class DoctorDocumentDetailComponent implements OnInit, OnDestroy {
   private loadInitial(): void {
     this.loading = true;
     this.error = '';
+    this.summarizeInfo = '';
     this.doc = null;
     this.api.getDetail(this.documentId).subscribe({
       next: (d) => {
@@ -99,6 +101,7 @@ export class DoctorDocumentDetailComponent implements OnInit, OnDestroy {
     }
     this.summarizeLoading = true;
     this.error = '';
+    this.summarizeInfo = '';
     this.api
       .requestSummary(this.documentId)
       .pipe(finalize(() => (this.summarizeLoading = false)))
@@ -107,6 +110,11 @@ export class DoctorDocumentDetailComponent implements OnInit, OnDestroy {
           if (res === null) {
             this.error = 'Could not start summarization.';
             return;
+          }
+          if (res.message) {
+            this.summarizeInfo = res.message;
+          } else if (res.job_id) {
+            this.summarizeInfo = 'Summary job queued. Refreshing status...';
           }
           this.api.getDetail(this.documentId).subscribe({
             next: (d) => {
@@ -135,5 +143,43 @@ export class DoctorDocumentDetailComponent implements OnInit, OnDestroy {
 
   showSummaryBlock(): boolean {
     return !!this.doc && (this.doc.summary_status === 'ready' || !!this.doc.summary);
+  }
+
+  statusLabel(s?: string): string {
+    switch (s) {
+      case 'pending':
+        return 'Summary pending';
+      case 'ready':
+        return 'Summary ready';
+      case 'failed':
+        return 'Summary failed';
+      default:
+        return 'No summary yet';
+    }
+  }
+
+  statusClass(s?: string): string {
+    switch (s) {
+      case 'pending':
+        return 'pill pill-pending';
+      case 'ready':
+        return 'pill pill-ready';
+      case 'failed':
+        return 'pill pill-failed';
+      default:
+        return 'pill';
+    }
+  }
+
+  canInlinePreview(d: DoctorDocumentDetail): boolean {
+    const ct = (d.content_type || '').toLowerCase();
+    return ct === 'application/pdf' || ct.startsWith('image/');
+  }
+
+  previewCaption(d: DoctorDocumentDetail): string {
+    if (this.canInlinePreview(d)) {
+      return 'Inline preview is enabled for this file type. Secure viewer endpoint will stream content in the next PR.';
+    }
+    return 'Inline preview is unavailable for this file type. Open/download support will use secure access flow.';
   }
 }

--- a/frontend/src/app/components/doctor-documents-list/doctor-documents-list.component.html
+++ b/frontend/src/app/components/doctor-documents-list/doctor-documents-list.component.html
@@ -38,7 +38,11 @@
           <td>{{ d.patient_email }}</td>
           <td>{{ d.filename }}</td>
           <td>{{ d.created_at | date: 'medium' }}</td>
-          <td>{{ statusLabel(d.summary_status) }}</td>
+          <td>
+            <span [class]="statusClass(d.summary_status)" data-cy="doctor-documents-summary-status">
+              {{ statusLabel(d.summary_status) }}
+            </span>
+          </td>
           <td>
             <a [routerLink]="['/doctor/documents', d.id]" class="link" data-cy="doctor-documents-open">Open</a>
           </td>

--- a/frontend/src/app/components/doctor-documents-list/doctor-documents-list.component.scss
+++ b/frontend/src/app/components/doctor-documents-list/doctor-documents-list.component.scss
@@ -106,3 +106,31 @@
     text-decoration: underline;
   }
 }
+
+.pill {
+  display: inline-flex;
+  align-items: center;
+  border-radius: 999px;
+  padding: 0.2rem 0.55rem;
+  font-size: 0.76rem;
+  color: var(--text-muted);
+  border: 1px solid rgba(148, 163, 184, 0.35);
+}
+
+.pill-pending {
+  color: #a16207;
+  border-color: rgba(245, 158, 11, 0.45);
+  background: rgba(245, 158, 11, 0.12);
+}
+
+.pill-ready {
+  color: #15803d;
+  border-color: rgba(34, 197, 94, 0.45);
+  background: rgba(34, 197, 94, 0.12);
+}
+
+.pill-failed {
+  color: #b91c1c;
+  border-color: rgba(248, 113, 113, 0.5);
+  background: rgba(248, 113, 113, 0.12);
+}

--- a/frontend/src/app/components/doctor-documents-list/doctor-documents-list.component.spec.ts
+++ b/frontend/src/app/components/doctor-documents-list/doctor-documents-list.component.spec.ts
@@ -1,0 +1,37 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { provideRouter } from '@angular/router';
+import { of } from 'rxjs';
+import { DoctorDocumentsListComponent } from './doctor-documents-list.component';
+import { DoctorDocumentsService } from '../../services/doctor-documents.service';
+
+describe('DoctorDocumentsListComponent', () => {
+  let fixture: ComponentFixture<DoctorDocumentsListComponent>;
+  const serviceMock = {
+    list: jasmine.createSpy('list').and.returnValue(
+      of([
+        {
+          id: 'd1',
+          filename: 'x.pdf',
+          patient_email: 'p@test.com',
+          created_at: '2026-01-01T00:00:00Z',
+          summary_status: 'ready'
+        }
+      ])
+    )
+  };
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [DoctorDocumentsListComponent],
+      providers: [provideRouter([]), { provide: DoctorDocumentsService, useValue: serviceMock }]
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(DoctorDocumentsListComponent);
+    fixture.detectChanges();
+  });
+
+  it('renders summary status pill', () => {
+    const el = fixture.nativeElement as HTMLElement;
+    expect(el.querySelector('[data-cy="doctor-documents-summary-status"]')?.textContent).toContain('Summary ready');
+  });
+});

--- a/frontend/src/app/components/doctor-documents-list/doctor-documents-list.component.ts
+++ b/frontend/src/app/components/doctor-documents-list/doctor-documents-list.component.ts
@@ -50,4 +50,17 @@ export class DoctorDocumentsListComponent implements OnInit {
         return '—';
     }
   }
+
+  statusClass(s?: string): string {
+    switch (s) {
+      case 'pending':
+        return 'pill pill-pending';
+      case 'ready':
+        return 'pill pill-ready';
+      case 'failed':
+        return 'pill pill-failed';
+      default:
+        return 'pill';
+    }
+  }
 }

--- a/frontend/src/app/services/doctor-documents.service.ts
+++ b/frontend/src/app/services/doctor-documents.service.ts
@@ -55,9 +55,9 @@ export class DoctorDocumentsService {
   }
 
   /** Triggers async summarization; poll getDetail until ready/failed. */
-  requestSummary(documentId: string): Observable<{ status?: string } | null> {
+  requestSummary(documentId: string): Observable<{ status?: string; message?: string; job_id?: string } | null> {
     return this.http
-      .post<{ status?: string }>(
+      .post<{ status?: string; message?: string; job_id?: string }>(
         ApiContract.doctorDocuments.summarize(encodeURIComponent(documentId)),
         {}
       )


### PR DESCRIPTION
## Summary
- add summary status pills in doctor document list and detail views
- add document preview section with type-aware inline preview messaging/state
- add queued summary info messaging and unit tests for the new list/detail UI behavior

## Test plan
- [x] npm run test:ci
- [x] npm run build
- [x] go test ./...
- [x] npm run cypress:e2e

Made with [Cursor](https://cursor.com)