### PR TITLE
S6 PR-29: KB embeddings + similarity/conflict scan (phase6)

### DIFF
--- a/backend/db/db.go
+++ b/backend/db/db.go
@@ -141,6 +141,19 @@ func Migrate(ctx context.Context) error {
 			SELECT 1 FROM knowledge_doc_versions v WHERE v.document_id = d.id AND v.version = 1
 		);
 
+		CREATE TABLE IF NOT EXISTS knowledge_doc_chunks (
+			id           UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+			document_id  UUID NOT NULL REFERENCES knowledge_docs(id) ON DELETE CASCADE,
+			chunk_index  INTEGER NOT NULL CHECK (chunk_index >= 0),
+			body         TEXT NOT NULL,
+			embedding    JSONB NOT NULL,
+			created_at   TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+			UNIQUE(document_id, chunk_index),
+			CONSTRAINT knowledge_doc_chunks_embedding_is_array CHECK (jsonb_typeof(embedding) = 'array')
+		);
+
+		CREATE INDEX IF NOT EXISTS idx_knowledge_doc_chunks_doc ON knowledge_doc_chunks(document_id);
+
 		CREATE TABLE IF NOT EXISTS doctor_slots (
 			id          UUID PRIMARY KEY DEFAULT gen_random_uuid(),
 			doctor_id   UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,

--- a/backend/handlers/embedding_math.go
+++ b/backend/handlers/embedding_math.go
@@ -1,0 +1,20 @@
+package handlers
+
+import "math"
+
+// CosineSimilarity returns cosine similarity in [-1, 1], or 0 if lengths mismatch or zero vectors.
+func CosineSimilarity(a, b []float64) float64 {
+	if len(a) != len(b) || len(a) == 0 {
+		return 0
+	}
+	var dot, na, nb float64
+	for i := range a {
+		dot += a[i] * b[i]
+		na += a[i] * a[i]
+		nb += b[i] * b[i]
+	}
+	if na == 0 || nb == 0 {
+		return 0
+	}
+	return dot / (math.Sqrt(na) * math.Sqrt(nb))
+}

--- a/backend/handlers/embedding_math_test.go
+++ b/backend/handlers/embedding_math_test.go
@@ -1,0 +1,22 @@
+package handlers
+
+import (
+	"math"
+	"testing"
+)
+
+func TestCosineSimilarity_identical(t *testing.T) {
+	a := []float64{1, 0, 0}
+	b := []float64{1, 0, 0}
+	if math.Abs(CosineSimilarity(a, b)-1) > 1e-9 {
+		t.Fatalf("expected 1, got %v", CosineSimilarity(a, b))
+	}
+}
+
+func TestCosineSimilarity_orthogonal(t *testing.T) {
+	a := []float64{1, 0}
+	b := []float64{0, 1}
+	if math.Abs(CosineSimilarity(a, b)) > 1e-9 {
+		t.Fatalf("expected 0, got %v", CosineSimilarity(a, b))
+	}
+}

--- a/backend/handlers/knowledge_embeddings.go
+++ b/backend/handlers/knowledge_embeddings.go
@@ -1,0 +1,233 @@
+package handlers
+
+import (
+	"encoding/json"
+	"net/http"
+	"sort"
+	"strconv"
+	"strings"
+
+	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
+	"github.com/healthonyx/backend/db"
+)
+
+type embeddingChunkInput struct {
+	ChunkIndex int       `json:"chunk_index"`
+	Body       string    `json:"body"`
+	Embedding  []float64 `json:"embedding"`
+}
+
+type embeddingsUpsertBody struct {
+	Chunks []embeddingChunkInput `json:"chunks" binding:"required"`
+}
+
+type loadedChunk struct {
+	DocID      uuid.UUID
+	ChunkIndex int
+	Body       string
+	Title      string
+	Vec        []float64
+}
+
+type similarityHit struct {
+	Similarity   float64 `json:"similarity"`
+	DocumentAID  string  `json:"document_a_id"`
+	DocumentBID  string  `json:"document_b_id"`
+	TitleA       string  `json:"title_a"`
+	TitleB       string  `json:"title_b"`
+	ChunkAIndex  int     `json:"chunk_a_index"`
+	ChunkBIndex  int     `json:"chunk_b_index"`
+	ExcerptA     string  `json:"excerpt_a"`
+	ExcerptB     string  `json:"excerpt_b"`
+	ConflictHint string  `json:"conflict_hint"`
+}
+
+func excerptKB(s string, n int) string {
+	s = strings.TrimSpace(s)
+	if len(s) <= n {
+		return s
+	}
+	return s[:n] + "…"
+}
+
+// UpsertEmbeddings replaces all chunks + embeddings for a knowledge doc (admin embedding pipeline).
+func (h *KnowledgeAdminHandler) UpsertEmbeddings(c *gin.Context) {
+	if _, ok := getClaims(c); !ok {
+		return
+	}
+	docID, err := uuid.Parse(strings.TrimSpace(c.Param("id")))
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid id"})
+		return
+	}
+	var body embeddingsUpsertBody
+	if err := c.ShouldBindJSON(&body); err != nil || len(body.Chunks) == 0 {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "chunks required"})
+		return
+	}
+	if len(body.Chunks) > 256 {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "max 256 chunks"})
+		return
+	}
+
+	dim := -1
+	for _, ch := range body.Chunks {
+		if ch.ChunkIndex < 0 || strings.TrimSpace(ch.Body) == "" || len(ch.Embedding) < 4 {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "each chunk needs chunk_index, body, embedding (min length 4)"})
+			return
+		}
+		if dim < 0 {
+			dim = len(ch.Embedding)
+		} else if len(ch.Embedding) != dim {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "all embeddings must share the same dimension"})
+			return
+		}
+	}
+
+	ctx := c.Request.Context()
+	var exists bool
+	if err := db.Pool.QueryRow(ctx, `SELECT EXISTS(SELECT 1 FROM knowledge_docs WHERE id = $1)`, docID).Scan(&exists); err != nil || !exists {
+		c.JSON(http.StatusNotFound, gin.H{"error": "Not found"})
+		return
+	}
+
+	tx, err := db.Pool.Begin(ctx)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Internal error"})
+		return
+	}
+	defer func() { _ = tx.Rollback(ctx) }()
+
+	if _, err := tx.Exec(ctx, `DELETE FROM knowledge_doc_chunks WHERE document_id = $1`, docID); err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Internal error"})
+		return
+	}
+
+	for _, ch := range body.Chunks {
+		payload, err := json.Marshal(ch.Embedding)
+		if err != nil {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "invalid embedding"})
+			return
+		}
+		if _, err := tx.Exec(ctx, `
+			INSERT INTO knowledge_doc_chunks (document_id, chunk_index, body, embedding)
+			VALUES ($1, $2, $3, $4::jsonb)
+		`, docID, ch.ChunkIndex, strings.TrimSpace(ch.Body), payload); err != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "Internal error"})
+			return
+		}
+	}
+
+	if err := tx.Commit(ctx); err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Internal error"})
+		return
+	}
+
+	c.JSON(http.StatusOK, gin.H{"document_id": docID.String(), "chunks": len(body.Chunks), "embedding_dim": dim})
+}
+
+// SimilarityScan compares embeddings across different KB documents (pairwise). Used for overlap / conflict review.
+func (h *KnowledgeAdminHandler) SimilarityScan(c *gin.Context) {
+	if _, ok := getClaims(c); !ok {
+		return
+	}
+	threshold := 0.85
+	if v := strings.TrimSpace(c.Query("threshold")); v != "" {
+		if f, err := strconv.ParseFloat(v, 64); err == nil && f > 0 && f <= 1 {
+			threshold = f
+		}
+	}
+	maxRows := 1200
+	if v := strings.TrimSpace(c.Query("max_chunks")); v != "" {
+		if n, err := strconv.Atoi(v); err == nil && n >= 10 && n <= 5000 {
+			maxRows = n
+		}
+	}
+
+	ctx := c.Request.Context()
+	rows, err := db.Pool.Query(ctx, `
+		SELECT c.document_id, c.chunk_index, c.body, c.embedding, d.title
+		FROM knowledge_doc_chunks c
+		INNER JOIN knowledge_docs d ON d.id = c.document_id
+		ORDER BY d.updated_at DESC, c.document_id, c.chunk_index
+		LIMIT $1
+	`, maxRows)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Internal error"})
+		return
+	}
+	defer rows.Close()
+
+	var chunks []loadedChunk
+	for rows.Next() {
+		var lc loadedChunk
+		var embRaw []byte
+		if err := rows.Scan(&lc.DocID, &lc.ChunkIndex, &lc.Body, &embRaw, &lc.Title); err != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "Internal error"})
+			return
+		}
+		if err := json.Unmarshal(embRaw, &lc.Vec); err != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "stored embedding corrupt"})
+			return
+		}
+		chunks = append(chunks, lc)
+	}
+
+	var hits []similarityHit
+	for i := 0; i < len(chunks); i++ {
+		for j := i + 1; j < len(chunks); j++ {
+			if chunks[i].DocID == chunks[j].DocID {
+				continue
+			}
+			if len(chunks[i].Vec) != len(chunks[j].Vec) || len(chunks[i].Vec) == 0 {
+				continue
+			}
+			sim := CosineSimilarity(chunks[i].Vec, chunks[j].Vec)
+			if sim < threshold {
+				continue
+			}
+
+			a, b := chunks[i], chunks[j]
+			if strings.Compare(a.DocID.String(), b.DocID.String()) > 0 {
+				a, b = b, a
+			}
+
+			ta := strings.TrimSpace(strings.ToLower(a.Title))
+			tb := strings.TrimSpace(strings.ToLower(b.Title))
+			hint := "high_similarity"
+			if ta != tb && sim >= 0.92 {
+				hint = "potential_conflict_review"
+			}
+			if ta == tb && sim >= 0.95 {
+				hint = "near_duplicate_under_same_title"
+			}
+
+			hits = append(hits, similarityHit{
+				Similarity:   sim,
+				DocumentAID:  a.DocID.String(),
+				DocumentBID:  b.DocID.String(),
+				TitleA:       a.Title,
+				TitleB:       b.Title,
+				ChunkAIndex:  a.ChunkIndex,
+				ChunkBIndex:  b.ChunkIndex,
+				ExcerptA:     excerptKB(a.Body, 180),
+				ExcerptB:     excerptKB(b.Body, 180),
+				ConflictHint: hint,
+			})
+		}
+	}
+
+	sort.Slice(hits, func(i, j int) bool {
+		return hits[i].Similarity > hits[j].Similarity
+	})
+	if len(hits) > 200 {
+		hits = hits[:200]
+	}
+
+	c.JSON(http.StatusOK, gin.H{
+		"threshold":      threshold,
+		"chunks_scanned": len(chunks),
+		"pairs":          hits,
+	})
+}

--- a/backend/main.go
+++ b/backend/main.go
@@ -98,6 +98,8 @@ func main() {
 		api.POST("/admin/notifications/:id/retry", auth.RequireAuth(), auth.RequireRole("admin"), notifications.RetryFailed)
 		api.GET("/admin/knowledge-docs", auth.RequireAuth(), auth.RequireRole("admin"), knowledge.List)
 		api.POST("/admin/knowledge-docs", auth.RequireAuth(), auth.RequireRole("admin"), knowledge.Create)
+		api.GET("/admin/knowledge-docs/similarity-scan", auth.RequireAuth(), auth.RequireRole("admin"), knowledge.SimilarityScan)
+		api.POST("/admin/knowledge-docs/:id/embeddings", auth.RequireAuth(), auth.RequireRole("admin"), knowledge.UpsertEmbeddings)
 		api.GET("/admin/knowledge-docs/:id/versions", auth.RequireAuth(), auth.RequireRole("admin"), knowledge.ListVersions)
 		api.POST("/admin/knowledge-docs/:id/review", auth.RequireAuth(), auth.RequireRole("admin"), knowledge.Review)
 		api.PATCH("/admin/knowledge-docs/:id", auth.RequireAuth(), auth.RequireRole("admin"), knowledge.Patch)


### PR DESCRIPTION
﻿PR-29 (Rohith, BE) phase6/kb-embeddings-similarity-conflict

- Table knowledge_doc_chunks: JSONB embedding vectors per chunk (unique document_id + chunk_index).
- POST /api/admin/knowledge-docs/:id/embeddings — replace all chunks (max 256); validates dimension consistency (min length 4 floats).
- GET /api/admin/knowledge-docs/similarity-scan — pairwise cosine similarity across different documents (threshold query default 0.85, max_chunks 10–5000 default 1200); returns pairs with excerpts and conflict_hint (potential_conflict_review / near_duplicate_under_same_title / high_similarity).
- embedding_math.CosineSimilarity + tests.

go test ./...
