### PR TITLE
S5 PR-25: Dashboard aggregations + alerts API (phase5)

### DIFF
--- a/backend/handlers/dashboard.go
+++ b/backend/handlers/dashboard.go
@@ -1,9 +1,11 @@
 package handlers
 
 import (
+	"context"
 	"net/http"
 
 	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
 	"github.com/healthonyx/backend/db"
 )
 
@@ -11,6 +13,96 @@ type DashboardHandler struct{}
 
 func NewDashboardHandler() *DashboardHandler {
 	return &DashboardHandler{}
+}
+
+// aggregateUnreadMessages matches GET /api/messages/unread logic for embedding in dashboard payloads.
+func aggregateUnreadMessages(ctx context.Context, userID uuid.UUID) (int, error) {
+	var total int
+	err := db.Pool.QueryRow(ctx, `
+		SELECT COALESCE(SUM(sub.c), 0)::int
+		FROM (
+			SELECT (
+				SELECT COUNT(*)::int
+				FROM messages m
+				WHERE m.thread_id = mt.id
+				  AND m.sender_id <> $1
+				  AND m.created_at > COALESCE(
+					(SELECT r.last_read_at FROM message_thread_reads r
+					 WHERE r.thread_id = mt.id AND r.user_id = $1),
+					'-infinity'::timestamptz
+				  )
+			) AS c
+			FROM message_threads mt
+			WHERE mt.patient_id = $1 OR mt.doctor_id = $1
+		) sub
+	`, userID).Scan(&total)
+	return total, err
+}
+
+func buildPatientAlerts(upcoming, pending, unread int) []gin.H {
+	out := []gin.H{}
+	if pending > 0 {
+		out = append(out, gin.H{
+			"severity": "warning",
+			"code":     "pending_appointment_requests",
+			"message":  "You have appointment requests awaiting confirmation.",
+			"count":    pending,
+		})
+	}
+	if unread > 0 {
+		sev := "info"
+		if unread >= 10 {
+			sev = "warning"
+		}
+		out = append(out, gin.H{
+			"severity": sev,
+			"code":     "unread_messages",
+			"message":  "Unread messages in your inbox.",
+			"count":    unread,
+		})
+	}
+	if upcoming > 3 && pending == 0 {
+		out = append(out, gin.H{
+			"severity": "info",
+			"code":     "busy_schedule",
+			"message":  "You have several upcoming appointments on your calendar.",
+			"count":    upcoming,
+		})
+	}
+	return out
+}
+
+func buildDoctorAlerts(today, pending, unread int) []gin.H {
+	out := []gin.H{}
+	if pending > 0 {
+		out = append(out, gin.H{
+			"severity": "warning",
+			"code":     "pending_queue",
+			"message":  "Appointment requests need your review.",
+			"count":    pending,
+		})
+	}
+	if unread > 0 {
+		sev := "info"
+		if unread >= 10 {
+			sev = "warning"
+		}
+		out = append(out, gin.H{
+			"severity": sev,
+			"code":     "unread_messages",
+			"message":  "Unread messages from patients.",
+			"count":    unread,
+		})
+	}
+	if today >= 8 {
+		out = append(out, gin.H{
+			"severity": "warning",
+			"code":     "heavy_clinic_day",
+			"message":  "Many appointments scheduled for today.",
+			"count":    today,
+		})
+	}
+	return out
 }
 
 func (h *DashboardHandler) PatientSummary(c *gin.Context) {
@@ -23,18 +115,53 @@ func (h *DashboardHandler) PatientSummary(c *gin.Context) {
 		return
 	}
 
+	ctx := c.Request.Context()
 	var upcoming, pending int
-	_ = db.Pool.QueryRow(c.Request.Context(), `
+	err := db.Pool.QueryRow(ctx, `
 		SELECT
-			COUNT(*) FILTER (WHERE status IN ('pending','approved') AND scheduled_at >= NOW()),
-			COUNT(*) FILTER (WHERE status = 'pending')
+			COUNT(*) FILTER (WHERE status IN ('pending','approved') AND scheduled_at >= NOW())::int,
+			COUNT(*) FILTER (WHERE status = 'pending')::int
 		FROM appointments WHERE patient_id = $1
 	`, claims.UserID).Scan(&upcoming, &pending)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Internal error"})
+		return
+	}
+
+	unread, err := aggregateUnreadMessages(ctx, claims.UserID)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Internal error"})
+		return
+	}
+
+	var rxCount int
+	if err := db.Pool.QueryRow(ctx, `
+		SELECT COUNT(*)::int FROM prescriptions WHERE patient_id = $1 AND status = 'active'
+	`, claims.UserID).Scan(&rxCount); err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Internal error"})
+		return
+	}
+
+	var docCount int
+	if err := db.Pool.QueryRow(ctx, `
+		SELECT COUNT(*)::int FROM patient_documents WHERE patient_id = $1
+	`, claims.UserID).Scan(&docCount); err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Internal error"})
+		return
+	}
+
+	alerts := buildPatientAlerts(upcoming, pending, unread)
 
 	c.JSON(http.StatusOK, gin.H{
 		"role":                     "patient",
 		"upcoming_or_active_count": upcoming,
 		"pending_requests":         pending,
+		"aggregations": gin.H{
+			"unread_messages":      unread,
+			"active_prescriptions": rxCount,
+			"documents_uploaded":   docCount,
+		},
+		"alerts": alerts,
 	})
 }
 
@@ -48,17 +175,44 @@ func (h *DashboardHandler) DoctorSummary(c *gin.Context) {
 		return
 	}
 
-	var today, pending int
-	_ = db.Pool.QueryRow(c.Request.Context(), `
+	ctx := c.Request.Context()
+	var today, pending, week int
+	err := db.Pool.QueryRow(ctx, `
 		SELECT
-			COUNT(*) FILTER (WHERE scheduled_at >= CURRENT_DATE AND scheduled_at < CURRENT_DATE + INTERVAL '1 day' AND status IN ('pending','approved')),
-			COUNT(*) FILTER (WHERE status = 'pending')
+			COUNT(*) FILTER (
+				WHERE scheduled_at >= CURRENT_DATE
+				  AND scheduled_at < CURRENT_DATE + INTERVAL '1 day'
+				  AND status IN ('pending','approved')
+			)::int,
+			COUNT(*) FILTER (WHERE status = 'pending')::int,
+			COUNT(*) FILTER (
+				WHERE scheduled_at >= date_trunc('week', CURRENT_TIMESTAMP)
+				  AND scheduled_at < date_trunc('week', CURRENT_TIMESTAMP) + INTERVAL '7 days'
+				  AND status IN ('pending','approved','completed','no_show','reschedule_requested')
+			)::int
 		FROM appointments WHERE doctor_id = $1
-	`, claims.UserID).Scan(&today, &pending)
+	`, claims.UserID).Scan(&today, &pending, &week)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Internal error"})
+		return
+	}
+
+	unread, err := aggregateUnreadMessages(ctx, claims.UserID)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Internal error"})
+		return
+	}
+
+	alerts := buildDoctorAlerts(today, pending, unread)
 
 	c.JSON(http.StatusOK, gin.H{
-		"role":            "doctor",
+		"role":               "doctor",
 		"appointments_today": today,
 		"pending_queue":      pending,
+		"aggregations": gin.H{
+			"unread_messages":        unread,
+			"appointments_this_week": week,
+		},
+		"alerts": alerts,
 	})
 }

--- a/backend/handlers/dashboard_test.go
+++ b/backend/handlers/dashboard_test.go
@@ -23,3 +23,24 @@ func TestDashboard_PatientSummary_ForbiddenForDoctor(t *testing.T) {
 		t.Fatalf("expected 403, got %d", w.Code)
 	}
 }
+
+func TestBuildPatientAlerts_PendingUnread(t *testing.T) {
+	a := buildPatientAlerts(1, 2, 5)
+	if len(a) < 2 {
+		t.Fatalf("expected pending + unread alerts, got %d", len(a))
+	}
+}
+
+func TestBuildDoctorAlerts_HeavyDay(t *testing.T) {
+	a := buildDoctorAlerts(10, 0, 0)
+	found := false
+	for _, x := range a {
+		if x["code"] == "heavy_clinic_day" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatal("expected heavy_clinic_day alert")
+	}
+}


### PR DESCRIPTION
## Summary (Kaushik, BE — phase5/dashboard-aggregations-alerts-api)

Adds **aggregations** and **alerts** to existing dashboard summaries (backward-compatible top-level keys unchanged).

### Patient `GET /api/patient/dashboard/summary`
- **aggregations**: `unread_messages`, `active_prescriptions`, `documents_uploaded`
- **alerts**: e.g. pending requests, unread messages (warning if count high), busy schedule info

### Doctor `GET /api/doctor/dashboard/summary`
- **aggregations**: `unread_messages`, `appointments_this_week`
- **alerts**: pending queue, unread messages, heavy clinic day (many appointments today)

Unread counts use the same logic as `/api/messages/unread`.

### Tests
`cd backend && go test ./...`
