### PR TITLE
feat(backend): phase7 admin user lifecycle settings + KPI API

### DIFF
--- a/backend/db/db.go
+++ b/backend/db/db.go
@@ -27,6 +27,17 @@ func Migrate(ctx context.Context) error {
 			created_at TIMESTAMPTZ DEFAULT NOW()
 		);
 
+		CREATE TABLE IF NOT EXISTS admin_user_lifecycle_settings (
+			id                     BOOLEAN PRIMARY KEY DEFAULT TRUE CHECK (id),
+			new_user_window_days   INTEGER NOT NULL DEFAULT 14 CHECK (new_user_window_days >= 1 AND new_user_window_days <= 3650),
+			inactive_window_days   INTEGER NOT NULL DEFAULT 30 CHECK (inactive_window_days >= 1 AND inactive_window_days <= 3650),
+			updated_by             UUID REFERENCES users(id) ON DELETE SET NULL,
+			updated_at             TIMESTAMPTZ NOT NULL DEFAULT NOW()
+		);
+		INSERT INTO admin_user_lifecycle_settings (id)
+		VALUES (TRUE)
+		ON CONFLICT (id) DO NOTHING;
+
 		CREATE TABLE IF NOT EXISTS appointments (
 			id           UUID PRIMARY KEY DEFAULT gen_random_uuid(),
 			patient_id   UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,

--- a/backend/handlers/admin_user_lifecycle.go
+++ b/backend/handlers/admin_user_lifecycle.go
@@ -1,0 +1,141 @@
+package handlers
+
+import (
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+	"github.com/healthonyx/backend/db"
+)
+
+type AdminUserLifecycleHandler struct{}
+
+type updateLifecycleSettingsRequest struct {
+	NewUserWindowDays  int `json:"new_user_window_days"`
+	InactiveWindowDays int `json:"inactive_window_days"`
+}
+
+func NewAdminUserLifecycleHandler() *AdminUserLifecycleHandler {
+	return &AdminUserLifecycleHandler{}
+}
+
+func (h *AdminUserLifecycleHandler) GetSettingsKpis(c *gin.Context) {
+	if _, ok := getClaims(c); !ok {
+		return
+	}
+
+	type settingsRow struct {
+		NewUserWindowDays  int    `json:"new_user_window_days"`
+		InactiveWindowDays int    `json:"inactive_window_days"`
+		UpdatedAt          string `json:"updated_at"`
+		UpdatedBy          string `json:"updated_by"`
+	}
+	type kpisRow struct {
+		TotalUsers         int `json:"total_users"`
+		TotalPatients      int `json:"total_patients"`
+		TotalDoctors       int `json:"total_doctors"`
+		TotalAdmins        int `json:"total_admins"`
+		NewUsersInWindow   int `json:"new_users_in_window"`
+		InactiveUsersCount int `json:"inactive_users_count"`
+	}
+
+	var settings settingsRow
+	if err := db.Pool.QueryRow(c.Request.Context(), `
+		SELECT
+			new_user_window_days,
+			inactive_window_days,
+			updated_at::text,
+			COALESCE(updated_by::text, '')
+		FROM admin_user_lifecycle_settings
+		WHERE id = TRUE
+	`).Scan(&settings.NewUserWindowDays, &settings.InactiveWindowDays, &settings.UpdatedAt, &settings.UpdatedBy); err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Internal error"})
+		return
+	}
+
+	var kpis kpisRow
+	if err := db.Pool.QueryRow(c.Request.Context(), `
+		WITH cfg AS (
+			SELECT new_user_window_days, inactive_window_days
+			FROM admin_user_lifecycle_settings
+			WHERE id = TRUE
+		),
+		last_activity AS (
+			SELECT user_id, MAX(event_at) AS last_event_at
+			FROM (
+				SELECT id AS user_id, created_at AS event_at FROM users
+				UNION ALL
+				SELECT patient_id AS user_id, created_at AS event_at FROM appointments
+				UNION ALL
+				SELECT doctor_id AS user_id, created_at AS event_at FROM appointments
+				UNION ALL
+				SELECT sender_id AS user_id, created_at AS event_at FROM messages
+			) events
+			GROUP BY user_id
+		)
+		SELECT
+			COUNT(*)::int AS total_users,
+			COUNT(*) FILTER (WHERE u.role = 'patient')::int AS total_patients,
+			COUNT(*) FILTER (WHERE u.role = 'doctor')::int AS total_doctors,
+			COUNT(*) FILTER (WHERE u.role = 'admin')::int AS total_admins,
+			COUNT(*) FILTER (
+				WHERE u.created_at >= NOW() - make_interval(days => cfg.new_user_window_days)
+			)::int AS new_users_in_window,
+			COUNT(*) FILTER (
+				WHERE COALESCE(la.last_event_at, u.created_at) < NOW() - make_interval(days => cfg.inactive_window_days)
+			)::int AS inactive_users_count
+		FROM users u
+		CROSS JOIN cfg
+		LEFT JOIN last_activity la ON la.user_id = u.id
+	`).Scan(
+		&kpis.TotalUsers,
+		&kpis.TotalPatients,
+		&kpis.TotalDoctors,
+		&kpis.TotalAdmins,
+		&kpis.NewUsersInWindow,
+		&kpis.InactiveUsersCount,
+	); err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Internal error"})
+		return
+	}
+
+	c.JSON(http.StatusOK, gin.H{
+		"settings": settings,
+		"kpis":     kpis,
+	})
+}
+
+func (h *AdminUserLifecycleHandler) UpdateSettings(c *gin.Context) {
+	claims, ok := getClaims(c)
+	if !ok {
+		return
+	}
+
+	var req updateLifecycleSettingsRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid request body"})
+		return
+	}
+	if req.NewUserWindowDays < 1 || req.NewUserWindowDays > 3650 {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "new_user_window_days must be between 1 and 3650"})
+		return
+	}
+	if req.InactiveWindowDays < 1 || req.InactiveWindowDays > 3650 {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "inactive_window_days must be between 1 and 3650"})
+		return
+	}
+
+	if _, err := db.Pool.Exec(c.Request.Context(), `
+		UPDATE admin_user_lifecycle_settings
+		SET
+			new_user_window_days = $1,
+			inactive_window_days = $2,
+			updated_by = $3,
+			updated_at = NOW()
+		WHERE id = TRUE
+	`, req.NewUserWindowDays, req.InactiveWindowDays, claims.UserID); err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Internal error"})
+		return
+	}
+
+	h.GetSettingsKpis(c)
+}

--- a/backend/handlers/admin_user_lifecycle_test.go
+++ b/backend/handlers/admin_user_lifecycle_test.go
@@ -1,0 +1,41 @@
+package handlers
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
+)
+
+func TestAdminUserLifecycle_GetSettingsKpis_Unauthorized(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest("GET", "/api/admin/user-lifecycle/settings-kpis", nil)
+
+	h := NewAdminUserLifecycleHandler()
+	h.GetSettingsKpis(c)
+
+	if w.Code != http.StatusUnauthorized {
+		t.Fatalf("expected 401, got %d", w.Code)
+	}
+}
+
+func TestAdminUserLifecycle_UpdateSettings_BadRange(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest("PUT", "/api/admin/user-lifecycle/settings", strings.NewReader(`{"new_user_window_days":0,"inactive_window_days":30}`))
+	c.Request.Header.Set("Content-Type", "application/json")
+	c.Set("claims", &Claims{UserID: uuid.New(), Role: "admin"})
+
+	h := NewAdminUserLifecycleHandler()
+	h.UpdateSettings(c)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d", w.Code)
+	}
+}

--- a/backend/main.go
+++ b/backend/main.go
@@ -89,10 +89,13 @@ func main() {
 		// Role-protected: demonstrates 403 when role doesn't match
 		adminAudit := handlers.NewAdminAuditHandler()
 		knowledge := handlers.NewKnowledgeAdminHandler()
+		userLifecycle := handlers.NewAdminUserLifecycleHandler()
 		api.GET("/admin", auth.RequireAuth(), auth.RequireRole("admin"), func(c *gin.Context) {
 			c.JSON(http.StatusOK, gin.H{"message": "Admin only"})
 		})
 		api.GET("/admin/audit-log", auth.RequireAuth(), auth.RequireRole("admin"), adminAudit.List)
+		api.GET("/admin/user-lifecycle/settings-kpis", auth.RequireAuth(), auth.RequireRole("admin"), userLifecycle.GetSettingsKpis)
+		api.PUT("/admin/user-lifecycle/settings", auth.RequireAuth(), auth.RequireRole("admin"), userLifecycle.UpdateSettings)
 		api.GET("/admin/notifications", auth.RequireAuth(), auth.RequireRole("admin"), notifications.AdminList)
 		api.GET("/admin/notifications/summary", auth.RequireAuth(), auth.RequireRole("admin"), notifications.AdminSummary)
 		api.POST("/admin/notifications/:id/retry", auth.RequireAuth(), auth.RequireRole("admin"), notifications.RetryFailed)


### PR DESCRIPTION
## Summary
Implements PR-31 backend scope: **phase7/admin-user-lifecycle-settings-kpis-api**.

- Adds dmin_user_lifecycle_settings table with seeded singleton config row.
- Adds admin handler endpoints to fetch lifecycle settings + KPI aggregates and update lifecycle window settings.
- Wires routes under /api/admin/user-lifecycle/* and includes handler tests for unauthorized + validation cases.

## Verification
- go test ./...

Made with [Cursor](https://cursor.com)