### PR TITLE
feat(frontend): phase7 admin management settings dashboard UI

### DIFF
--- a/frontend/src/app/app.routes.ts
+++ b/frontend/src/app/app.routes.ts
@@ -8,6 +8,7 @@ import { AdminShellComponent } from './components/admin-shell/admin-shell.compon
 import { AdminAuditComponent } from './components/admin-audit/admin-audit.component';
 import { AdminNotificationsLogComponent } from './components/admin-notifications-log/admin-notifications-log.component';
 import { AdminKnowledgeComponent } from './components/admin-knowledge/admin-knowledge.component';
+import { AdminManagementComponent } from './components/admin-management/admin-management.component';
 import { PatientAppointmentsComponent } from './components/patient-appointments/patient-appointments.component';
 import { PatientAppointmentDetailComponent } from './components/patient-appointment-detail/patient-appointment-detail.component';
 import { DoctorAppointmentsComponent } from './components/doctor-appointments/doctor-appointments.component';
@@ -193,6 +194,12 @@ export const routes: Routes = [
             path: 'knowledge',
             component: AdminKnowledgeComponent,
             data: { title: 'Knowledge', roles: ['admin'] },
+            canActivate: [roleGuard]
+          },
+          {
+            path: 'management',
+            component: AdminManagementComponent,
+            data: { title: 'Management', roles: ['admin'] },
             canActivate: [roleGuard]
           }
         ]

--- a/frontend/src/app/components/admin-management/admin-management.component.html
+++ b/frontend/src/app/components/admin-management/admin-management.component.html
@@ -1,0 +1,45 @@
+<section class="admin-management" data-cy="admin-management-page">
+  <header class="head">
+    <h1>Admin management</h1>
+    <p>User lifecycle KPIs and threshold settings.</p>
+  </header>
+
+  <p class="state" *ngIf="loading">Loading dashboard...</p>
+  <p class="state err" *ngIf="!loading && error">{{ error }}</p>
+  <p class="state ok" *ngIf="!loading && success">{{ success }}</p>
+
+  <div class="kpi-grid" *ngIf="!loading && kpis">
+    <article class="kpi"><span>Total users</span><strong>{{ kpis.total_users }}</strong></article>
+    <article class="kpi"><span>Patients</span><strong>{{ kpis.total_patients }}</strong></article>
+    <article class="kpi"><span>Doctors</span><strong>{{ kpis.total_doctors }}</strong></article>
+    <article class="kpi"><span>Admins</span><strong>{{ kpis.total_admins }}</strong></article>
+    <article class="kpi"><span>New users (window)</span><strong>{{ kpis.new_users_in_window }}</strong></article>
+    <article class="kpi"><span>Inactive users</span><strong>{{ kpis.inactive_users_count }}</strong></article>
+  </div>
+
+  <form class="settings" *ngIf="!loading && settings" (ngSubmit)="save()">
+    <h2>Lifecycle settings</h2>
+    <label>
+      <span>New user window (days)</span>
+      <input
+        type="number"
+        name="newUserWindowDays"
+        min="1"
+        max="3650"
+        [(ngModel)]="form.new_user_window_days"
+      />
+    </label>
+    <label>
+      <span>Inactive user window (days)</span>
+      <input
+        type="number"
+        name="inactiveWindowDays"
+        min="1"
+        max="3650"
+        [(ngModel)]="form.inactive_window_days"
+      />
+    </label>
+    <p class="muted">Last updated: {{ settings.updated_at || 'n/a' }}</p>
+    <button type="submit" [disabled]="saving">{{ saving ? 'Saving...' : 'Save settings' }}</button>
+  </form>
+</section>

--- a/frontend/src/app/components/admin-management/admin-management.component.scss
+++ b/frontend/src/app/components/admin-management/admin-management.component.scss
@@ -1,0 +1,96 @@
+.admin-management {
+  display: grid;
+  gap: 1rem;
+}
+
+.head h1 {
+  margin: 0;
+}
+
+.head p {
+  margin: 0.25rem 0 0;
+  color: #94a3b8;
+}
+
+.state {
+  margin: 0;
+}
+
+.state.err {
+  color: #f87171;
+}
+
+.state.ok {
+  color: #34d399;
+}
+
+.kpi-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(170px, 1fr));
+  gap: 0.75rem;
+}
+
+.kpi {
+  border: 1px solid rgba(148, 163, 184, 0.35);
+  border-radius: 0.5rem;
+  background: rgba(15, 23, 42, 0.35);
+  padding: 0.75rem;
+  display: grid;
+  gap: 0.35rem;
+}
+
+.kpi span {
+  color: #94a3b8;
+  font-size: 0.8rem;
+}
+
+.kpi strong {
+  font-size: 1.3rem;
+}
+
+.settings {
+  display: grid;
+  gap: 0.75rem;
+  border: 1px solid rgba(148, 163, 184, 0.3);
+  border-radius: 0.5rem;
+  padding: 1rem;
+  max-width: 480px;
+}
+
+.settings h2 {
+  margin: 0;
+}
+
+.settings label {
+  display: grid;
+  gap: 0.35rem;
+}
+
+.settings input {
+  background: rgba(15, 23, 42, 0.65);
+  border: 1px solid rgba(148, 163, 184, 0.35);
+  border-radius: 0.35rem;
+  color: #e2e8f0;
+  padding: 0.45rem 0.55rem;
+}
+
+.settings button {
+  width: fit-content;
+  border: 1px solid #22d3ee;
+  border-radius: 0.35rem;
+  background: transparent;
+  color: #22d3ee;
+  padding: 0.45rem 0.75rem;
+  cursor: pointer;
+}
+
+.settings button:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.muted {
+  margin: 0;
+  color: #94a3b8;
+  font-size: 0.85rem;
+}

--- a/frontend/src/app/components/admin-management/admin-management.component.ts
+++ b/frontend/src/app/components/admin-management/admin-management.component.ts
@@ -1,0 +1,76 @@
+import { Component, OnInit } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormsModule } from '@angular/forms';
+import {
+  AdminLifecycleKpis,
+  AdminLifecycleSettings,
+  AdminUserLifecycleService
+} from '../../services/admin-user-lifecycle.service';
+
+@Component({
+  selector: 'app-admin-management',
+  standalone: true,
+  imports: [CommonModule, FormsModule],
+  templateUrl: './admin-management.component.html',
+  styleUrl: './admin-management.component.scss'
+})
+export class AdminManagementComponent implements OnInit {
+  loading = true;
+  saving = false;
+  error: string | null = null;
+  success: string | null = null;
+  settings: AdminLifecycleSettings | null = null;
+  kpis: AdminLifecycleKpis | null = null;
+
+  form = {
+    new_user_window_days: 14,
+    inactive_window_days: 30
+  };
+
+  constructor(private readonly api: AdminUserLifecycleService) {}
+
+  ngOnInit(): void {
+    this.load();
+  }
+
+  load(): void {
+    this.loading = true;
+    this.error = null;
+    this.api.getSettingsKpis().subscribe({
+      next: (res) => {
+        this.settings = res.settings;
+        this.kpis = res.kpis;
+        this.form.new_user_window_days = res.settings.new_user_window_days;
+        this.form.inactive_window_days = res.settings.inactive_window_days;
+        this.loading = false;
+      },
+      error: () => {
+        this.error = 'Could not load lifecycle settings.';
+        this.loading = false;
+      }
+    });
+  }
+
+  save(): void {
+    this.saving = true;
+    this.error = null;
+    this.success = null;
+    this.api
+      .updateSettings({
+        new_user_window_days: Number(this.form.new_user_window_days),
+        inactive_window_days: Number(this.form.inactive_window_days)
+      })
+      .subscribe({
+        next: (res) => {
+          this.settings = res.settings;
+          this.kpis = res.kpis;
+          this.success = 'Settings updated.';
+          this.saving = false;
+        },
+        error: () => {
+          this.error = 'Could not update settings.';
+          this.saving = false;
+        }
+      });
+  }
+}

--- a/frontend/src/app/components/admin-shell/admin-shell.component.ts
+++ b/frontend/src/app/components/admin-shell/admin-shell.component.ts
@@ -11,6 +11,7 @@ import { RouterLink, RouterLinkActive, RouterOutlet } from '@angular/router';
       <a routerLink="/admin/audit" routerLinkActive="active">Audit log</a>
       <a routerLink="/admin/notifications" routerLinkActive="active">Notifications</a>
       <a routerLink="/admin/knowledge" routerLinkActive="active">Knowledge</a>
+      <a routerLink="/admin/management" routerLinkActive="active">Management</a>
     </nav>
     <router-outlet />
   `,

--- a/frontend/src/app/services/admin-user-lifecycle.service.ts
+++ b/frontend/src/app/services/admin-user-lifecycle.service.ts
@@ -1,0 +1,41 @@
+import { Injectable } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { Observable } from 'rxjs';
+import { ApiContract } from './api-contract';
+
+export type AdminLifecycleSettings = {
+  new_user_window_days: number;
+  inactive_window_days: number;
+  updated_at: string;
+  updated_by: string;
+};
+
+export type AdminLifecycleKpis = {
+  total_users: number;
+  total_patients: number;
+  total_doctors: number;
+  total_admins: number;
+  new_users_in_window: number;
+  inactive_users_count: number;
+};
+
+export type AdminLifecycleSettingsKpisResponse = {
+  settings: AdminLifecycleSettings;
+  kpis: AdminLifecycleKpis;
+};
+
+@Injectable({ providedIn: 'root' })
+export class AdminUserLifecycleService {
+  constructor(private http: HttpClient) {}
+
+  getSettingsKpis(): Observable<AdminLifecycleSettingsKpisResponse> {
+    return this.http.get<AdminLifecycleSettingsKpisResponse>(ApiContract.admin.userLifecycleSettingsKpis);
+  }
+
+  updateSettings(payload: {
+    new_user_window_days: number;
+    inactive_window_days: number;
+  }): Observable<AdminLifecycleSettingsKpisResponse> {
+    return this.http.put<AdminLifecycleSettingsKpisResponse>(ApiContract.admin.userLifecycleSettings, payload);
+  }
+}

--- a/frontend/src/app/services/api-contract.ts
+++ b/frontend/src/app/services/api-contract.ts
@@ -68,6 +68,8 @@ export const ApiContract = {
   },
   admin: {
     auditLog: `${API}/admin/audit-log`,
+    userLifecycleSettingsKpis: `${API}/admin/user-lifecycle/settings-kpis`,
+    userLifecycleSettings: `${API}/admin/user-lifecycle/settings`,
     knowledgeDocs: `${API}/admin/knowledge-docs`,
     knowledgeSimilarityScan: `${API}/admin/knowledge-docs/similarity-scan`,
     knowledgeDocById: (id: string): string => `${API}/admin/knowledge-docs/${id}`,


### PR DESCRIPTION
## Summary
Implements PR-31 frontend scope: **phase7/admin-management-settings-dashboard-ui**.

- Adds admin lifecycle service for settings/KPI endpoints.
- Adds new Admin Management page with KPI cards and editable lifecycle settings.
- Wires route + admin subnav link for /admin/management.

## Verification
- 
pm run test:ci
- 
pm run build

Made with [Cursor](https://cursor.com)