### PR TITLE
feat(backend): PR-01 AI runtime core integration

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -16,3 +16,13 @@ PORT=8080
 # NOMINATIM_BASE_URL=https://nominatim.openstreetmap.org
 # Identifiable User-Agent for Nominatim (set to your real contact URL in production).
 # GEOCODE_USER_AGENT=Healthonyx/1.0 (https://example.com/contact)
+
+# AI runtime core integration (PR-01)
+# Global switch: false forces fallback-safe local behavior.
+AI_ENABLED=false
+# Local Ollama server base URL
+OLLAMA_HOST=http://127.0.0.1:11434
+# Default model for document summaries/eval
+OLLAMA_MODEL=llama3.1:8b
+# Request timeout to Ollama in milliseconds
+OLLAMA_TIMEOUT_MS=7000

--- a/backend/config/config.go
+++ b/backend/config/config.go
@@ -2,6 +2,8 @@ package config
 
 import (
 	"os"
+	"strconv"
+	"strings"
 
 	"github.com/joho/godotenv"
 )
@@ -11,13 +13,17 @@ func init() {
 }
 
 type Config struct {
-	DatabaseURL       string
-	JWTSecret         string
-	Port              string
-	CORSOrigins       string // Comma-separated, e.g. "http://localhost:4200,http://localhost:3000"
-	NominatimBaseURL  string // OpenStreetMap Nominatim (or self-hosted). Empty = public default.
-	GeocodeUserAgent  string // Required-style identification for Nominatim; override in production.
-	UploadDir         string // Patient file uploads (filesystem); default data/uploads
+	DatabaseURL      string
+	JWTSecret        string
+	Port             string
+	CORSOrigins      string // Comma-separated, e.g. "http://localhost:4200,http://localhost:3000"
+	NominatimBaseURL string // OpenStreetMap Nominatim (or self-hosted). Empty = public default.
+	GeocodeUserAgent string // Required-style identification for Nominatim; override in production.
+	UploadDir        string // Patient file uploads (filesystem); default data/uploads
+	AIEnabled        bool   // Global AI kill switch. false => always use fallback behavior.
+	OllamaHost       string // Ollama base URL, e.g. http://127.0.0.1:11434
+	OllamaModel      string // Default Ollama model name.
+	OllamaTimeoutMS  int    // Timeout for Ollama HTTP calls in milliseconds.
 }
 
 func Load() *Config {
@@ -29,6 +35,14 @@ func Load() *Config {
 	if uploadDir == "" {
 		uploadDir = "data/uploads"
 	}
+	ollamaHost := os.Getenv("OLLAMA_HOST")
+	if ollamaHost == "" {
+		ollamaHost = "http://127.0.0.1:11434"
+	}
+	ollamaModel := os.Getenv("OLLAMA_MODEL")
+	if ollamaModel == "" {
+		ollamaModel = "llama3.1:8b"
+	}
 	return &Config{
 		DatabaseURL:      os.Getenv("DATABASE_URL"),
 		JWTSecret:        os.Getenv("JWT_SECRET"),
@@ -37,5 +51,17 @@ func Load() *Config {
 		NominatimBaseURL: os.Getenv("NOMINATIM_BASE_URL"),
 		GeocodeUserAgent: os.Getenv("GEOCODE_USER_AGENT"),
 		UploadDir:        uploadDir,
+		AIEnabled:        strings.EqualFold(strings.TrimSpace(os.Getenv("AI_ENABLED")), "true"),
+		OllamaHost:       ollamaHost,
+		OllamaModel:      ollamaModel,
+		OllamaTimeoutMS:  parsePositiveIntWithDefault(os.Getenv("OLLAMA_TIMEOUT_MS"), 7000),
 	}
+}
+
+func parsePositiveIntWithDefault(raw string, fallback int) int {
+	v, err := strconv.Atoi(strings.TrimSpace(raw))
+	if err != nil || v <= 0 {
+		return fallback
+	}
+	return v
 }

--- a/backend/handlers/admin_ai_runtime.go
+++ b/backend/handlers/admin_ai_runtime.go
@@ -1,6 +1,7 @@
 package handlers
 
 import (
+	"context"
 	"net/http"
 	"strings"
 
@@ -68,10 +69,12 @@ func (h *AdminAIRuntimeHandler) GetObservability(c *gin.Context) {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "Internal error"})
 		return
 	}
+	runtime := getOllamaRuntimeStatus(c.Request.Context(), settings)
 
 	c.JSON(http.StatusOK, gin.H{
 		"settings":      settings,
 		"observability": obs,
+		"runtime":       runtime,
 	})
 }
 
@@ -159,12 +162,44 @@ func (h *AdminAIRuntimeHandler) RunEval(c *gin.Context) {
 		result.SuccessRate = float64(doneCount) / float64(samples)
 		result.QualityScore = result.SuccessRate * 100
 	}
-	c.JSON(http.StatusOK, gin.H{"eval": result})
+	c.JSON(http.StatusOK, gin.H{
+		"eval":    result,
+		"runtime": getOllamaRuntimeStatus(c.Request.Context(), settings),
+	})
 }
 
 func loadAIRuntimeSettings(c *gin.Context) (adminAIRuntimeSettings, error) {
 	var out adminAIRuntimeSettings
 	err := db.Pool.QueryRow(c.Request.Context(), `
+		SELECT
+			ollama_enabled,
+			fallback_enabled,
+			rate_limit_enabled,
+			rate_limit_per_minute,
+			cache_enabled,
+			cache_ttl_seconds,
+			ollama_model,
+			updated_at::text,
+			COALESCE(updated_by::text, '')
+		FROM admin_ai_runtime_settings
+		WHERE id = TRUE
+	`).Scan(
+		&out.OllamaEnabled,
+		&out.FallbackEnabled,
+		&out.RateLimitEnabled,
+		&out.RateLimitPerMinute,
+		&out.CacheEnabled,
+		&out.CacheTTLSeconds,
+		&out.OllamaModel,
+		&out.UpdatedAt,
+		&out.UpdatedBy,
+	)
+	return out, err
+}
+
+func LoadAIRuntimeSettingsForWorker(ctx context.Context) (adminAIRuntimeSettings, error) {
+	var out adminAIRuntimeSettings
+	err := db.Pool.QueryRow(ctx, `
 		SELECT
 			ollama_enabled,
 			fallback_enabled,

--- a/backend/handlers/ai_runtime_core.go
+++ b/backend/handlers/ai_runtime_core.go
@@ -1,0 +1,224 @@
+package handlers
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"sync"
+	"time"
+)
+
+type aiRuntimeConfig struct {
+	AIEnabled       bool
+	OllamaHost      string
+	OllamaModel     string
+	OllamaTimeoutMS int
+}
+
+var (
+	aiRuntimeCfgMu sync.RWMutex
+	aiRuntimeCfg   = aiRuntimeConfig{
+		AIEnabled:       false,
+		OllamaHost:      "http://127.0.0.1:11434",
+		OllamaModel:     "llama3.1:8b",
+		OllamaTimeoutMS: 7000,
+	}
+)
+
+type ollamaRuntimeStatus struct {
+	AIEnabled       bool   `json:"ai_enabled"`
+	OllamaHost      string `json:"ollama_host"`
+	ConfiguredModel string `json:"configured_model"`
+	OllamaReachable bool   `json:"ollama_reachable"`
+	ModelAvailable  bool   `json:"model_available"`
+	ActiveMode      string `json:"active_mode"`
+}
+
+type ollamaTagsResponse struct {
+	Models []struct {
+		Name  string `json:"name"`
+		Model string `json:"model"`
+	} `json:"models"`
+}
+
+type ollamaGenerateResponse struct {
+	Response string `json:"response"`
+}
+
+func ConfigureAIRuntime(enabled bool, host, model string, timeoutMS int) {
+	aiRuntimeCfgMu.Lock()
+	defer aiRuntimeCfgMu.Unlock()
+
+	host = strings.TrimSpace(host)
+	if host == "" {
+		host = "http://127.0.0.1:11434"
+	}
+	model = strings.TrimSpace(model)
+	if model == "" {
+		model = "llama3.1:8b"
+	}
+	if timeoutMS <= 0 {
+		timeoutMS = 7000
+	}
+	aiRuntimeCfg = aiRuntimeConfig{
+		AIEnabled:       enabled,
+		OllamaHost:      strings.TrimRight(host, "/"),
+		OllamaModel:     model,
+		OllamaTimeoutMS: timeoutMS,
+	}
+}
+
+func getAIRuntimeConfig() aiRuntimeConfig {
+	aiRuntimeCfgMu.RLock()
+	defer aiRuntimeCfgMu.RUnlock()
+	return aiRuntimeCfg
+}
+
+func getOllamaRuntimeStatus(ctx context.Context, settings adminAIRuntimeSettings) ollamaRuntimeStatus {
+	cfg := getAIRuntimeConfig()
+	out := ollamaRuntimeStatus{
+		AIEnabled:       cfg.AIEnabled,
+		OllamaHost:      cfg.OllamaHost,
+		ConfiguredModel: modelFromSettingsOrConfig(settings, cfg),
+		OllamaReachable: false,
+		ModelAvailable:  false,
+		ActiveMode:      "fallback",
+	}
+	if !cfg.AIEnabled || !settings.OllamaEnabled {
+		return out
+	}
+
+	models, err := fetchOllamaModels(ctx, cfg)
+	if err != nil {
+		return out
+	}
+	out.OllamaReachable = true
+	for _, m := range models {
+		if m == out.ConfiguredModel {
+			out.ModelAvailable = true
+			out.ActiveMode = "ollama"
+			return out
+		}
+	}
+	return out
+}
+
+func GenerateSummaryWithAIRuntime(
+	ctx context.Context,
+	settings adminAIRuntimeSettings,
+	filename string,
+	sizeBytes int64,
+	extracted string,
+) (summary string, mode string, err error) {
+	cfg := getAIRuntimeConfig()
+	fallback := BuildSummaryFromExtractedTextForWorker(filename, sizeBytes, extracted)
+
+	if !cfg.AIEnabled || !settings.OllamaEnabled {
+		return fallback, "fallback_local", nil
+	}
+	model := modelFromSettingsOrConfig(settings, cfg)
+	ollamaResp, genErr := callOllamaGenerate(ctx, cfg, model, extracted)
+	if genErr != nil || strings.TrimSpace(ollamaResp) == "" {
+		if settings.FallbackEnabled {
+			return fallback, "fallback_local", nil
+		}
+		if genErr == nil {
+			genErr = fmt.Errorf("ollama returned empty response")
+		}
+		return "", "ollama_error", genErr
+	}
+	return strings.TrimSpace(ollamaResp), "ollama", nil
+}
+
+func modelFromSettingsOrConfig(settings adminAIRuntimeSettings, cfg aiRuntimeConfig) string {
+	model := strings.TrimSpace(settings.OllamaModel)
+	if model == "" {
+		model = strings.TrimSpace(cfg.OllamaModel)
+	}
+	if model == "" {
+		model = "llama3.1:8b"
+	}
+	return model
+}
+
+func fetchOllamaModels(ctx context.Context, cfg aiRuntimeConfig) ([]string, error) {
+	body, err := ollamaRequest(ctx, cfg, http.MethodGet, "/api/tags", nil)
+	if err != nil {
+		return nil, err
+	}
+	var tags ollamaTagsResponse
+	if err := json.Unmarshal(body, &tags); err != nil {
+		return nil, err
+	}
+	out := make([]string, 0, len(tags.Models))
+	for _, m := range tags.Models {
+		if n := strings.TrimSpace(m.Name); n != "" {
+			out = append(out, n)
+			continue
+		}
+		if mm := strings.TrimSpace(m.Model); mm != "" {
+			out = append(out, mm)
+		}
+	}
+	return out, nil
+}
+
+func callOllamaGenerate(ctx context.Context, cfg aiRuntimeConfig, model, extracted string) (string, error) {
+	prompt := fmt.Sprintf(
+		"Summarize the following clinical document text in plain language with key findings and risks. Keep it concise and non-diagnostic.\n\n%s",
+		extracted,
+	)
+	req := map[string]any{
+		"model":  model,
+		"prompt": prompt,
+		"stream": false,
+	}
+	body, err := ollamaRequest(ctx, cfg, http.MethodPost, "/api/generate", req)
+	if err != nil {
+		return "", err
+	}
+	var resp ollamaGenerateResponse
+	if err := json.Unmarshal(body, &resp); err != nil {
+		return "", err
+	}
+	return resp.Response, nil
+}
+
+func ollamaRequest(ctx context.Context, cfg aiRuntimeConfig, method, path string, payload any) ([]byte, error) {
+	var bodyReader io.Reader
+	if payload != nil {
+		raw, err := json.Marshal(payload)
+		if err != nil {
+			return nil, err
+		}
+		bodyReader = bytes.NewReader(raw)
+	}
+	timeout := time.Duration(cfg.OllamaTimeoutMS) * time.Millisecond
+	rctx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(rctx, method, cfg.OllamaHost+path, bodyReader)
+	if err != nil {
+		return nil, err
+	}
+	if payload != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	raw, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+	if resp.StatusCode >= http.StatusBadRequest {
+		return nil, fmt.Errorf("ollama %s %s failed: status=%d body=%s", method, path, resp.StatusCode, strings.TrimSpace(string(raw)))
+	}
+	return raw, nil
+}

--- a/backend/handlers/ai_runtime_core_test.go
+++ b/backend/handlers/ai_runtime_core_test.go
@@ -1,0 +1,59 @@
+package handlers
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestGenerateSummaryWithAIRuntime_FallbackWhenAIDisabled(t *testing.T) {
+	ConfigureAIRuntime(false, "http://127.0.0.1:11434", "llama3.1:8b", 500)
+	settings := adminAIRuntimeSettings{
+		OllamaEnabled:   true,
+		FallbackEnabled: true,
+		OllamaModel:     "llama3.1:8b",
+	}
+	summary, mode, err := GenerateSummaryWithAIRuntime(context.Background(), settings, "r.pdf", 4096, "sample extracted text")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if mode != "fallback_local" {
+		t.Fatalf("expected fallback_local mode, got %s", mode)
+	}
+	if !strings.Contains(summary, "AI summary") {
+		t.Fatalf("expected local summary fallback")
+	}
+}
+
+func TestGenerateSummaryWithAIRuntime_OllamaSuccess(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/generate":
+			_, _ = w.Write([]byte(`{"response":"Ollama summary output"}`))
+		case "/api/tags":
+			_, _ = w.Write([]byte(`{"models":[{"name":"llama3.1:8b"}]}`))
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer server.Close()
+
+	ConfigureAIRuntime(true, server.URL, "llama3.1:8b", 1000)
+	settings := adminAIRuntimeSettings{
+		OllamaEnabled:   true,
+		FallbackEnabled: true,
+		OllamaModel:     "llama3.1:8b",
+	}
+	summary, mode, err := GenerateSummaryWithAIRuntime(context.Background(), settings, "r.pdf", 4096, "sample extracted text")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if mode != "ollama" {
+		t.Fatalf("expected ollama mode, got %s", mode)
+	}
+	if summary != "Ollama summary output" {
+		t.Fatalf("unexpected summary: %s", summary)
+	}
+}

--- a/backend/main.go
+++ b/backend/main.go
@@ -24,6 +24,7 @@ func main() {
 	if cfg.JWTSecret == "" {
 		log.Fatal("JWT_SECRET is required")
 	}
+	handlers.ConfigureAIRuntime(cfg.AIEnabled, cfg.OllamaHost, cfg.OllamaModel, cfg.OllamaTimeoutMS)
 
 	if err := db.Connect(cfg.DatabaseURL); err != nil {
 		log.Fatalf("database connection: %v", err)

--- a/backend/workers/document_summary_worker.go
+++ b/backend/workers/document_summary_worker.go
@@ -129,7 +129,39 @@ func processSingleSummaryJob(ctx context.Context) (bool, error) {
 		return true, nil
 	}
 
-	summary := handlers.BuildSummaryFromExtractedTextForWorker(filename, sizeBytes, extracted)
+	settings, settingsErr := handlers.LoadAIRuntimeSettingsForWorker(ctx)
+	if settingsErr != nil {
+		_, _ = db.Pool.Exec(ctx, `
+			UPDATE patient_documents
+			SET summary_status = 'failed', summary_error = $2
+			WHERE id = $1
+		`, docID, settingsErr.Error())
+		_, _ = db.Pool.Exec(ctx, `
+			UPDATE document_summary_jobs
+			SET status = 'failed', finished_at = NOW(), last_error = $2
+			WHERE id = $1
+		`, jobID, settingsErr.Error())
+		return true, nil
+	}
+
+	summary, mode, summarizeErr := handlers.GenerateSummaryWithAIRuntime(ctx, settings, filename, sizeBytes, extracted)
+	if summarizeErr != nil {
+		_, _ = db.Pool.Exec(ctx, `
+			UPDATE patient_documents
+			SET summary_status = 'failed', summary_error = $2
+			WHERE id = $1
+		`, docID, summarizeErr.Error())
+		_, _ = db.Pool.Exec(ctx, `
+			UPDATE document_summary_jobs
+			SET status = 'failed', finished_at = NOW(), last_error = $2
+			WHERE id = $1
+		`, jobID, summarizeErr.Error())
+		return true, nil
+	}
+	if mode != "" && mode != "ollama" {
+		summary = summary + "\n\n[summary_mode=" + mode + "]"
+	}
+
 	_, err = db.Pool.Exec(ctx, `
 		UPDATE patient_documents
 		SET summary = $2, summary_status = 'ready', summary_error = NULL


### PR DESCRIPTION
## Summary
Implements PR-01 backend AI runtime core integration.

- Adds global runtime config (AI_ENABLED, OLLAMA_HOST, OLLAMA_MODEL, OLLAMA_TIMEOUT_MS) and .env docs.
- Adds Ollama runtime client/service with model availability + health checks and fallback-safe summary contract.
- Wires admin AI observability/eval responses with runtime status and updates summary worker to use Ollama when enabled with safe fallback.

## Verification
- go test ./...
- go build ./...

Made with [Cursor](https://cursor.com)