### PR TITLE
PR-21: document summary retry and error UI

### DIFF
--- a/frontend/src/app/components/doctor-document-detail/doctor-document-detail.component.html
+++ b/frontend/src/app/components/doctor-document-detail/doctor-document-detail.component.html
@@ -64,18 +64,10 @@
           type="button"
           class="btn-primary"
           (click)="requestSummary()"
-          [disabled]="summarizeLoading || d.summary_status === 'pending'"
+          [disabled]="primarySummaryDisabled(d)"
           data-cy="doctor-document-summarize"
         >
-          {{
-            summarizeLoading
-              ? 'Starting…'
-              : d.summary_status === 'pending'
-                ? 'Generating…'
-                : d.summary_status === 'ready'
-                  ? 'Regenerate summary'
-                  : 'Generate summary'
-          }}
+          {{ primarySummaryLabel(d) }}
         </button>
       </div>
 
@@ -86,10 +78,41 @@
 
       <p *ngIf="summarizeInfo" class="muted hint" data-cy="doctor-document-summary-info">{{ summarizeInfo }}</p>
 
+      <div
+        *ngIf="summaryRequestError"
+        class="request-error-box"
+        data-cy="doctor-document-summary-request-error"
+        role="alert"
+      >
+        <span>{{ summaryRequestError }}</span>
+        <button
+          type="button"
+          class="btn-ghost"
+          (click)="retrySummary()"
+          [disabled]="summarizeLoading || d.summary_status === 'pending'"
+          data-cy="doctor-document-summary-retry-from-error"
+        >
+          Retry
+        </button>
+      </div>
+
       <div *ngIf="d.summary_status === 'failed'" class="failed-box" data-cy="doctor-document-summary-failed">
-        <strong>Summary could not be generated.</strong>
-        <span *ngIf="d.summary_error">{{ d.summary_error }}</span>
-        <span *ngIf="!d.summary_error">Please try again later.</span>
+        <div class="failed-content">
+          <strong>Summary could not be generated.</strong>
+          <p *ngIf="d.summary_error" class="failed-detail" data-cy="doctor-document-summary-error-text">
+            {{ d.summary_error }}
+          </p>
+          <p *ngIf="!d.summary_error" class="failed-detail muted">No error details from the server. You can try again.</p>
+        </div>
+        <button
+          type="button"
+          class="btn-retry"
+          (click)="retrySummary()"
+          [disabled]="primarySummaryDisabled(d)"
+          data-cy="doctor-document-summary-retry"
+        >
+          {{ summarizeLoading ? 'Retrying…' : 'Try again' }}
+        </button>
       </div>
 
       <div *ngIf="showSummaryBlock()" class="summary-body" data-cy="doctor-document-summary-text">

--- a/frontend/src/app/components/doctor-document-detail/doctor-document-detail.component.scss
+++ b/frontend/src/app/components/doctor-document-detail/doctor-document-detail.component.scss
@@ -216,6 +216,37 @@
   }
 }
 
+.request-error-box {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-sm);
+  padding: var(--space-md);
+  border-radius: var(--radius-md);
+  background: rgba(255, 68, 102, 0.06);
+  border: 1px solid rgba(255, 68, 102, 0.35);
+  color: var(--color-error);
+  font-size: 0.9rem;
+  margin-bottom: var(--space-sm);
+}
+
+.btn-ghost {
+  padding: 0.35rem 0.75rem;
+  border-radius: var(--radius-sm);
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  background: rgba(0, 0, 0, 0.2);
+  color: var(--text-primary);
+  font-size: 0.85rem;
+  font-weight: 600;
+  cursor: pointer;
+
+  &:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+  }
+}
+
 .failed-box {
   padding: var(--space-md);
   border-radius: var(--radius-md);
@@ -223,8 +254,44 @@
   border: 1px solid rgba(255, 68, 102, 0.3);
   color: var(--color-error);
   display: flex;
-  flex-direction: column;
-  gap: var(--space-sm);
+  flex-direction: row;
+  flex-wrap: wrap;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: var(--space-md);
+}
+
+.failed-content {
+  flex: 1 1 12rem;
+  min-width: 0;
+}
+
+.failed-detail {
+  margin: 0.35rem 0 0;
+  font-size: 0.9rem;
+  line-height: 1.45;
+  color: var(--text-secondary);
+}
+
+.btn-retry {
+  flex-shrink: 0;
+  padding: var(--space-sm) var(--space-md);
+  border-radius: var(--radius-md);
+  border: 1px solid rgba(255, 68, 102, 0.45);
+  background: rgba(255, 68, 102, 0.12);
+  color: #fecdd3;
+  font-weight: 600;
+  cursor: pointer;
+  font-size: 0.9rem;
+
+  &:disabled {
+    opacity: 0.55;
+    cursor: not-allowed;
+  }
+
+  &:not(:disabled):hover {
+    background: rgba(255, 68, 102, 0.2);
+  }
 }
 
 .summary-body {

--- a/frontend/src/app/components/doctor-document-detail/doctor-document-detail.component.spec.ts
+++ b/frontend/src/app/components/doctor-document-detail/doctor-document-detail.component.spec.ts
@@ -1,6 +1,6 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { ActivatedRoute, convertToParamMap, provideRouter } from '@angular/router';
-import { of } from 'rxjs';
+import { of, throwError } from 'rxjs';
 import { DoctorDocumentDetailComponent } from './doctor-document-detail.component';
 import { DoctorDocumentsService } from '../../services/doctor-documents.service';
 
@@ -53,5 +53,68 @@ describe('DoctorDocumentDetailComponent', () => {
     const el = fixture.nativeElement as HTMLElement;
     expect(el.querySelector('[data-cy="doctor-document-preview-section"]')).toBeTruthy();
     expect(el.querySelector('[data-cy="doctor-document-preview-placeholder"]')).toBeTruthy();
+  });
+
+  it('shows Generating on primary button when summary is pending', () => {
+    const btn = (fixture.nativeElement as HTMLElement).querySelector('[data-cy="doctor-document-summarize"]');
+    expect(btn?.textContent?.trim()).toBe('Generating…');
+  });
+
+  it('sets summaryRequestError and shows inline retry when requestSummary fails', () => {
+    serviceMock.requestSummary.and.returnValue(throwError(() => ({ error: { error: 'Rate limited' } })));
+    const comp = fixture.componentInstance;
+    comp.requestSummary();
+    expect(comp.summaryRequestError).toBe('Rate limited');
+    fixture.detectChanges();
+    const el = fixture.nativeElement as HTMLElement;
+    expect(el.querySelector('[data-cy="doctor-document-summary-request-error"]')?.textContent).toContain('Rate limited');
+    expect(el.querySelector('[data-cy="doctor-document-summary-retry-from-error"]')).toBeTruthy();
+  });
+});
+
+describe('DoctorDocumentDetailComponent (failed summary)', () => {
+  let fixture: ComponentFixture<DoctorDocumentDetailComponent>;
+  const serviceMock = {
+    getDetail: jasmine.createSpy('getDetail').and.returnValue(
+      of({
+        id: 'd1',
+        filename: 'lab.pdf',
+        patient_id: 'p1',
+        patient_email: 'p@test.com',
+        size_bytes: 1024,
+        content_type: 'application/pdf',
+        created_at: '2026-01-01T00:00:00Z',
+        summary: null,
+        summary_status: 'failed' as const,
+        summary_error: 'Extraction failed'
+      })
+    ),
+    requestSummary: jasmine.createSpy('requestSummary').and.returnValue(of({ status: 'pending' }))
+  };
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [DoctorDocumentDetailComponent],
+      providers: [
+        provideRouter([]),
+        {
+          provide: ActivatedRoute,
+          useValue: { paramMap: of(convertToParamMap({ documentId: 'd1' })) }
+        },
+        { provide: DoctorDocumentsService, useValue: serviceMock }
+      ]
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(DoctorDocumentDetailComponent);
+    fixture.detectChanges();
+  });
+
+  it('renders failed state with backend error and retry control', () => {
+    const el = fixture.nativeElement as HTMLElement;
+    expect(el.querySelector('[data-cy="doctor-document-summary-failed"]')).toBeTruthy();
+    expect(el.querySelector('[data-cy="doctor-document-summary-error-text"]')?.textContent).toContain('Extraction failed');
+    expect(el.querySelector('[data-cy="doctor-document-summary-retry"]')?.textContent?.trim()).toBe('Try again');
+    const primary = el.querySelector('[data-cy="doctor-document-summarize"]');
+    expect(primary?.textContent?.trim()).toBe('Try again');
   });
 });

--- a/frontend/src/app/components/doctor-document-detail/doctor-document-detail.component.ts
+++ b/frontend/src/app/components/doctor-document-detail/doctor-document-detail.component.ts
@@ -18,6 +18,8 @@ export class DoctorDocumentDetailComponent implements OnInit, OnDestroy {
   loading = true;
   summarizeLoading = false;
   error = '';
+  /** Last error from POST /summarize (shown inline; distinct from page load error). */
+  summaryRequestError = '';
   summarizeInfo = '';
   private documentId = '';
   private pollSub?: Subscription;
@@ -48,6 +50,7 @@ export class DoctorDocumentDetailComponent implements OnInit, OnDestroy {
   private loadInitial(): void {
     this.loading = true;
     this.error = '';
+    this.summaryRequestError = '';
     this.summarizeInfo = '';
     this.doc = null;
     this.api.getDetail(this.documentId).subscribe({
@@ -95,12 +98,14 @@ export class DoctorDocumentDetailComponent implements OnInit, OnDestroy {
     this.pollSub = undefined;
   }
 
+  /** Re-run the async summary pipeline (generate, regenerate, or retry after failure). */
   requestSummary(): void {
     if (!this.documentId || this.summarizeLoading) {
       return;
     }
     this.summarizeLoading = true;
     this.error = '';
+    this.summaryRequestError = '';
     this.summarizeInfo = '';
     this.api
       .requestSummary(this.documentId)
@@ -108,9 +113,10 @@ export class DoctorDocumentDetailComponent implements OnInit, OnDestroy {
       .subscribe({
         next: (res) => {
           if (res === null) {
-            this.error = 'Could not start summarization.';
+            this.summaryRequestError = 'Could not start summarization. Please try again.';
             return;
           }
+          this.summaryRequestError = '';
           if (res.message) {
             this.summarizeInfo = res.message;
           } else if (res.job_id) {
@@ -126,9 +132,14 @@ export class DoctorDocumentDetailComponent implements OnInit, OnDestroy {
           });
         },
         error: (err) => {
-          this.error = err?.error?.error ?? 'Could not start summarization.';
+          this.summaryRequestError = err?.error?.error ?? 'Could not start summarization. Check your connection and try again.';
         }
       });
+  }
+
+  /** Alias for template clarity on failed state. */
+  retrySummary(): void {
+    this.requestSummary();
   }
 
   formatBytes(n: number): string {
@@ -181,5 +192,26 @@ export class DoctorDocumentDetailComponent implements OnInit, OnDestroy {
       return 'Inline preview is enabled for this file type. Secure viewer endpoint will stream content in the next PR.';
     }
     return 'Inline preview is unavailable for this file type. Open/download support will use secure access flow.';
+  }
+
+  /** Primary CTA label for the summary action button. */
+  primarySummaryLabel(d: DoctorDocumentDetail): string {
+    if (this.summarizeLoading) {
+      return 'Starting…';
+    }
+    switch (d.summary_status) {
+      case 'pending':
+        return 'Generating…';
+      case 'ready':
+        return 'Regenerate summary';
+      case 'failed':
+        return 'Try again';
+      default:
+        return 'Generate summary';
+    }
+  }
+
+  primarySummaryDisabled(d: DoctorDocumentDetail): boolean {
+    return this.summarizeLoading || d.summary_status === 'pending';
   }
 }


### PR DESCRIPTION
## Summary
- add inline error state for failed POST /summarize with retry control
- add dedicated Try again control in backend failed summary block with clearer error text layout
- refine primary button labels (Try again when status is failed; keep generate/regenerate otherwise)
- expand unit tests for failed state, request errors, and pending label

## Test plan
- [x] npm run test:ci
- [x] npm run build
- [x] go test ./...
- [x] npm run cypress:e2e

Made with [Cursor](https://cursor.com)