### PR TITLE
chore(test): add AI runtime coverage and API collection

### DIFF
--- a/backend/handlers/doctor_documents_rate_limit_test.go
+++ b/backend/handlers/doctor_documents_rate_limit_test.go
@@ -1,0 +1,46 @@
+package handlers
+
+import (
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+func TestAllowSummarizeForDoctor_RateLimit(t *testing.T) {
+	doctorID := uuid.New()
+
+	summarizeRateMu.Lock()
+	summarizeRateByDoctor = map[uuid.UUID]summarizeRateBucket{}
+	summarizeRateMu.Unlock()
+
+	if !allowSummarizeForDoctor(doctorID, 2) {
+		t.Fatalf("first call should be allowed")
+	}
+	if !allowSummarizeForDoctor(doctorID, 2) {
+		t.Fatalf("second call should be allowed")
+	}
+	if allowSummarizeForDoctor(doctorID, 2) {
+		t.Fatalf("third call should be blocked by rate limit")
+	}
+}
+
+func TestAllowSummarizeForDoctor_WindowReset(t *testing.T) {
+	doctorID := uuid.New()
+
+	summarizeRateMu.Lock()
+	summarizeRateByDoctor = map[uuid.UUID]summarizeRateBucket{
+		doctorID: {
+			windowStart: time.Now().Add(-2 * time.Minute),
+			count:       50,
+		},
+	}
+	summarizeRateMu.Unlock()
+
+	if !allowSummarizeForDoctor(doctorID, 1) {
+		t.Fatalf("window should reset after one minute")
+	}
+	if allowSummarizeForDoctor(doctorID, 1) {
+		t.Fatalf("second call in new window should be blocked for limit=1")
+	}
+}

--- a/backend/tests/ai-runtime.postman_collection.json
+++ b/backend/tests/ai-runtime.postman_collection.json
@@ -1,0 +1,108 @@
+{
+  "info": {
+    "name": "Healthonyx AI Runtime API",
+    "_postman_id": "6f9ef6c9-0f0f-4f9d-9d61-2c6d6b17d111",
+    "description": "Backend API checks for admin AI runtime settings, observability and eval endpoints.",
+    "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
+  },
+  "item": [
+    {
+      "name": "Get AI observability",
+      "request": {
+        "method": "GET",
+        "header": [
+          {
+            "key": "Authorization",
+            "value": "Bearer {{admin_token}}"
+          }
+        ],
+        "url": {
+          "raw": "{{base_url}}/api/admin/ai/observability",
+          "host": [
+            "{{base_url}}"
+          ],
+          "path": [
+            "api",
+            "admin",
+            "ai",
+            "observability"
+          ]
+        }
+      }
+    },
+    {
+      "name": "Update AI settings",
+      "request": {
+        "method": "PUT",
+        "header": [
+          {
+            "key": "Authorization",
+            "value": "Bearer {{admin_token}}"
+          },
+          {
+            "key": "Content-Type",
+            "value": "application/json"
+          }
+        ],
+        "body": {
+          "mode": "raw",
+          "raw": "{\n  \"ollama_enabled\": true,\n  \"fallback_enabled\": true,\n  \"rate_limit_enabled\": true,\n  \"rate_limit_per_minute\": 20,\n  \"cache_enabled\": true,\n  \"cache_ttl_seconds\": 900,\n  \"ollama_model\": \"llama3.1:8b\"\n}"
+        },
+        "url": {
+          "raw": "{{base_url}}/api/admin/ai/settings",
+          "host": [
+            "{{base_url}}"
+          ],
+          "path": [
+            "api",
+            "admin",
+            "ai",
+            "settings"
+          ]
+        }
+      }
+    },
+    {
+      "name": "Run AI eval",
+      "request": {
+        "method": "POST",
+        "header": [
+          {
+            "key": "Authorization",
+            "value": "Bearer {{admin_token}}"
+          },
+          {
+            "key": "Content-Type",
+            "value": "application/json"
+          }
+        ],
+        "body": {
+          "mode": "raw",
+          "raw": "{}"
+        },
+        "url": {
+          "raw": "{{base_url}}/api/admin/ai/eval",
+          "host": [
+            "{{base_url}}"
+          ],
+          "path": [
+            "api",
+            "admin",
+            "ai",
+            "eval"
+          ]
+        }
+      }
+    }
+  ],
+  "variable": [
+    {
+      "key": "base_url",
+      "value": "http://127.0.0.1:8080"
+    },
+    {
+      "key": "admin_token",
+      "value": ""
+    }
+  ]
+}

--- a/frontend/cypress/e2e/admin-ai.cy.js
+++ b/frontend/cypress/e2e/admin-ai.cy.js
@@ -1,0 +1,89 @@
+describe('admin ai observability', () => {
+  it('renders controls and runs eval', () => {
+    const API = Cypress.env('API_URL');
+    cy.intercept('GET', '**/api/admin/ai/observability', {
+      statusCode: 200,
+      body: {
+        settings: {
+          ollama_enabled: false,
+          fallback_enabled: true,
+          rate_limit_enabled: true,
+          rate_limit_per_minute: 30,
+          cache_enabled: true,
+          cache_ttl_seconds: 900,
+          ollama_model: 'llama3.1:8b',
+          updated_at: '2026-04-28T00:00:00Z',
+          updated_by: ''
+        },
+        observability: {
+          queued_jobs_24h: 4,
+          completed_jobs_24h: 3,
+          failed_jobs_24h: 1,
+          avg_latency_seconds: 0.35,
+          cache_ready_count: 10,
+          pending_docs_count: 2,
+          failed_docs_count: 1
+        }
+      }
+    }).as('getObs');
+
+    cy.intercept('PUT', '**/api/admin/ai/settings', (req) => {
+      req.reply({
+        statusCode: 200,
+        body: {
+          settings: {
+            ...req.body,
+            updated_at: '2026-04-28T00:01:00Z',
+            updated_by: 'admin-id'
+          },
+          observability: {
+            queued_jobs_24h: 5,
+            completed_jobs_24h: 4,
+            failed_jobs_24h: 1,
+            avg_latency_seconds: 0.31,
+            cache_ready_count: 11,
+            pending_docs_count: 1,
+            failed_docs_count: 1
+          }
+        }
+      });
+    }).as('putSettings');
+
+    cy.intercept('POST', '**/api/admin/ai/eval', {
+      statusCode: 200,
+      body: {
+        eval: {
+          model_name: 'llama3.1:8b',
+          samples_evaluated: 20,
+          success_rate: 0.8,
+          quality_score: 80
+        }
+      }
+    }).as('runEval');
+
+    cy.request('POST', `${API}/api/login`, {
+      email: 'admin@healthonyx.demo',
+      password: 'admin123'
+    }).then((res) => {
+      const { token, user } = res.body;
+      cy.visit('/admin/ai', {
+        onBeforeLoad(win) {
+          win.localStorage.setItem('token', token);
+          win.localStorage.setItem('user', JSON.stringify(user));
+        }
+      });
+    });
+    cy.wait('@getObs');
+
+    cy.contains('AI observability and controls').should('exist');
+    cy.get('input[name="rateLimitPerMinute"]').clear().type('25');
+    cy.contains('Save controls').click();
+    cy.wait('@putSettings');
+    cy.contains('AI runtime settings updated.').should('exist');
+
+    cy.contains('Run eval').click();
+    cy.wait('@runEval');
+    cy.contains('Eval result').should('exist');
+    cy.contains('Samples:').should('exist');
+  });
+});

--- a/frontend/src/app/components/admin-ai-observability/admin-ai-observability.component.spec.ts
+++ b/frontend/src/app/components/admin-ai-observability/admin-ai-observability.component.spec.ts
@@ -1,0 +1,106 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { of } from 'rxjs';
+import { AdminAiObservabilityComponent } from './admin-ai-observability.component';
+import { AdminAiRuntimeService } from '../../services/admin-ai-runtime.service';
+
+describe('AdminAiObservabilityComponent', () => {
+  let fixture: ComponentFixture<AdminAiObservabilityComponent>;
+  let serviceSpy: jasmine.SpyObj<AdminAiRuntimeService>;
+
+  beforeEach(async () => {
+    serviceSpy = jasmine.createSpyObj<AdminAiRuntimeService>('AdminAiRuntimeService', [
+      'getObservability',
+      'updateSettings',
+      'runEval'
+    ]);
+    serviceSpy.getObservability.and.returnValue(
+      of({
+        settings: {
+          ollama_enabled: false,
+          fallback_enabled: true,
+          rate_limit_enabled: true,
+          rate_limit_per_minute: 30,
+          cache_enabled: true,
+          cache_ttl_seconds: 900,
+          ollama_model: 'llama3.1:8b',
+          updated_at: '2026-04-28T00:00:00Z',
+          updated_by: ''
+        },
+        observability: {
+          queued_jobs_24h: 2,
+          completed_jobs_24h: 2,
+          failed_jobs_24h: 0,
+          avg_latency_seconds: 0.25,
+          cache_ready_count: 4,
+          pending_docs_count: 1,
+          failed_docs_count: 0
+        }
+      })
+    );
+
+    await TestBed.configureTestingModule({
+      imports: [AdminAiObservabilityComponent],
+      providers: [{ provide: AdminAiRuntimeService, useValue: serviceSpy }]
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(AdminAiObservabilityComponent);
+    fixture.detectChanges();
+  });
+
+  it('loads and renders page', () => {
+    const el = fixture.nativeElement as HTMLElement;
+    expect(serviceSpy.getObservability).toHaveBeenCalled();
+    expect(el.querySelector('[data-cy="admin-ai-observability-page"]')).toBeTruthy();
+  });
+
+  it('saves settings', () => {
+    serviceSpy.updateSettings.and.returnValue(
+      of({
+        settings: {
+          ollama_enabled: true,
+          fallback_enabled: true,
+          rate_limit_enabled: true,
+          rate_limit_per_minute: 20,
+          cache_enabled: true,
+          cache_ttl_seconds: 600,
+          ollama_model: 'llama3.1:8b',
+          updated_at: '2026-04-28T00:00:00Z',
+          updated_by: 'admin'
+        },
+        observability: {
+          queued_jobs_24h: 1,
+          completed_jobs_24h: 1,
+          failed_jobs_24h: 0,
+          avg_latency_seconds: 0.1,
+          cache_ready_count: 5,
+          pending_docs_count: 0,
+          failed_docs_count: 0
+        }
+      })
+    );
+
+    const component = fixture.componentInstance;
+    component.form.ollama_enabled = true;
+    component.form.rate_limit_per_minute = 20;
+    component.save();
+
+    expect(serviceSpy.updateSettings).toHaveBeenCalled();
+  });
+
+  it('runs eval', () => {
+    serviceSpy.runEval.and.returnValue(
+      of({
+        eval: {
+          model_name: 'llama3.1:8b',
+          samples_evaluated: 8,
+          success_rate: 0.75,
+          quality_score: 75
+        }
+      })
+    );
+    const component = fixture.componentInstance;
+    component.runEval();
+    expect(serviceSpy.runEval).toHaveBeenCalled();
+    expect(component.evalResult?.samples_evaluated).toBe(8);
+  });
+});

--- a/frontend/src/app/services/admin-ai-runtime.service.spec.ts
+++ b/frontend/src/app/services/admin-ai-runtime.service.spec.ts
@@ -1,0 +1,113 @@
+import { TestBed } from '@angular/core/testing';
+import { provideHttpClient } from '@angular/common/http';
+import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
+import { AdminAiRuntimeService } from './admin-ai-runtime.service';
+import { ApiContract } from './api-contract';
+
+describe('AdminAiRuntimeService', () => {
+  let service: AdminAiRuntimeService;
+  let httpMock: HttpTestingController;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [AdminAiRuntimeService, provideHttpClient(), provideHttpClientTesting()]
+    });
+    service = TestBed.inject(AdminAiRuntimeService);
+    httpMock = TestBed.inject(HttpTestingController);
+  });
+
+  afterEach(() => httpMock.verify());
+
+  it('loads observability payload', () => {
+    service.getObservability().subscribe((res) => {
+      expect(res.settings.ollama_model).toBe('llama3.1:8b');
+      expect(res.observability.queued_jobs_24h).toBe(4);
+    });
+
+    const req = httpMock.expectOne(ApiContract.admin.aiObservability);
+    expect(req.request.method).toBe('GET');
+    req.flush({
+      settings: {
+        ollama_enabled: false,
+        fallback_enabled: true,
+        rate_limit_enabled: true,
+        rate_limit_per_minute: 30,
+        cache_enabled: true,
+        cache_ttl_seconds: 900,
+        ollama_model: 'llama3.1:8b',
+        updated_at: '2026-04-28T00:00:00Z',
+        updated_by: ''
+      },
+      observability: {
+        queued_jobs_24h: 4,
+        completed_jobs_24h: 3,
+        failed_jobs_24h: 1,
+        avg_latency_seconds: 0.45,
+        cache_ready_count: 9,
+        pending_docs_count: 1,
+        failed_docs_count: 0
+      }
+    });
+  });
+
+  it('updates runtime settings', () => {
+    service
+      .updateSettings({
+        ollama_enabled: true,
+        fallback_enabled: true,
+        rate_limit_enabled: true,
+        rate_limit_per_minute: 20,
+        cache_enabled: true,
+        cache_ttl_seconds: 1200,
+        ollama_model: 'llama3.1:8b'
+      })
+      .subscribe((res) => {
+        expect(res.settings.ollama_enabled).toBeTrue();
+        expect(res.settings.rate_limit_per_minute).toBe(20);
+      });
+
+    const req = httpMock.expectOne(ApiContract.admin.aiSettings);
+    expect(req.request.method).toBe('PUT');
+    expect(req.request.body.rate_limit_per_minute).toBe(20);
+    req.flush({
+      settings: {
+        ollama_enabled: true,
+        fallback_enabled: true,
+        rate_limit_enabled: true,
+        rate_limit_per_minute: 20,
+        cache_enabled: true,
+        cache_ttl_seconds: 1200,
+        ollama_model: 'llama3.1:8b',
+        updated_at: '2026-04-28T00:00:00Z',
+        updated_by: 'admin-id'
+      },
+      observability: {
+        queued_jobs_24h: 5,
+        completed_jobs_24h: 4,
+        failed_jobs_24h: 1,
+        avg_latency_seconds: 0.4,
+        cache_ready_count: 10,
+        pending_docs_count: 0,
+        failed_docs_count: 0
+      }
+    });
+  });
+
+  it('runs eval', () => {
+    service.runEval().subscribe((res) => {
+      expect(res.eval.model_name).toBe('llama3.1:8b');
+      expect(res.eval.samples_evaluated).toBe(12);
+    });
+
+    const req = httpMock.expectOne(ApiContract.admin.aiEval);
+    expect(req.request.method).toBe('POST');
+    req.flush({
+      eval: {
+        model_name: 'llama3.1:8b',
+        samples_evaluated: 12,
+        success_rate: 0.75,
+        quality_score: 75
+      }
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- add backend rate-limit tests for doctor summarize flow
- add frontend unit tests for AI runtime service and admin AI component
- add Cypress admin AI flow and backend Postman collection for AI runtime APIs

## Verification
- go test ./...
- npm run test:ci
- npm run cypress:e2e

Made with [Cursor](https://cursor.com)