### PR TITLE
S4 PR-22: Messaging WebSocket backend (phase4)

### DIFF
--- a/backend/go.mod
+++ b/backend/go.mod
@@ -20,6 +20,7 @@ require (
 	github.com/go-playground/universal-translator v0.18.1 // indirect
 	github.com/go-playground/validator/v10 v10.14.0 // indirect
 	github.com/goccy/go-json v0.10.2 // indirect
+	github.com/gorilla/websocket v1.5.3 // indirect
 	github.com/jackc/pgpassfile v1.0.0 // indirect
 	github.com/jackc/pgservicefile v0.0.0-20221227161230-091c0ba34f0a // indirect
 	github.com/jackc/puddle/v2 v2.2.1 // indirect

--- a/backend/go.sum
+++ b/backend/go.sum
@@ -32,6 +32,8 @@ github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
 github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
+github.com/gorilla/websocket v1.5.3 h1:saDtZ6Pbx/0u+bgYQ3q96pZgCzfhKXGPqt7kZ72aNNg=
+github.com/gorilla/websocket v1.5.3/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 github.com/jackc/pgpassfile v1.0.0 h1:/6Hmqy13Ss2zCq62VdNG8tM1wchn8zjSGOBJ6icpsIM=
 github.com/jackc/pgpassfile v1.0.0/go.mod h1:CEx0iS5ambNFdcRtxPj5JhEz+xB6uRky5eyVu/W2HEg=
 github.com/jackc/pgservicefile v0.0.0-20221227161230-091c0ba34f0a h1:bbPeKD0xmW/Y25WS6cokEszi5g+S0QxI/d45PkRi7Nk=

--- a/backend/handlers/auth.go
+++ b/backend/handlers/auth.go
@@ -166,6 +166,24 @@ func (h *AuthHandler) createToken(id uuid.UUID, email, role string) (string, err
 	return token.SignedString(h.JWTSecret)
 }
 
+// ParseJWTClaims validates a raw JWT string (used by WebSocket token auth).
+func (h *AuthHandler) ParseJWTClaims(rawToken string) (*Claims, error) {
+	token, err := jwt.ParseWithClaims(rawToken, &Claims{}, func(t *jwt.Token) (interface{}, error) {
+		if _, ok := t.Method.(*jwt.SigningMethodHMAC); !ok {
+			return nil, errors.New("unexpected signing method")
+		}
+		return h.JWTSecret, nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	claims, ok := token.Claims.(*Claims)
+	if !ok || !token.Valid {
+		return nil, errors.New("invalid claims")
+	}
+	return claims, nil
+}
+
 func (h *AuthHandler) RequireAuth() gin.HandlerFunc {
 	return func(c *gin.Context) {
 		auth := c.GetHeader("Authorization")

--- a/backend/handlers/auth_integration_test.go
+++ b/backend/handlers/auth_integration_test.go
@@ -78,6 +78,30 @@ func TestRequireAuthRole_AllowedRole_Returns200(t *testing.T) {
 	}
 }
 
+func TestParseJWTClaims_RoundTrip(t *testing.T) {
+	auth := NewAuthHandler("test-secret-key-for-jwt-parse-tests-xx")
+	id := uuid.New()
+	tok, err := auth.createToken(id, "patient@test.local", "patient")
+	if err != nil {
+		t.Fatalf("token: %v", err)
+	}
+	claims, err := auth.ParseJWTClaims(tok)
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if claims.UserID != id || claims.Role != "patient" || claims.Email != "patient@test.local" {
+		t.Fatalf("unexpected claims")
+	}
+}
+
+func TestParseJWTClaims_Invalid(t *testing.T) {
+	auth := NewAuthHandler("test-secret-key-for-jwt-parse-tests-xx")
+	_, err := auth.ParseJWTClaims("not-a-valid-jwt")
+	if err == nil {
+		t.Fatal("expected error")
+	}
+}
+
 func TestRequireAuthRole_MultiRole_AllowsEither(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 	auth := NewAuthHandler("test-secret")

--- a/backend/handlers/messaging.go
+++ b/backend/handlers/messaging.go
@@ -13,10 +13,12 @@ import (
 	"github.com/jackc/pgx/v5"
 )
 
-type MessagingHandler struct{}
+type MessagingHandler struct {
+	hub *MessagingHub
+}
 
-func NewMessagingHandler() *MessagingHandler {
-	return &MessagingHandler{}
+func NewMessagingHandler(hub *MessagingHub) *MessagingHandler {
+	return &MessagingHandler{hub: hub}
 }
 
 const maxMessageRunes = 8000
@@ -249,6 +251,10 @@ func (h *MessagingHandler) SendMessage(c *gin.Context) {
 		WHERE id = $1
 	`, threadID, msg.CreatedAt, previewText(body))
 
+	if h.hub != nil {
+		h.hub.NotifyNewMessage(ctx, threadID, msg)
+	}
+
 	c.JSON(http.StatusCreated, msg)
 }
 
@@ -373,6 +379,19 @@ func (h *MessagingHandler) CreateThread(c *gin.Context) {
 	if err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "Unable to load thread"})
 		return
+	}
+
+	if h.hub != nil {
+		var msg chatMessageRow
+		if qerr := db.Pool.QueryRow(ctx, `
+			SELECT id, thread_id, sender_id, body, created_at
+			FROM messages
+			WHERE thread_id = $1
+			ORDER BY created_at DESC
+			LIMIT 1
+		`, threadID).Scan(&msg.ID, &msg.ThreadID, &msg.SenderID, &msg.Body, &msg.CreatedAt); qerr == nil {
+			h.hub.NotifyNewMessage(ctx, threadID, msg)
+		}
 	}
 
 	c.JSON(http.StatusCreated, row)

--- a/backend/handlers/messaging_hub.go
+++ b/backend/handlers/messaging_hub.go
@@ -1,0 +1,85 @@
+package handlers
+
+import (
+	"context"
+	"encoding/json"
+	"sync"
+
+	"github.com/google/uuid"
+	"github.com/healthonyx/backend/db"
+)
+
+// MessagingHub tracks authenticated WebSocket connections per user and pushes JSON events (e.g. new_message).
+type MessagingHub struct {
+	mu         sync.RWMutex
+	clients    map[uuid.UUID]map[*wsClient]bool
+	register   chan *wsClient
+	unregister chan *wsClient
+}
+
+func NewMessagingHub() *MessagingHub {
+	return &MessagingHub{
+		clients:    make(map[uuid.UUID]map[*wsClient]bool),
+		register:   make(chan *wsClient),
+		unregister: make(chan *wsClient),
+	}
+}
+
+// Run processes registration lifecycle until Stop is integrated (runs forever).
+func (h *MessagingHub) Run() {
+	for {
+		select {
+		case client := <-h.register:
+			if h.clients[client.userID] == nil {
+				h.clients[client.userID] = make(map[*wsClient]bool)
+			}
+			h.clients[client.userID][client] = true
+		case client := <-h.unregister:
+			if m, ok := h.clients[client.userID]; ok {
+				delete(m, client)
+				if len(m) == 0 {
+					delete(h.clients, client.userID)
+				}
+			}
+		}
+	}
+}
+
+// NotifyNewMessage notifies both thread participants over WebSocket (best-effort).
+func (h *MessagingHub) NotifyNewMessage(ctx context.Context, threadID uuid.UUID, msg chatMessageRow) {
+	if h == nil {
+		return
+	}
+	var patientID, doctorID uuid.UUID
+	err := db.Pool.QueryRow(ctx, `
+		SELECT patient_id, doctor_id FROM message_threads WHERE id = $1
+	`, threadID).Scan(&patientID, &doctorID)
+	if err != nil {
+		return
+	}
+	payload, err := json.Marshal(map[string]interface{}{
+		"type":      "new_message",
+		"thread_id": threadID.String(),
+		"message":   msg,
+	})
+	if err != nil {
+		return
+	}
+
+	h.mu.RLock()
+	var targets []*wsClient
+	for _, uid := range []uuid.UUID{patientID, doctorID} {
+		for c := range h.clients[uid] {
+			targets = append(targets, c)
+		}
+	}
+	h.mu.RUnlock()
+
+	for _, c := range targets {
+		select {
+		case c.send <- payload:
+		default:
+			// Slow consumer — skip this tick (polling fallback still works).
+		}
+	}
+}

--- a/backend/handlers/messaging_test.go
+++ b/backend/handlers/messaging_test.go
@@ -53,7 +53,7 @@ func TestUnreadTotal_Unauthorized(t *testing.T) {
 	c, _ := gin.CreateTestContext(w)
 	c.Request = httptest.NewRequest("GET", "/api/messages/unread", nil)
 
-	h := NewMessagingHandler()
+	h := NewMessagingHandler(nil)
 	h.UnreadTotal(c)
 
 	if w.Code != http.StatusUnauthorized {
@@ -73,7 +73,7 @@ func TestListMessages_InvalidThreadUUID(t *testing.T) {
 		Role:   "patient",
 	})
 
-	h := NewMessagingHandler()
+	h := NewMessagingHandler(nil)
 	h.ListMessages(c)
 
 	if w.Code != http.StatusBadRequest {
@@ -94,7 +94,7 @@ func TestSendMessage_InvalidJSON(t *testing.T) {
 		Role:   "patient",
 	})
 
-	h := NewMessagingHandler()
+	h := NewMessagingHandler(nil)
 	h.SendMessage(c)
 
 	if w.Code != http.StatusBadRequest {
@@ -115,7 +115,7 @@ func TestCreateThread_InvalidPeerUUID(t *testing.T) {
 		Role:   "patient",
 	})
 
-	h := NewMessagingHandler()
+	h := NewMessagingHandler(nil)
 	h.CreateThread(c)
 
 	if w.Code != http.StatusBadRequest {

--- a/backend/handlers/messaging_ws.go
+++ b/backend/handlers/messaging_ws.go
@@ -1,0 +1,106 @@
+package handlers
+
+import (
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
+	"github.com/gorilla/websocket"
+)
+
+type wsClient struct {
+	hub    *MessagingHub
+	userID uuid.UUID
+	conn   *websocket.Conn
+	send   chan []byte
+}
+
+var wsUpgrader = websocket.Upgrader{
+	ReadBufferSize:  1024,
+	WriteBufferSize: 1024,
+	CheckOrigin: func(r *http.Request) bool {
+		return true // browsers send Origin; tighten alongside API CORS in production
+	},
+}
+
+func (c *wsClient) readPump() {
+	defer func() {
+		if c.hub != nil {
+			c.hub.unregister <- c
+		}
+		_ = c.conn.Close()
+	}()
+	_ = c.conn.SetReadDeadline(time.Now().Add(60 * time.Second))
+	c.conn.SetPongHandler(func(string) error {
+		return c.conn.SetReadDeadline(time.Now().Add(60 * time.Second))
+	})
+	for {
+		_, _, err := c.conn.ReadMessage()
+		if err != nil {
+			break
+		}
+	}
+}
+
+func (c *wsClient) writePump() {
+	ticker := time.NewTicker(30 * time.Second)
+	defer ticker.Stop()
+	for {
+		select {
+		case msg, ok := <-c.send:
+			if !ok {
+				return
+			}
+			_ = c.conn.SetWriteDeadline(time.Now().Add(10 * time.Second))
+			if err := c.conn.WriteMessage(websocket.TextMessage, msg); err != nil {
+				return
+			}
+		case <-ticker.C:
+			_ = c.conn.SetWriteDeadline(time.Now().Add(10 * time.Second))
+			if err := c.conn.WriteMessage(websocket.PingMessage, nil); err != nil {
+				return
+			}
+		}
+	}
+}
+
+// ServeWebSocket upgrades GET /ws with query token=<JWT>.
+func (mh *MessagingHandler) ServeWebSocket(auth *AuthHandler) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		if mh.hub == nil {
+			c.JSON(http.StatusServiceUnavailable, gin.H{"error": "Realtime messaging unavailable"})
+			return
+		}
+		token := strings.TrimSpace(c.Query("token"))
+		if token == "" {
+			c.JSON(http.StatusUnauthorized, gin.H{"error": "token query parameter required"})
+			return
+		}
+		claims, err := auth.ParseJWTClaims(token)
+		if err != nil {
+			c.JSON(http.StatusUnauthorized, gin.H{"error": "Invalid token"})
+			return
+		}
+		if claims.Role != "patient" && claims.Role != "doctor" {
+			c.JSON(http.StatusForbidden, gin.H{"error": "Forbidden"})
+			return
+		}
+
+		conn, err := wsUpgrader.Upgrade(c.Writer, c.Request, nil)
+		if err != nil {
+			return
+		}
+
+		client := &wsClient{
+			hub:    mh.hub,
+			userID: claims.UserID,
+			conn:   conn,
+			send:   make(chan []byte, 256),
+		}
+		mh.hub.register <- client
+		go client.writePump()
+		go client.readPump()
+	}
+}

--- a/backend/handlers/messaging_ws_test.go
+++ b/backend/handlers/messaging_ws_test.go
@@ -1,0 +1,58 @@
+package handlers
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
+)
+
+func TestServeWebSocket_MissingToken(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	auth := NewAuthHandler("test-secret-key-for-jwt-parse-tests-xx")
+	hub := NewMessagingHub()
+	mh := NewMessagingHandler(hub)
+	h := mh.ServeWebSocket(auth)
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest(http.MethodGet, "/api/messages/ws", nil)
+	h(c)
+	if w.Code != http.StatusUnauthorized {
+		t.Fatalf("expected 401, got %d body=%s", w.Code, w.Body.String())
+	}
+}
+
+func TestServeWebSocket_HubNil(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	auth := NewAuthHandler("test-secret-key-for-jwt-parse-tests-xx")
+	mh := NewMessagingHandler(nil)
+	h := mh.ServeWebSocket(auth)
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest(http.MethodGet, "/api/messages/ws?token=x", nil)
+	h(c)
+	if w.Code != http.StatusServiceUnavailable {
+		t.Fatalf("expected 503, got %d", w.Code)
+	}
+}
+
+func TestServeWebSocket_AdminForbidden(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	auth := NewAuthHandler("test-secret-key-for-jwt-parse-tests-xx")
+	tok, err := auth.createToken(uuid.New(), "admin@test.local", "admin")
+	if err != nil {
+		t.Fatal(err)
+	}
+	hub := NewMessagingHub()
+	mh := NewMessagingHandler(hub)
+	h := mh.ServeWebSocket(auth)
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest(http.MethodGet, "/api/messages/ws?token="+tok, nil)
+	h(c)
+	if w.Code != http.StatusForbidden {
+		t.Fatalf("expected 403, got %d body=%s", w.Code, w.Body.String())
+	}
+}

--- a/backend/main.go
+++ b/backend/main.go
@@ -41,7 +41,9 @@ func main() {
 	apptComments := handlers.NewAppointmentCommentsHandler()
 	documents := handlers.NewDocumentsHandler()
 	doctorDocuments := handlers.NewDoctorDocumentsHandler()
-	messaging := handlers.NewMessagingHandler()
+	msgHub := handlers.NewMessagingHub()
+	go msgHub.Run()
+	messaging := handlers.NewMessagingHandler(msgHub)
 	prescriptions := handlers.NewPrescriptionsHandler()
 	notifications := handlers.NewNotificationsHandler()
 	geo := handlers.NewGeoBookingHandler()
@@ -146,6 +148,7 @@ func main() {
 			msg.POST("/threads/:threadId/messages", messaging.SendMessage)
 			msg.POST("/threads/:threadId/read", messaging.MarkRead)
 		}
+		api.GET("/messages/ws", messaging.ServeWebSocket(auth))
 	}
 
 	addr := fmt.Sprintf(":%s", cfg.Port)


### PR DESCRIPTION
## Summary
Realtime messaging WebSocket endpoint for doctors and patients.

- **Endpoint:** \GET /api/messages/ws?token=<JWT>\ (registered outside Bearer-auth group; auth validated inside handler).
- **Hub:** Broadcasts \
ew_message\ JSON to patient + doctor after \SendMessage\ and \CreateThread\ when hub is wired.
- **Dependency:** \github.com/gorilla/websocket\.
- **Tests:** \ServeWebSocket\ (missing token, hub nil, admin forbidden); \ParseJWTClaims\ round-trip and invalid token.

## Testing
\\\
cd backend && go test ./...
\\\


Made with [Cursor](https://cursor.com)