### PR TITLE
S6 PR-28: KB versioning, staleness + health score API (phase6)

### DIFF
--- a/backend/db/db.go
+++ b/backend/db/db.go
@@ -115,6 +115,32 @@ func Migrate(ctx context.Context) error {
 
 		CREATE INDEX IF NOT EXISTS idx_knowledge_docs_title ON knowledge_docs(title);
 
+		ALTER TABLE knowledge_docs ADD COLUMN IF NOT EXISTS current_version INTEGER NOT NULL DEFAULT 1;
+		ALTER TABLE knowledge_docs ADD COLUMN IF NOT EXISTS review_interval_days INTEGER NOT NULL DEFAULT 180;
+		ALTER TABLE knowledge_docs DROP CONSTRAINT IF EXISTS knowledge_docs_review_interval_days_check;
+		ALTER TABLE knowledge_docs ADD CONSTRAINT knowledge_docs_review_interval_days_check CHECK (review_interval_days > 0 AND review_interval_days <= 3650);
+		ALTER TABLE knowledge_docs ADD COLUMN IF NOT EXISTS last_reviewed_at TIMESTAMPTZ;
+
+		CREATE TABLE IF NOT EXISTS knowledge_doc_versions (
+			id           UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+			document_id  UUID NOT NULL REFERENCES knowledge_docs(id) ON DELETE CASCADE,
+			version      INTEGER NOT NULL CHECK (version >= 1),
+			title        TEXT NOT NULL,
+			body         TEXT NOT NULL,
+			created_by   UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+			created_at   TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+			UNIQUE(document_id, version)
+		);
+
+		CREATE INDEX IF NOT EXISTS idx_knowledge_doc_versions_doc ON knowledge_doc_versions(document_id, version DESC);
+
+		INSERT INTO knowledge_doc_versions (document_id, version, title, body, created_by, created_at)
+		SELECT d.id, 1, d.title, d.body, d.created_by, d.created_at
+		FROM knowledge_docs d
+		WHERE NOT EXISTS (
+			SELECT 1 FROM knowledge_doc_versions v WHERE v.document_id = d.id AND v.version = 1
+		);
+
 		CREATE TABLE IF NOT EXISTS doctor_slots (
 			id          UUID PRIMARY KEY DEFAULT gen_random_uuid(),
 			doctor_id   UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,

--- a/backend/handlers/knowledge_admin.go
+++ b/backend/handlers/knowledge_admin.go
@@ -1,12 +1,14 @@
 package handlers
 
 import (
+	"errors"
 	"net/http"
 	"strings"
 
 	"github.com/gin-gonic/gin"
 	"github.com/google/uuid"
 	"github.com/healthonyx/backend/db"
+	"github.com/jackc/pgx/v5"
 )
 
 type KnowledgeAdminHandler struct{}
@@ -19,8 +21,13 @@ func (h *KnowledgeAdminHandler) List(c *gin.Context) {
 	if _, ok := getClaims(c); !ok {
 		return
 	}
-	rows, err := db.Pool.Query(c.Request.Context(), `
-		SELECT id::text, title, left(body, 200) AS excerpt, created_at::text, updated_at::text
+	ctx := c.Request.Context()
+	rows, err := db.Pool.Query(ctx, `
+		SELECT id::text, title, left(body, 200) AS excerpt, created_at::text, updated_at::text,
+			current_version,
+			review_interval_days,
+			COALESCE(last_reviewed_at::text, ''),
+			GREATEST(0, FLOOR(EXTRACT(EPOCH FROM (NOW() - COALESCE(last_reviewed_at, updated_at))) / 86400))::int
 		FROM knowledge_docs
 		ORDER BY updated_at DESC
 		LIMIT 100
@@ -32,19 +39,32 @@ func (h *KnowledgeAdminHandler) List(c *gin.Context) {
 	defer rows.Close()
 
 	type row struct {
-		ID        string `json:"id"`
-		Title     string `json:"title"`
-		Excerpt   string `json:"excerpt"`
-		CreatedAt string `json:"created_at"`
-		UpdatedAt string `json:"updated_at"`
+		ID                 string `json:"id"`
+		Title              string `json:"title"`
+		Excerpt            string `json:"excerpt"`
+		CreatedAt          string `json:"created_at"`
+		UpdatedAt          string `json:"updated_at"`
+		CurrentVersion     int    `json:"current_version"`
+		ReviewIntervalDays int    `json:"review_interval_days"`
+		LastReviewedAt     string `json:"last_reviewed_at,omitempty"`
+		DaysSinceReview    int    `json:"days_since_review"`
+		HealthScore        int    `json:"health_score"`
+		IsStale            bool   `json:"is_stale"`
 	}
 	var out []row
 	for rows.Next() {
 		var r row
-		if err := rows.Scan(&r.ID, &r.Title, &r.Excerpt, &r.CreatedAt, &r.UpdatedAt); err != nil {
+		var lastRev string
+		if err := rows.Scan(&r.ID, &r.Title, &r.Excerpt, &r.CreatedAt, &r.UpdatedAt,
+			&r.CurrentVersion, &r.ReviewIntervalDays, &lastRev, &r.DaysSinceReview); err != nil {
 			c.JSON(http.StatusInternalServerError, gin.H{"error": "Internal error"})
 			return
 		}
+		if lastRev != "" {
+			r.LastReviewedAt = lastRev
+		}
+		r.HealthScore = KnowledgeHealthScore(r.DaysSinceReview, r.ReviewIntervalDays)
+		r.IsStale = KnowledgeIsStale(r.DaysSinceReview, r.ReviewIntervalDays)
 		out = append(out, r)
 	}
 	if out == nil {
@@ -54,8 +74,9 @@ func (h *KnowledgeAdminHandler) List(c *gin.Context) {
 }
 
 type knowledgeCreateBody struct {
-	Title string `json:"title" binding:"required"`
-	Body  string `json:"body" binding:"required"`
+	Title              string `json:"title" binding:"required"`
+	Body               string `json:"body" binding:"required"`
+	ReviewIntervalDays *int   `json:"review_interval_days"`
 }
 
 func (h *KnowledgeAdminHandler) Create(c *gin.Context) {
@@ -74,17 +95,45 @@ func (h *KnowledgeAdminHandler) Create(c *gin.Context) {
 		c.JSON(http.StatusBadRequest, gin.H{"error": "title and body required"})
 		return
 	}
+	interval := 180
+	if body.ReviewIntervalDays != nil && *body.ReviewIntervalDays > 0 && *body.ReviewIntervalDays <= 3650 {
+		interval = *body.ReviewIntervalDays
+	}
 
-	var id string
-	err := db.Pool.QueryRow(c.Request.Context(), `
-		INSERT INTO knowledge_docs (title, body, created_by)
-		VALUES ($1, $2, $3) RETURNING id::text
-	`, title, text, claims.UserID).Scan(&id)
+	ctx := c.Request.Context()
+	tx, err := db.Pool.Begin(ctx)
 	if err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "Internal error"})
 		return
 	}
-	c.JSON(http.StatusCreated, gin.H{"id": id})
+	defer func() { _ = tx.Rollback(ctx) }()
+
+	var docID uuid.UUID
+	err = tx.QueryRow(ctx, `
+		INSERT INTO knowledge_docs (title, body, created_by, current_version, review_interval_days)
+		VALUES ($1, $2, $3, 1, $4)
+		RETURNING id
+	`, title, text, claims.UserID, interval).Scan(&docID)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Internal error"})
+		return
+	}
+
+	_, err = tx.Exec(ctx, `
+		INSERT INTO knowledge_doc_versions (document_id, version, title, body, created_by)
+		VALUES ($1, 1, $2, $3, $4)
+	`, docID, title, text, claims.UserID)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Internal error"})
+		return
+	}
+
+	if err := tx.Commit(ctx); err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Internal error"})
+		return
+	}
+
+	c.JSON(http.StatusCreated, gin.H{"id": docID.String(), "current_version": 1})
 }
 
 func (h *KnowledgeAdminHandler) Get(c *gin.Context) {
@@ -96,14 +145,225 @@ func (h *KnowledgeAdminHandler) Get(c *gin.Context) {
 		c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid id"})
 		return
 	}
+	ctx := c.Request.Context()
 	var title, body string
 	var updated string
-	err = db.Pool.QueryRow(c.Request.Context(), `
-		SELECT title, body, updated_at::text FROM knowledge_docs WHERE id = $1
-	`, id).Scan(&title, &body, &updated)
+	var curVer, intervalDays int
+	var lastRevStr string
+	var days int
+	err = db.Pool.QueryRow(ctx, `
+		SELECT title, body, updated_at::text, current_version, review_interval_days,
+			COALESCE(last_reviewed_at::text, ''),
+			GREATEST(0, FLOOR(EXTRACT(EPOCH FROM (NOW() - COALESCE(last_reviewed_at, updated_at))) / 86400))::int
+		FROM knowledge_docs WHERE id = $1
+	`, id).Scan(&title, &body, &updated, &curVer, &intervalDays, &lastRevStr, &days)
 	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			c.JSON(http.StatusNotFound, gin.H{"error": "Not found"})
+			return
+		}
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Internal error"})
+		return
+	}
+
+	resp := gin.H{
+		"id":                   id.String(),
+		"title":                title,
+		"body":                 body,
+		"updated_at":           updated,
+		"current_version":      curVer,
+		"review_interval_days": intervalDays,
+		"days_since_review":    days,
+		"health_score":         KnowledgeHealthScore(days, intervalDays),
+		"is_stale":             KnowledgeIsStale(days, intervalDays),
+	}
+	if lastRevStr != "" {
+		resp["last_reviewed_at"] = lastRevStr
+	}
+
+	c.JSON(http.StatusOK, resp)
+}
+
+type knowledgePatchBody struct {
+	Title              *string `json:"title"`
+	Body               *string `json:"body"`
+	ReviewIntervalDays *int    `json:"review_interval_days"`
+}
+
+func (h *KnowledgeAdminHandler) Patch(c *gin.Context) {
+	claims, ok := getClaims(c)
+	if !ok {
+		return
+	}
+	id, err := uuid.Parse(strings.TrimSpace(c.Param("id")))
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid id"})
+		return
+	}
+	var body knowledgePatchBody
+	if err := c.ShouldBindJSON(&body); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid request body"})
+		return
+	}
+	if body.Title == nil && body.Body == nil && body.ReviewIntervalDays == nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "At least one of title, body, review_interval_days required"})
+		return
+	}
+
+	ctx := c.Request.Context()
+	tx, err := db.Pool.Begin(ctx)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Internal error"})
+		return
+	}
+	defer func() { _ = tx.Rollback(ctx) }()
+
+	var curTitle, curBody string
+	var curVer, intervalDays int
+	err = tx.QueryRow(ctx, `
+		SELECT title, body, current_version, review_interval_days FROM knowledge_docs WHERE id = $1 FOR UPDATE
+	`, id).Scan(&curTitle, &curBody, &curVer, &intervalDays)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			c.JSON(http.StatusNotFound, gin.H{"error": "Not found"})
+			return
+		}
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Internal error"})
+		return
+	}
+
+	newTitle := curTitle
+	newBody := curBody
+	newInterval := intervalDays
+	contentChanged := false
+	if body.Title != nil {
+		t := strings.TrimSpace(*body.Title)
+		if t != "" && t != curTitle {
+			newTitle = t
+			contentChanged = true
+		}
+	}
+	if body.Body != nil {
+		t := strings.TrimSpace(*body.Body)
+		if t != "" && t != curBody {
+			newBody = t
+			contentChanged = true
+		}
+	}
+	if body.ReviewIntervalDays != nil {
+		v := *body.ReviewIntervalDays
+		if v > 0 && v <= 3650 {
+			newInterval = v
+		}
+	}
+
+	nextVer := curVer
+	if contentChanged {
+		nextVer = curVer + 1
+	}
+
+	if _, err := tx.Exec(ctx, `
+		UPDATE knowledge_docs SET
+			title = $1,
+			body = $2,
+			current_version = $3,
+			review_interval_days = $4,
+			updated_at = NOW()
+		WHERE id = $5
+	`, newTitle, newBody, nextVer, newInterval, id); err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Internal error"})
+		return
+	}
+
+	if contentChanged {
+		if _, err := tx.Exec(ctx, `
+			INSERT INTO knowledge_doc_versions (document_id, version, title, body, created_by)
+			VALUES ($1, $2, $3, $4, $5)
+		`, id, nextVer, newTitle, newBody, claims.UserID); err != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "Internal error"})
+			return
+		}
+	}
+
+	if err := tx.Commit(ctx); err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Internal error"})
+		return
+	}
+
+	c.JSON(http.StatusOK, gin.H{"id": id.String(), "current_version": nextVer})
+}
+
+func (h *KnowledgeAdminHandler) Review(c *gin.Context) {
+	if _, ok := getClaims(c); !ok {
+		return
+	}
+	id, err := uuid.Parse(strings.TrimSpace(c.Param("id")))
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid id"})
+		return
+	}
+	ctx := c.Request.Context()
+	tag, err := db.Pool.Exec(ctx, `
+		UPDATE knowledge_docs SET last_reviewed_at = NOW(), updated_at = NOW() WHERE id = $1
+	`, id)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Internal error"})
+		return
+	}
+	if tag.RowsAffected() == 0 {
 		c.JSON(http.StatusNotFound, gin.H{"error": "Not found"})
 		return
 	}
-	c.JSON(http.StatusOK, gin.H{"id": id.String(), "title": title, "body": body, "updated_at": updated})
+	c.JSON(http.StatusOK, gin.H{"ok": true})
+}
+
+func (h *KnowledgeAdminHandler) ListVersions(c *gin.Context) {
+	if _, ok := getClaims(c); !ok {
+		return
+	}
+	docID, err := uuid.Parse(strings.TrimSpace(c.Param("id")))
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid id"})
+		return
+	}
+	ctx := c.Request.Context()
+	var exists bool
+	if err := db.Pool.QueryRow(ctx, `SELECT EXISTS(SELECT 1 FROM knowledge_docs WHERE id = $1)`, docID).Scan(&exists); err != nil || !exists {
+		c.JSON(http.StatusNotFound, gin.H{"error": "Not found"})
+		return
+	}
+
+	rows, err := db.Pool.Query(ctx, `
+		SELECT version, title, left(body, 200) AS excerpt, created_at::text, created_by::text
+		FROM knowledge_doc_versions
+		WHERE document_id = $1
+		ORDER BY version DESC
+		LIMIT 50
+	`, docID)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Internal error"})
+		return
+	}
+	defer rows.Close()
+
+	type vrow struct {
+		Version   int    `json:"version"`
+		Title     string `json:"title"`
+		Excerpt   string `json:"excerpt"`
+		CreatedAt string `json:"created_at"`
+		CreatedBy string `json:"created_by"`
+	}
+	var out []vrow
+	for rows.Next() {
+		var r vrow
+		if err := rows.Scan(&r.Version, &r.Title, &r.Excerpt, &r.CreatedAt, &r.CreatedBy); err != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "Internal error"})
+			return
+		}
+		out = append(out, r)
+	}
+	if out == nil {
+		out = []vrow{}
+	}
+	c.JSON(http.StatusOK, gin.H{"versions": out})
 }

--- a/backend/handlers/knowledge_health.go
+++ b/backend/handlers/knowledge_health.go
@@ -1,0 +1,28 @@
+package handlers
+
+// KnowledgeHealthScore returns 100 when freshly reviewed and decreases linearly toward 0 as
+// days_since_review approaches review_interval_days (phase 6 staleness model).
+func KnowledgeHealthScore(daysSinceReview int, reviewIntervalDays int) int {
+	if reviewIntervalDays <= 0 {
+		reviewIntervalDays = 180
+	}
+	if daysSinceReview <= 0 {
+		return 100
+	}
+	score := 100 - (daysSinceReview*100)/reviewIntervalDays
+	if score < 0 {
+		return 0
+	}
+	if score > 100 {
+		return 100
+	}
+	return score
+}
+
+// KnowledgeIsStale is true when days_since_review exceeds the configured interval.
+func KnowledgeIsStale(daysSinceReview int, reviewIntervalDays int) bool {
+	if reviewIntervalDays <= 0 {
+		reviewIntervalDays = 180
+	}
+	return daysSinceReview > reviewIntervalDays
+}

--- a/backend/handlers/knowledge_health_test.go
+++ b/backend/handlers/knowledge_health_test.go
@@ -1,0 +1,27 @@
+package handlers
+
+import "testing"
+
+func TestKnowledgeHealthScore_LinearDrop(t *testing.T) {
+	if KnowledgeHealthScore(0, 180) != 100 {
+		t.Fatal("fresh review")
+	}
+	if KnowledgeHealthScore(90, 180) != 50 {
+		t.Fatalf("half interval: got %d", KnowledgeHealthScore(90, 180))
+	}
+	if KnowledgeHealthScore(180, 180) != 0 {
+		t.Fatalf("at interval: got %d", KnowledgeHealthScore(180, 180))
+	}
+	if KnowledgeHealthScore(400, 180) != 0 {
+		t.Fatal("beyond interval clamps to 0")
+	}
+}
+
+func TestKnowledgeIsStale(t *testing.T) {
+	if KnowledgeIsStale(180, 180) {
+		t.Fatal("equal boundary not stale")
+	}
+	if !KnowledgeIsStale(181, 180) {
+		t.Fatal("beyond boundary stale")
+	}
+}

--- a/backend/main.go
+++ b/backend/main.go
@@ -98,6 +98,9 @@ func main() {
 		api.POST("/admin/notifications/:id/retry", auth.RequireAuth(), auth.RequireRole("admin"), notifications.RetryFailed)
 		api.GET("/admin/knowledge-docs", auth.RequireAuth(), auth.RequireRole("admin"), knowledge.List)
 		api.POST("/admin/knowledge-docs", auth.RequireAuth(), auth.RequireRole("admin"), knowledge.Create)
+		api.GET("/admin/knowledge-docs/:id/versions", auth.RequireAuth(), auth.RequireRole("admin"), knowledge.ListVersions)
+		api.POST("/admin/knowledge-docs/:id/review", auth.RequireAuth(), auth.RequireRole("admin"), knowledge.Review)
+		api.PATCH("/admin/knowledge-docs/:id", auth.RequireAuth(), auth.RequireRole("admin"), knowledge.Patch)
 		api.GET("/admin/knowledge-docs/:id", auth.RequireAuth(), auth.RequireRole("admin"), knowledge.Get)
 		api.GET("/doctor", auth.RequireAuth(), auth.RequireRole("doctor"), func(c *gin.Context) {
 			c.JSON(http.StatusOK, gin.H{"message": "Doctor only"})


### PR DESCRIPTION
﻿PR-28 (Rohith, BE) phase6/kb-versioning-staleness-health-score

- DB: knowledge_doc_versions (snapshot per version); knowledge_docs current_version, review_interval_days (default 180), last_reviewed_at; backfill v1 rows.
- GET list/detail: days_since_review (vs COALESCE(last_reviewed_at, updated_at)), health_score (linear vs interval), is_stale.
- POST /admin/knowledge-docs/:id/review marks reviewed.
- PATCH /admin/knowledge-docs/:id updates title/body/interval; content change bumps version + inserts knowledge_doc_versions row.
- GET /admin/knowledge-docs/:id/versions — recent snapshots.

Tests: go test ./...
