### PR TITLE
S5 PR-27: Doctor dashboard workload + alerts UI (phase5)

### DIFF
--- a/frontend/src/app/components/doctor-dashboard/doctor-dashboard.component.html
+++ b/frontend/src/app/components/doctor-dashboard/doctor-dashboard.component.html
@@ -1,0 +1,87 @@
+<section class="dash" data-cy="doctor-dashboard">
+  <header class="dash-head">
+    <h1>Dashboard</h1>
+    <p class="dash-sub">Clinic workload snapshot — today’s load, queue, inbox, and weekly volume.</p>
+  </header>
+
+  <p *ngIf="error" class="err">{{ error }}</p>
+
+  <ng-container *ngIf="data">
+    <div class="cards" data-cy="doctor-dashboard-stats">
+      <div class="card card--today">
+        <span class="num">{{ data.appointments_today }}</span>
+        <span class="lbl">Today (scheduled)</span>
+      </div>
+      <div class="card">
+        <span class="num">{{ data.pending_queue }}</span>
+        <span class="lbl">Pending queue</span>
+      </div>
+      <ng-container *ngIf="data.aggregations as agg">
+        <div class="card">
+          <span class="num">{{ agg.unread_messages }}</span>
+          <span class="lbl">Unread messages</span>
+        </div>
+        <div class="card">
+          <span class="num">{{ agg.appointments_this_week }}</span>
+          <span class="lbl">This week</span>
+        </div>
+      </ng-container>
+    </div>
+
+    <div class="workload-grid">
+      <div class="panel chart-panel" data-cy="doctor-dashboard-workload-ring">
+        <h2>Workload mix</h2>
+        <p class="panel-hint">Relative weight of today, queue, inbox, and weekly appointments.</p>
+        <div class="donut-wrap" aria-hidden="true">
+          <div class="donut-ring" [style.background]="pieBackground"></div>
+          <div class="donut-hole"></div>
+        </div>
+        <ul class="legend">
+          <li><span class="swatch swatch--today"></span> Today</li>
+          <li><span class="swatch swatch--queue"></span> Pending queue</li>
+          <li><span class="swatch swatch--msg"></span> Unread messages</li>
+          <li><span class="swatch swatch--week"></span> This week</li>
+        </ul>
+      </div>
+
+      <div class="panel bars-panel" data-cy="doctor-dashboard-workload-bars">
+        <h2>Volume comparison</h2>
+        <p class="panel-hint">Bars scale to your highest metric.</p>
+        <div class="bar-row" *ngFor="let row of barRows">
+          <span class="bar-label">{{ row.label }}</span>
+          <div class="bar-track">
+            <div class="bar-fill" [style.width.%]="row.pct"></div>
+          </div>
+          <span class="bar-val">{{ row.value }}</span>
+        </div>
+      </div>
+    </div>
+
+    <div class="panel alerts-panel" *ngIf="data.alerts && data.alerts.length > 0" data-cy="doctor-dashboard-alerts">
+      <h2>Alerts</h2>
+      <ul class="alert-list">
+        <li
+          *ngFor="let a of data.alerts"
+          class="alert-item"
+          [class.alert-item--warning]="a.severity === 'warning'"
+          [attr.data-cy]="'doctor-alert-' + a.code"
+        >
+          <span class="alert-ic" aria-hidden="true">{{ alertIcon(a.severity) }}</span>
+          <div class="alert-body">
+            <p class="alert-msg">{{ a.message }}</p>
+            <span class="alert-meta" *ngIf="a.count != null && a.count > 0">{{ a.count }}</span>
+          </div>
+        </li>
+      </ul>
+    </div>
+
+    <div
+      class="panel alerts-panel alerts-panel--empty"
+      *ngIf="data.alerts !== undefined && data.alerts.length === 0"
+      data-cy="doctor-dashboard-alerts-empty"
+    >
+      <h2>Alerts</h2>
+      <p class="muted">No alerts — queue and inbox look clear.</p>
+    </div>
+  </ng-container>
+</section>

--- a/frontend/src/app/components/doctor-dashboard/doctor-dashboard.component.scss
+++ b/frontend/src/app/components/doctor-dashboard/doctor-dashboard.component.scss
@@ -1,0 +1,234 @@
+.dash {
+  max-width: 960px;
+  margin: 0 auto;
+  padding-bottom: 2rem;
+}
+
+.dash-head {
+  margin-bottom: 1.25rem;
+
+  h1 {
+    margin: 0 0 0.35rem;
+    font-size: 1.65rem;
+  }
+}
+
+.dash-sub {
+  margin: 0;
+  color: #94a3b8;
+  font-size: 0.95rem;
+}
+
+.err {
+  color: #f87171;
+}
+
+.cards {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 1.5rem;
+}
+
+.card {
+  border: 1px solid rgba(148, 163, 184, 0.3);
+  border-radius: 12px;
+  padding: 1rem 1.1rem;
+  min-width: 130px;
+  flex: 1 1 120px;
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  background: rgba(15, 23, 42, 0.45);
+
+  &--today {
+    border-color: rgba(245, 158, 11, 0.4);
+    box-shadow: 0 0 0 1px rgba(245, 158, 11, 0.12);
+  }
+}
+
+.num {
+  font-size: 1.75rem;
+  font-weight: 700;
+}
+
+.lbl {
+  color: #94a3b8;
+  font-size: 0.85rem;
+}
+
+.workload-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: 1.25rem;
+  margin-bottom: 1.5rem;
+}
+
+.panel {
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  border-radius: 14px;
+  padding: 1.25rem;
+  background: rgba(15, 23, 42, 0.55);
+
+  h2 {
+    margin: 0 0 0.35rem;
+    font-size: 1.1rem;
+  }
+}
+
+.panel-hint {
+  margin: 0 0 1rem;
+  font-size: 0.82rem;
+  color: #64748b;
+}
+
+.donut-wrap {
+  position: relative;
+  width: 200px;
+  height: 200px;
+  margin: 0 auto 1rem;
+}
+
+.donut-ring {
+  width: 100%;
+  height: 100%;
+  border-radius: 50%;
+}
+
+.donut-hole {
+  position: absolute;
+  inset: 22%;
+  border-radius: 50%;
+  background: #0f172a;
+  box-shadow: inset 0 0 0 1px rgba(148, 163, 184, 0.15);
+}
+
+.legend {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 0.35rem;
+  font-size: 0.82rem;
+  color: #cbd5e1;
+
+  li {
+    display: flex;
+    align-items: center;
+    gap: 0.45rem;
+  }
+}
+
+.swatch {
+  width: 10px;
+  height: 10px;
+  border-radius: 2px;
+  flex-shrink: 0;
+
+  &--today {
+    background: #f59e0b;
+  }
+  &--queue {
+    background: #f43f5e;
+  }
+  &--msg {
+    background: #38bdf8;
+  }
+  &--week {
+    background: #a78bfa;
+  }
+}
+
+.bar-row {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(120px, 2fr) 2rem;
+  gap: 0.5rem 0.75rem;
+  align-items: center;
+  margin-bottom: 0.65rem;
+  font-size: 0.85rem;
+}
+
+.bar-label {
+  color: #94a3b8;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.bar-track {
+  height: 10px;
+  border-radius: 999px;
+  background: rgba(51, 65, 85, 0.8);
+  overflow: hidden;
+}
+
+.bar-fill {
+  height: 100%;
+  border-radius: 999px;
+  background: linear-gradient(90deg, #f59e0b, #f43f5e);
+  transition: width 0.35s ease;
+}
+
+.bar-val {
+  text-align: right;
+  font-variant-numeric: tabular-nums;
+  font-weight: 600;
+}
+
+.alerts-panel {
+  &--empty .muted {
+    margin: 0;
+    color: #64748b;
+    font-size: 0.92rem;
+  }
+}
+
+.alert-list {
+  list-style: none;
+  margin: 0.5rem 0 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.65rem;
+}
+
+.alert-item {
+  display: flex;
+  gap: 0.65rem;
+  align-items: flex-start;
+  padding: 0.75rem 0.9rem;
+  border-radius: 10px;
+  background: rgba(56, 189, 248, 0.08);
+  border: 1px solid rgba(56, 189, 248, 0.22);
+
+  &--warning {
+    background: rgba(251, 191, 36, 0.1);
+    border-color: rgba(251, 191, 36, 0.35);
+  }
+}
+
+.alert-ic {
+  font-size: 1.1rem;
+  line-height: 1.4;
+}
+
+.alert-body {
+  flex: 1;
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: 0.75rem;
+}
+
+.alert-msg {
+  margin: 0;
+  font-size: 0.9rem;
+  color: #e2e8f0;
+}
+
+.alert-meta {
+  font-size: 0.85rem;
+  font-weight: 700;
+  color: #94a3b8;
+  font-variant-numeric: tabular-nums;
+}

--- a/frontend/src/app/components/doctor-dashboard/doctor-dashboard.component.spec.ts
+++ b/frontend/src/app/components/doctor-dashboard/doctor-dashboard.component.spec.ts
@@ -17,17 +17,26 @@ describe('DoctorDashboardComponent', () => {
     fixture.detectChanges();
     httpMock.expectOne('/api/doctor/dashboard/summary').flush({
       role: 'doctor',
-      appointments_today: 1,
-      pending_queue: 0
+      appointments_today: 2,
+      pending_queue: 1,
+      aggregations: {
+        unread_messages: 4,
+        appointments_this_week: 12
+      },
+      alerts: [
+        { severity: 'warning', code: 'pending_queue', message: 'Appointment requests need your review.', count: 1 }
+      ]
     });
     fixture.detectChanges();
   });
 
   afterEach(() => httpMock.verify());
 
-  it('renders stats', () => {
-    expect(
-      (fixture.nativeElement as HTMLElement).querySelector('[data-cy="doctor-dashboard-stats"]')
-    ).toBeTruthy();
+  it('renders stats, workload ring, bars, and alerts', () => {
+    const el = fixture.nativeElement as HTMLElement;
+    expect(el.querySelector('[data-cy="doctor-dashboard-stats"]')).toBeTruthy();
+    expect(el.querySelector('[data-cy="doctor-dashboard-workload-ring"]')).toBeTruthy();
+    expect(el.querySelector('[data-cy="doctor-dashboard-workload-bars"]')).toBeTruthy();
+    expect(el.querySelector('[data-cy="doctor-dashboard-alerts"]')).toBeTruthy();
   });
 });

--- a/frontend/src/app/components/doctor-dashboard/doctor-dashboard.component.ts
+++ b/frontend/src/app/components/doctor-dashboard/doctor-dashboard.component.ts
@@ -2,69 +2,82 @@ import { Component, OnInit } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { DashboardService, DoctorDashboardSummary } from '../../services/dashboard.service';
 
+export interface DoctorBarRow {
+  label: string;
+  value: number;
+  pct: number;
+}
+
 @Component({
   selector: 'app-doctor-dashboard',
   standalone: true,
   imports: [CommonModule],
-  template: `
-    <section class="dash" data-cy="doctor-dashboard">
-      <h1>Dashboard</h1>
-      <p *ngIf="error" class="err">{{ error }}</p>
-      <div *ngIf="data" class="cards" data-cy="doctor-dashboard-stats">
-        <div class="card">
-          <span class="num">{{ data.appointments_today }}</span>
-          <span class="lbl">Today (scheduled)</span>
-        </div>
-        <div class="card">
-          <span class="num">{{ data.pending_queue }}</span>
-          <span class="lbl">Pending queue</span>
-        </div>
-      </div>
-    </section>
-  `,
-  styles: [
-    `
-      .dash {
-        max-width: 720px;
-      }
-      .cards {
-        display: flex;
-        gap: 1rem;
-        flex-wrap: wrap;
-      }
-      .card {
-        border: 1px solid rgba(148, 163, 184, 0.3);
-        border-radius: 10px;
-        padding: 1rem;
-        min-width: 140px;
-        display: flex;
-        flex-direction: column;
-        gap: 0.25rem;
-      }
-      .num {
-        font-size: 1.75rem;
-        font-weight: 700;
-      }
-      .lbl {
-        color: #94a3b8;
-        font-size: 0.85rem;
-      }
-      .err {
-        color: #f87171;
-      }
-    `
-  ]
+  templateUrl: './doctor-dashboard.component.html',
+  styleUrl: './doctor-dashboard.component.scss'
 })
 export class DoctorDashboardComponent implements OnInit {
   data: DoctorDashboardSummary | null = null;
   error: string | null = null;
+  pieBackground = 'conic-gradient(#334155 0% 100%)';
 
   constructor(private dash: DashboardService) {}
 
   ngOnInit(): void {
     this.dash.doctorSummary().subscribe({
-      next: (d) => (this.data = d),
+      next: (d) => {
+        this.data = d;
+        this.pieBackground = this.computePieGradient(d);
+      },
       error: () => (this.error = 'Could not load summary')
     });
+  }
+
+  get barRows(): DoctorBarRow[] {
+    const d = this.data;
+    if (!d) {
+      return [];
+    }
+    const agg = d.aggregations;
+    const rows = [
+      { label: 'Appointments today', value: d.appointments_today },
+      { label: 'Pending queue', value: d.pending_queue },
+      { label: 'Unread messages', value: agg?.unread_messages ?? 0 },
+      { label: 'Scheduled this week', value: agg?.appointments_this_week ?? 0 }
+    ];
+    const max = Math.max(...rows.map((r) => r.value), 1);
+    return rows.map((r) => ({
+      ...r,
+      pct: Math.round((r.value / max) * 100)
+    }));
+  }
+
+  private computePieGradient(d: DoctorDashboardSummary): string {
+    const agg = d.aggregations;
+    const parts: { color: string; value: number }[] = [
+      { color: '#f59e0b', value: d.appointments_today },
+      { color: '#f43f5e', value: d.pending_queue },
+      { color: '#38bdf8', value: agg?.unread_messages ?? 0 },
+      { color: '#a78bfa', value: agg?.appointments_this_week ?? 0 }
+    ];
+    const sum = parts.reduce((s, p) => s + p.value, 0);
+    if (sum <= 0) {
+      return 'conic-gradient(#334155 0% 100%)';
+    }
+    let acc = 0;
+    const stops: string[] = [];
+    for (const p of parts) {
+      const pct = (p.value / sum) * 100;
+      if (pct <= 0) {
+        continue;
+      }
+      const start = acc;
+      acc += pct;
+      stops.push(`${p.color} ${start}% ${acc}%`);
+    }
+    return `conic-gradient(${stops.join(', ')})`;
+  }
+
+  alertIcon(sev: string): string {
+    return sev === 'warning' ? '⚠' : 'ⓘ';
   }
 }

--- a/frontend/src/app/services/dashboard.service.ts
+++ b/frontend/src/app/services/dashboard.service.ts
@@ -27,10 +27,17 @@ export interface PatientDashboardSummary {
   alerts?: DashboardAlert[];
 }
 
+export interface DoctorDashboardAggregations {
+  unread_messages: number;
+  appointments_this_week: number;
+}
+
 export interface DoctorDashboardSummary {
   role: string;
   appointments_today: number;
   pending_queue: number;
+  aggregations?: DoctorDashboardAggregations;
+  alerts?: DashboardAlert[];
 }
 
 @Injectable({ providedIn: 'root' })


### PR DESCRIPTION
﻿PR-27 (Abhinav, FE) phase5/doctor-dashboard-workload-alerts-ui

- Doctor dashboard: workload mix donut (CSS conic), volume bars, alerts from API.
- dashboard.service: DoctorDashboardAggregations (unread_messages, appointments_this_week) on DoctorDashboardSummary.
- npm run test:ci and npm run build OK.
