### PR TITLE
S4 PR-23: Comments visibility model + API (phase4)

### DIFF
--- a/backend/db/db.go
+++ b/backend/db/db.go
@@ -70,6 +70,10 @@ func Migrate(ctx context.Context) error {
 
 		CREATE INDEX IF NOT EXISTS idx_appointment_comments_appt ON appointment_comments(appointment_id);
 
+		ALTER TABLE appointment_comments ADD COLUMN IF NOT EXISTS visibility TEXT NOT NULL DEFAULT 'patient_visible';
+		ALTER TABLE appointment_comments DROP CONSTRAINT IF EXISTS appointment_comments_visibility_check;
+		ALTER TABLE appointment_comments ADD CONSTRAINT appointment_comments_visibility_check CHECK (visibility IN ('internal', 'patient_visible'));
+
 		CREATE TABLE IF NOT EXISTS hospitals (
 			id         UUID PRIMARY KEY DEFAULT gen_random_uuid(),
 			name       TEXT NOT NULL,

--- a/backend/handlers/appointment_comments.go
+++ b/backend/handlers/appointment_comments.go
@@ -1,13 +1,40 @@
 package handlers
 
 import (
+	"errors"
 	"net/http"
 	"strings"
 
 	"github.com/gin-gonic/gin"
 	"github.com/google/uuid"
 	"github.com/healthonyx/backend/db"
+	"github.com/jackc/pgx/v5"
 )
+
+// Appointment comment visibility: internal (staff-only) vs shared with the patient.
+const (
+	CommentVisibilityInternal       = "internal"
+	CommentVisibilityPatientVisible = "patient_visible"
+)
+
+var (
+	errInvalidAppointmentCommentVisibility = errors.New("invalid visibility")
+	errPatientInternalCommentForbidden     = errors.New("patients cannot create internal comments")
+)
+
+func resolveCommentVisibility(role string, requested string) (string, error) {
+	s := strings.TrimSpace(strings.ToLower(requested))
+	if s == "" {
+		return CommentVisibilityPatientVisible, nil
+	}
+	if s != CommentVisibilityInternal && s != CommentVisibilityPatientVisible {
+		return "", errInvalidAppointmentCommentVisibility
+	}
+	if role == "patient" && s == CommentVisibilityInternal {
+		return "", errPatientInternalCommentForbidden
+	}
+	return s, nil
+}
 
 type AppointmentCommentsHandler struct{}
 
@@ -47,12 +74,23 @@ func (h *AppointmentCommentsHandler) List(c *gin.Context) {
 		return
 	}
 
-	rows, err := db.Pool.Query(c.Request.Context(), `
-		SELECT id::text, author_user_id::text, body, created_at::text
-		FROM appointment_comments
-		WHERE appointment_id = $1
-		ORDER BY created_at ASC
-	`, id)
+	ctx := c.Request.Context()
+	var rows pgx.Rows
+	if claims.Role == "patient" {
+		rows, err = db.Pool.Query(ctx, `
+			SELECT id::text, author_user_id::text, body, visibility, created_at::text
+			FROM appointment_comments
+			WHERE appointment_id = $1 AND visibility = $2
+			ORDER BY created_at ASC
+		`, id, CommentVisibilityPatientVisible)
+	} else {
+		rows, err = db.Pool.Query(ctx, `
+			SELECT id::text, author_user_id::text, body, visibility, created_at::text
+			FROM appointment_comments
+			WHERE appointment_id = $1
+			ORDER BY created_at ASC
+		`, id)
+	}
 	if err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "Internal error"})
 		return
@@ -60,19 +98,24 @@ func (h *AppointmentCommentsHandler) List(c *gin.Context) {
 	defer rows.Close()
 
 	type row struct {
-		ID       string `json:"id"`
-		AuthorID string `json:"author_user_id"`
-		Body     string `json:"body"`
-		Created  string `json:"created_at"`
+		ID         string `json:"id"`
+		AuthorID   string `json:"author_user_id"`
+		Body       string `json:"body"`
+		Visibility string `json:"visibility"`
+		Created    string `json:"created_at"`
 	}
 	var out []row
 	for rows.Next() {
 		var r row
-		if err := rows.Scan(&r.ID, &r.AuthorID, &r.Body, &r.Created); err != nil {
+		if err := rows.Scan(&r.ID, &r.AuthorID, &r.Body, &r.Visibility, &r.Created); err != nil {
 			c.JSON(http.StatusInternalServerError, gin.H{"error": "Internal error"})
 			return
 		}
 		out = append(out, r)
+	}
+	if err := rows.Err(); err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Internal error"})
+		return
 	}
 	if out == nil {
 		out = []row{}
@@ -81,7 +124,8 @@ func (h *AppointmentCommentsHandler) List(c *gin.Context) {
 }
 
 type postCommentBody struct {
-	Body string `json:"body" binding:"required"`
+	Body       string `json:"body" binding:"required"`
+	Visibility string `json:"visibility"` // optional: internal | patient_visible (default patient_visible)
 }
 
 func (h *AppointmentCommentsHandler) Create(c *gin.Context) {
@@ -110,14 +154,24 @@ func (h *AppointmentCommentsHandler) Create(c *gin.Context) {
 		return
 	}
 
+	visibility, visErr := resolveCommentVisibility(claims.Role, body.Visibility)
+	if visErr != nil {
+		if errors.Is(visErr, errPatientInternalCommentForbidden) {
+			c.JSON(http.StatusForbidden, gin.H{"error": "Patients cannot create internal comments"})
+			return
+		}
+		c.JSON(http.StatusBadRequest, gin.H{"error": "visibility must be internal or patient_visible"})
+		return
+	}
+
 	var cid string
 	err = db.Pool.QueryRow(c.Request.Context(), `
-		INSERT INTO appointment_comments (appointment_id, author_user_id, body)
-		VALUES ($1, $2, $3) RETURNING id::text
-	`, id, claims.UserID, text).Scan(&cid)
+		INSERT INTO appointment_comments (appointment_id, author_user_id, body, visibility)
+		VALUES ($1, $2, $3, $4) RETURNING id::text
+	`, id, claims.UserID, text, visibility).Scan(&cid)
 	if err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "Internal error"})
 		return
 	}
-	c.JSON(http.StatusCreated, gin.H{"id": cid})
+	c.JSON(http.StatusCreated, gin.H{"id": cid, "visibility": visibility})
 }

--- a/backend/handlers/appointment_comments_test.go
+++ b/backend/handlers/appointment_comments_test.go
@@ -1,6 +1,7 @@
 package handlers
 
 import (
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -8,6 +9,41 @@ import (
 	"github.com/gin-gonic/gin"
 	"github.com/google/uuid"
 )
+
+func TestResolveCommentVisibility_DefaultPatientVisible(t *testing.T) {
+	v, err := resolveCommentVisibility("patient", "")
+	if err != nil || v != CommentVisibilityPatientVisible {
+		t.Fatalf("got %q err=%v", v, err)
+	}
+}
+
+func TestResolveCommentVisibility_PatientCannotUseInternal(t *testing.T) {
+	_, err := resolveCommentVisibility("patient", "internal")
+	if !errors.Is(err, errPatientInternalCommentForbidden) {
+		t.Fatalf("expected forbidden: %v", err)
+	}
+}
+
+func TestResolveCommentVisibility_DoctorInternalOK(t *testing.T) {
+	v, err := resolveCommentVisibility("doctor", "internal")
+	if err != nil || v != CommentVisibilityInternal {
+		t.Fatalf("got %q err=%v", v, err)
+	}
+}
+
+func TestResolveCommentVisibility_AdminPatientVisibleAlias(t *testing.T) {
+	v, err := resolveCommentVisibility("admin", "patient_visible")
+	if err != nil || v != CommentVisibilityPatientVisible {
+		t.Fatalf("got %q err=%v", v, err)
+	}
+}
+
+func TestResolveCommentVisibility_Invalid(t *testing.T) {
+	_, err := resolveCommentVisibility("doctor", "secret")
+	if !errors.Is(err, errInvalidAppointmentCommentVisibility) {
+		t.Fatalf("expected invalid: %v", err)
+	}
+}
 
 func TestAppointmentComments_List_InvalidUUID(t *testing.T) {
 	gin.SetMode(gin.TestMode)


### PR DESCRIPTION
## Summary (Kaushik, BE — \phase4/comments-model-api-visibility\)

Adds **internal** vs **patient-visible** appointment comments aligned with roadmap (internal vs patient-visible).

### Data model
- \ppointment_comments.visibility\: \internal\ \| \patient_visible\ (default \patient_visible\), enforced with CHECK constraint.

### API behavior
- **GET** \/api/appointments/:id/comments\: **patients** receive only \patient_visible\ rows; **doctors** and **admins** receive all comments for the appointment. Each item includes \isibility\.
- **POST** \/api/appointments/:id/comments\: optional JSON \isibility\. **Patients** may only create \patient_visible\ (default); **doctor/admin** may set \internal\ for staff-only notes. **403** if a patient requests \internal\.

### Tests
\go test ./...\ under \ackend/\ (includes \esolveCommentVisibility\ unit tests).

### Note
Local **app-shell** frontend edits remain uncommitted for the next frontend story (per team direction).

Made with [Cursor](https://cursor.com)