### PR TITLE
S5 PR-26: Patient dashboard charts + insights UI (phase5)

### DIFF
--- a/frontend/src/app/components/patient-dashboard/patient-dashboard.component.html
+++ b/frontend/src/app/components/patient-dashboard/patient-dashboard.component.html
@@ -1,0 +1,91 @@
+<section class="dash" data-cy="patient-dashboard">
+  <header class="dash-head">
+    <h1>Dashboard</h1>
+    <p class="dash-sub">Your care snapshot — appointments, messages, and records at a glance.</p>
+  </header>
+
+  <p *ngIf="error" class="err">{{ error }}</p>
+
+  <ng-container *ngIf="data">
+    <div class="cards" data-cy="patient-dashboard-stats">
+      <div class="card card--accent">
+        <span class="num">{{ data.upcoming_or_active_count }}</span>
+        <span class="lbl">Upcoming / active</span>
+      </div>
+      <div class="card">
+        <span class="num">{{ data.pending_requests }}</span>
+        <span class="lbl">Pending requests</span>
+      </div>
+      <ng-container *ngIf="data.aggregations as agg">
+        <div class="card">
+          <span class="num">{{ agg.unread_messages }}</span>
+          <span class="lbl">Unread messages</span>
+        </div>
+        <div class="card">
+          <span class="num">{{ agg.active_prescriptions }}</span>
+          <span class="lbl">Active prescriptions</span>
+        </div>
+        <div class="card">
+          <span class="num">{{ agg.documents_uploaded }}</span>
+          <span class="lbl">Documents</span>
+        </div>
+      </ng-container>
+    </div>
+
+    <div class="insights-grid">
+      <div class="panel chart-panel" data-cy="patient-dashboard-chart">
+        <h2>Activity balance</h2>
+        <p class="panel-hint">Relative mix of scheduled care, requests, inbox, and records.</p>
+        <div class="donut-wrap" aria-hidden="true">
+          <div class="donut-ring" [style.background]="pieBackground"></div>
+          <div class="donut-hole"></div>
+        </div>
+        <ul class="legend">
+          <li><span class="swatch swatch--up"></span> Upcoming / active</li>
+          <li><span class="swatch swatch--pend"></span> Pending requests</li>
+          <li><span class="swatch swatch--msg"></span> Unread messages</li>
+          <li><span class="swatch swatch--rxdoc"></span> Prescriptions + documents</li>
+        </ul>
+      </div>
+
+      <div class="panel bars-panel" data-cy="patient-dashboard-bars">
+        <h2>Volume comparison</h2>
+        <p class="panel-hint">Bars scale to your highest metric this period.</p>
+        <div class="bar-row" *ngFor="let row of barRows">
+          <span class="bar-label">{{ row.label }}</span>
+          <div class="bar-track">
+            <div class="bar-fill" [style.width.%]="row.pct"></div>
+          </div>
+          <span class="bar-val">{{ row.value }}</span>
+        </div>
+      </div>
+    </div>
+
+    <div class="panel alerts-panel" *ngIf="data.alerts?.length" data-cy="patient-dashboard-insights">
+      <h2>Insights</h2>
+      <ul class="alert-list">
+        <li
+          *ngFor="let a of data.alerts"
+          class="alert-item"
+          [class.alert-item--warning]="a.severity === 'warning'"
+          [attr.data-cy]="'patient-alert-' + a.code"
+        >
+          <span class="alert-ic" aria-hidden="true">{{ alertIcon(a.severity) }}</span>
+          <div class="alert-body">
+            <p class="alert-msg">{{ a.message }}</p>
+            <span class="alert-meta" *ngIf="a.count != null && a.count > 0">{{ a.count }}</span>
+          </div>
+        </li>
+      </ul>
+    </div>
+
+    <div
+      class="panel alerts-panel alerts-panel--empty"
+      *ngIf="data.alerts !== undefined && data.alerts.length === 0"
+      data-cy="patient-dashboard-insights-empty"
+    >
+      <h2>Insights</h2>
+      <p class="muted">No alerts right now — you’re all caught up.</p>
+    </div>
+  </ng-container>
+</section>

--- a/frontend/src/app/components/patient-dashboard/patient-dashboard.component.scss
+++ b/frontend/src/app/components/patient-dashboard/patient-dashboard.component.scss
@@ -1,0 +1,239 @@
+.dash {
+  max-width: 960px;
+  margin: 0 auto;
+  padding-bottom: 2rem;
+}
+
+.dash-head {
+  margin-bottom: 1.25rem;
+
+  h1 {
+    margin: 0 0 0.35rem;
+    font-size: 1.65rem;
+  }
+}
+
+.dash-sub {
+  margin: 0;
+  color: #94a3b8;
+  font-size: 0.95rem;
+}
+
+.err {
+  color: #f87171;
+}
+
+.cards {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 1.5rem;
+}
+
+.card {
+  border: 1px solid rgba(148, 163, 184, 0.3);
+  border-radius: 12px;
+  padding: 1rem 1.1rem;
+  min-width: 130px;
+  flex: 1 1 120px;
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  background: rgba(15, 23, 42, 0.45);
+
+  &--accent {
+    border-color: rgba(34, 197, 94, 0.35);
+    box-shadow: 0 0 0 1px rgba(34, 197, 94, 0.12);
+  }
+}
+
+.num {
+  font-size: 1.75rem;
+  font-weight: 700;
+}
+
+.lbl {
+  color: #94a3b8;
+  font-size: 0.85rem;
+}
+
+.insights-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: 1.25rem;
+  margin-bottom: 1.5rem;
+}
+
+.panel {
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  border-radius: 14px;
+  padding: 1.25rem;
+  background: rgba(15, 23, 42, 0.55);
+
+  h2 {
+    margin: 0 0 0.35rem;
+    font-size: 1.1rem;
+  }
+}
+
+.panel-hint {
+  margin: 0 0 1rem;
+  font-size: 0.82rem;
+  color: #64748b;
+}
+
+.chart-panel {
+  display: flex;
+  flex-direction: column;
+}
+
+.donut-wrap {
+  position: relative;
+  width: 200px;
+  height: 200px;
+  margin: 0 auto 1rem;
+}
+
+.donut-ring {
+  width: 100%;
+  height: 100%;
+  border-radius: 50%;
+}
+
+.donut-hole {
+  position: absolute;
+  inset: 22%;
+  border-radius: 50%;
+  background: #0f172a;
+  box-shadow: inset 0 0 0 1px rgba(148, 163, 184, 0.15);
+}
+
+.legend {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 0.35rem;
+  font-size: 0.82rem;
+  color: #cbd5e1;
+
+  li {
+    display: flex;
+    align-items: center;
+    gap: 0.45rem;
+  }
+}
+
+.swatch {
+  width: 10px;
+  height: 10px;
+  border-radius: 2px;
+  flex-shrink: 0;
+
+  &--up {
+    background: #22c55e;
+  }
+  &--pend {
+    background: #eab308;
+  }
+  &--msg {
+    background: #38bdf8;
+  }
+  &--rxdoc {
+    background: #a78bfa;
+  }
+}
+
+.bar-row {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(120px, 2fr) 2rem;
+  gap: 0.5rem 0.75rem;
+  align-items: center;
+  margin-bottom: 0.65rem;
+  font-size: 0.85rem;
+}
+
+.bar-label {
+  color: #94a3b8;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.bar-track {
+  height: 10px;
+  border-radius: 999px;
+  background: rgba(51, 65, 85, 0.8);
+  overflow: hidden;
+}
+
+.bar-fill {
+  height: 100%;
+  border-radius: 999px;
+  background: linear-gradient(90deg, #38bdf8, #6366f1);
+  transition: width 0.35s ease;
+}
+
+.bar-val {
+  text-align: right;
+  font-variant-numeric: tabular-nums;
+  font-weight: 600;
+}
+
+.alerts-panel {
+  &--empty .muted {
+    margin: 0;
+    color: #64748b;
+    font-size: 0.92rem;
+  }
+}
+
+.alert-list {
+  list-style: none;
+  margin: 0.5rem 0 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.65rem;
+}
+
+.alert-item {
+  display: flex;
+  gap: 0.65rem;
+  align-items: flex-start;
+  padding: 0.75rem 0.9rem;
+  border-radius: 10px;
+  background: rgba(56, 189, 248, 0.08);
+  border: 1px solid rgba(56, 189, 248, 0.22);
+
+  &--warning {
+    background: rgba(251, 191, 36, 0.1);
+    border-color: rgba(251, 191, 36, 0.35);
+  }
+}
+
+.alert-ic {
+  font-size: 1.1rem;
+  line-height: 1.4;
+}
+
+.alert-body {
+  flex: 1;
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: 0.75rem;
+}
+
+.alert-msg {
+  margin: 0;
+  font-size: 0.9rem;
+  color: #e2e8f0;
+}
+
+.alert-meta {
+  font-size: 0.85rem;
+  font-weight: 700;
+  color: #94a3b8;
+  font-variant-numeric: tabular-nums;
+}

--- a/frontend/src/app/components/patient-dashboard/patient-dashboard.component.spec.ts
+++ b/frontend/src/app/components/patient-dashboard/patient-dashboard.component.spec.ts
@@ -18,16 +18,25 @@ describe('PatientDashboardComponent', () => {
     httpMock.expectOne('/api/patient/dashboard/summary').flush({
       role: 'patient',
       upcoming_or_active_count: 2,
-      pending_requests: 1
+      pending_requests: 1,
+      aggregations: {
+        unread_messages: 3,
+        active_prescriptions: 1,
+        documents_uploaded: 4
+      },
+      alerts: [{ severity: 'info', code: 'unread_messages', message: 'Unread messages in your inbox.', count: 3 }]
     });
     fixture.detectChanges();
   });
 
   afterEach(() => httpMock.verify());
 
-  it('renders stats', () => {
+  it('renders stats, chart, bars, and insights', () => {
     const el = fixture.nativeElement as HTMLElement;
     expect(el.querySelector('[data-cy="patient-dashboard-stats"]')).toBeTruthy();
+    expect(el.querySelector('[data-cy="patient-dashboard-chart"]')).toBeTruthy();
+    expect(el.querySelector('[data-cy="patient-dashboard-bars"]')).toBeTruthy();
+    expect(el.querySelector('[data-cy="patient-dashboard-insights"]')).toBeTruthy();
     expect(el.textContent).toContain('2');
   });
 });

--- a/frontend/src/app/components/patient-dashboard/patient-dashboard.component.ts
+++ b/frontend/src/app/components/patient-dashboard/patient-dashboard.component.ts
@@ -2,69 +2,85 @@ import { Component, OnInit } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { DashboardService, PatientDashboardSummary } from '../../services/dashboard.service';
 
+export interface BarRow {
+  label: string;
+  value: number;
+  pct: number;
+}
+
 @Component({
   selector: 'app-patient-dashboard',
   standalone: true,
   imports: [CommonModule],
-  template: `
-    <section class="dash" data-cy="patient-dashboard">
-      <h1>Dashboard</h1>
-      <p *ngIf="error" class="err">{{ error }}</p>
-      <div *ngIf="data" class="cards" data-cy="patient-dashboard-stats">
-        <div class="card">
-          <span class="num">{{ data.upcoming_or_active_count }}</span>
-          <span class="lbl">Upcoming / active</span>
-        </div>
-        <div class="card">
-          <span class="num">{{ data.pending_requests }}</span>
-          <span class="lbl">Pending requests</span>
-        </div>
-      </div>
-    </section>
-  `,
-  styles: [
-    `
-      .dash {
-        max-width: 720px;
-      }
-      .cards {
-        display: flex;
-        gap: 1rem;
-        flex-wrap: wrap;
-      }
-      .card {
-        border: 1px solid rgba(148, 163, 184, 0.3);
-        border-radius: 10px;
-        padding: 1rem;
-        min-width: 140px;
-        display: flex;
-        flex-direction: column;
-        gap: 0.25rem;
-      }
-      .num {
-        font-size: 1.75rem;
-        font-weight: 700;
-      }
-      .lbl {
-        color: #94a3b8;
-        font-size: 0.85rem;
-      }
-      .err {
-        color: #f87171;
-      }
-    `
-  ]
+  templateUrl: './patient-dashboard.component.html',
+  styleUrl: './patient-dashboard.component.scss'
 })
 export class PatientDashboardComponent implements OnInit {
   data: PatientDashboardSummary | null = null;
   error: string | null = null;
 
+  /** Conic-gradient for the activity ring (non-zero total only). */
+  pieBackground = 'conic-gradient(#334155 0% 100%)';
+
   constructor(private dash: DashboardService) {}
 
   ngOnInit(): void {
     this.dash.patientSummary().subscribe({
-      next: (d) => (this.data = d),
+      next: (d) => {
+        this.data = d;
+        this.pieBackground = this.computePieGradient(d);
+      },
       error: () => (this.error = 'Could not load summary')
     });
+  }
+
+  get barRows(): BarRow[] {
+    const d = this.data;
+    if (!d) {
+      return [];
+    }
+    const agg = d.aggregations;
+    const rows = [
+      { label: 'Upcoming / active', value: d.upcoming_or_active_count },
+      { label: 'Pending requests', value: d.pending_requests },
+      { label: 'Unread messages', value: agg?.unread_messages ?? 0 },
+      { label: 'Active prescriptions', value: agg?.active_prescriptions ?? 0 },
+      { label: 'Documents', value: agg?.documents_uploaded ?? 0 }
+    ];
+    const max = Math.max(...rows.map((r) => r.value), 1);
+    return rows.map((r) => ({
+      ...r,
+      pct: Math.round((r.value / max) * 100)
+    }));
+  }
+
+  private computePieGradient(d: PatientDashboardSummary): string {
+    const agg = d.aggregations;
+    const parts: { color: string; value: number }[] = [
+      { color: '#22c55e', value: d.upcoming_or_active_count },
+      { color: '#eab308', value: d.pending_requests },
+      { color: '#38bdf8', value: agg?.unread_messages ?? 0 },
+      { color: '#a78bfa', value: (agg?.active_prescriptions ?? 0) + (agg?.documents_uploaded ?? 0) }
+    ];
+    const sum = parts.reduce((s, p) => s + p.value, 0);
+    if (sum <= 0) {
+      return 'conic-gradient(#334155 0% 100%)';
+    }
+    let acc = 0;
+    const stops: string[] = [];
+    for (const p of parts) {
+      const pct = (p.value / sum) * 100;
+      if (pct <= 0) {
+        continue;
+      }
+      const start = acc;
+      acc += pct;
+      stops.push(`${p.color} ${start}% ${acc}%`);
+    }
+    return `conic-gradient(${stops.join(', ')})`;
+  }
+
+  alertIcon(sev: string): string {
+    return sev === 'warning' ? '⚠' : 'ⓘ';
   }
 }

--- a/frontend/src/app/services/dashboard.service.ts
+++ b/frontend/src/app/services/dashboard.service.ts
@@ -3,10 +3,28 @@ import { HttpClient } from '@angular/common/http';
 import { Observable } from 'rxjs';
 import { ApiContract } from './api-contract';
 
+/** Matches backend PR-25 dashboard alerts. */
+export type DashboardAlertSeverity = 'info' | 'warning';
+
+export interface DashboardAlert {
+  severity: DashboardAlertSeverity;
+  code: string;
+  message: string;
+  count?: number;
+}
+
+export interface PatientDashboardAggregations {
+  unread_messages: number;
+  active_prescriptions: number;
+  documents_uploaded: number;
+}
+
 export interface PatientDashboardSummary {
   role: string;
   upcoming_or_active_count: number;
   pending_requests: number;
+  aggregations?: PatientDashboardAggregations;
+  alerts?: DashboardAlert[];
 }
 
 export interface DoctorDashboardSummary {


### PR DESCRIPTION
﻿## PR-26 (Abhinav, FE) phase5/patient-dashboard-charts-insights-ui

- Patient dashboard: activity balance donut (CSS conic-gradient), volume comparison bars, Insights section from API alerts.
- dashboard.service: types for aggregations, alerts, severity.
- No new chart.js dependency; data-cy hooks for tests.

Verify: cd frontend; npm run test:ci; npm run build
