### PR TITLE
chore(backend): PR-02 OpenAPI/Swagger baseline + CI sync check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   push:
-    branches: [main, master]
+    branches: [main, master, dev]
   pull_request:
-    branches: [main, master]
+    branches: [main, master, dev]
 
 jobs:
   backend:
@@ -26,6 +26,8 @@ jobs:
           restore-keys: ${{ runner.os }}-go-
       - name: Build
         run: go build -v ./...
+      - name: OpenAPI sync check
+        run: go run ./cmd/openapi-sync-check
       - name: Test
         run: go test -v -count=1 ./...
 

--- a/backend/cmd/openapi-sync-check/main.go
+++ b/backend/cmd/openapi-sync-check/main.go
@@ -1,0 +1,146 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+)
+
+type routeKey struct {
+	Method string
+	Path   string
+}
+
+var (
+	apiRouteRe      = regexp.MustCompile(`\b(api|msg)\.(GET|POST|PUT|PATCH|DELETE)\("([^"]+)"`)
+	healthRouteRe   = regexp.MustCompile(`\br\.(GET|HEAD)\("(/health)"`)
+	openapiPathRe   = regexp.MustCompile(`^  (/[^\s:]+):\s*$`)
+	openapiMethodRe = regexp.MustCompile(`^    (get|post|put|patch|delete|head):\s*$`)
+)
+
+func main() {
+	mainGo := filepath.Clean("main.go")
+	openAPI := filepath.Clean("../docs/openapi.yaml")
+
+	declared, err := extractDeclaredRoutes(mainGo)
+	if err != nil {
+		fatal(err)
+	}
+	documented, err := extractDocumentedRoutes(openAPI)
+	if err != nil {
+		fatal(err)
+	}
+
+	var missing []routeKey
+	for _, r := range declared {
+		if _, ok := documented[r]; !ok {
+			missing = append(missing, r)
+		}
+	}
+	if len(missing) == 0 {
+		fmt.Println("openapi sync check passed")
+		return
+	}
+	sort.Slice(missing, func(i, j int) bool {
+		if missing[i].Path == missing[j].Path {
+			return missing[i].Method < missing[j].Method
+		}
+		return missing[i].Path < missing[j].Path
+	})
+	fmt.Println("openapi sync check failed: missing route/method entries in docs/openapi.yaml")
+	for _, m := range missing {
+		fmt.Printf("- %s %s\n", m.Method, m.Path)
+	}
+	os.Exit(1)
+}
+
+func extractDeclaredRoutes(path string) ([]routeKey, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+
+	seen := map[routeKey]struct{}{}
+	sc := bufio.NewScanner(f)
+	for sc.Scan() {
+		line := sc.Text()
+		if m := apiRouteRe.FindStringSubmatch(line); len(m) == 4 {
+			group := m[1]
+			method := strings.ToLower(m[2])
+			rawPath := m[3]
+			var fullPath string
+			switch group {
+			case "api":
+				fullPath = "/api" + convertGinPath(rawPath)
+			case "msg":
+				fullPath = "/api/messages" + convertGinPath(rawPath)
+			}
+			seen[routeKey{Method: method, Path: fullPath}] = struct{}{}
+			continue
+		}
+		if m := healthRouteRe.FindStringSubmatch(line); len(m) == 3 {
+			seen[routeKey{Method: strings.ToLower(m[1]), Path: m[2]}] = struct{}{}
+		}
+	}
+	if err := sc.Err(); err != nil {
+		return nil, err
+	}
+	out := make([]routeKey, 0, len(seen))
+	for k := range seen {
+		out = append(out, k)
+	}
+	return out, nil
+}
+
+func extractDocumentedRoutes(path string) (map[routeKey]struct{}, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+
+	out := map[routeKey]struct{}{}
+	sc := bufio.NewScanner(f)
+	currentPath := ""
+	for sc.Scan() {
+		line := sc.Text()
+		if m := openapiPathRe.FindStringSubmatch(line); len(m) == 2 {
+			currentPath = m[1]
+			continue
+		}
+		if currentPath == "" {
+			continue
+		}
+		if m := openapiMethodRe.FindStringSubmatch(line); len(m) == 2 {
+			out[routeKey{Method: m[1], Path: currentPath}] = struct{}{}
+			continue
+		}
+	}
+	if err := sc.Err(); err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func convertGinPath(p string) string {
+	if strings.TrimSpace(p) == "" {
+		return p
+	}
+	parts := strings.Split(p, "/")
+	for i := range parts {
+		if strings.HasPrefix(parts[i], ":") && len(parts[i]) > 1 {
+			parts[i] = "{" + parts[i][1:] + "}"
+		}
+	}
+	return strings.Join(parts, "/")
+}
+
+func fatal(err error) {
+	fmt.Println("openapi sync check failed:", err)
+	os.Exit(1)
+}

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -117,6 +117,28 @@ paths:
         "401":
           $ref: "#/components/responses/Unauthorized"
 
+  /api/notifications/preferences:
+    get:
+      tags: [Notifications]
+      summary: Get notification preferences for current user
+      security:
+        - bearerAuth: []
+      responses:
+        "200":
+          description: Notification preferences
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+    put:
+      tags: [Notifications]
+      summary: Update notification preferences for current user
+      security:
+        - bearerAuth: []
+      responses:
+        "200":
+          description: Preferences updated
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+
   /api/patient/dashboard/summary:
     get:
       tags: [Dashboard]
@@ -205,6 +227,108 @@ paths:
         "403":
           $ref: "#/components/responses/Forbidden"
 
+  /api/admin/user-lifecycle/settings-kpis:
+    get:
+      tags: [Admin]
+      summary: Get admin user lifecycle settings and KPI snapshot
+      security:
+        - bearerAuth: []
+      responses:
+        "200":
+          description: Lifecycle settings and KPIs
+        "403":
+          $ref: "#/components/responses/Forbidden"
+
+  /api/admin/user-lifecycle/settings:
+    put:
+      tags: [Admin]
+      summary: Update admin user lifecycle settings
+      security:
+        - bearerAuth: []
+      responses:
+        "200":
+          description: Lifecycle settings updated
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+
+  /api/admin/ai/observability:
+    get:
+      tags: [Admin]
+      summary: Get AI runtime settings, observability, and runtime health
+      security:
+        - bearerAuth: []
+      responses:
+        "200":
+          description: AI observability snapshot
+        "403":
+          $ref: "#/components/responses/Forbidden"
+
+  /api/admin/ai/settings:
+    put:
+      tags: [Admin]
+      summary: Update AI runtime settings
+      security:
+        - bearerAuth: []
+      responses:
+        "200":
+          description: AI runtime settings updated
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+
+  /api/admin/ai/eval:
+    post:
+      tags: [Admin]
+      summary: Run AI evaluation baseline
+      security:
+        - bearerAuth: []
+      responses:
+        "200":
+          description: AI eval result
+        "403":
+          $ref: "#/components/responses/Forbidden"
+
+  /api/admin/notifications:
+    get:
+      tags: [Admin]
+      summary: List admin notifications log
+      security:
+        - bearerAuth: []
+      responses:
+        "200":
+          description: Admin notification list
+        "403":
+          $ref: "#/components/responses/Forbidden"
+
+  /api/admin/notifications/summary:
+    get:
+      tags: [Admin]
+      summary: Get admin notifications summary
+      security:
+        - bearerAuth: []
+      responses:
+        "200":
+          description: Admin notification summary
+        "403":
+          $ref: "#/components/responses/Forbidden"
+
+  /api/admin/notifications/{id}/retry:
+    post:
+      tags: [Admin]
+      summary: Retry failed notification by id
+      security:
+        - bearerAuth: []
+      parameters:
+        - $ref: "#/components/parameters/IdPath"
+      responses:
+        "200":
+          description: Retry accepted
+        "403":
+          $ref: "#/components/responses/Forbidden"
+
   /api/admin/knowledge-docs:
     get:
       tags: [Admin]
@@ -234,6 +358,72 @@ paths:
       responses:
         "200":
           description: Knowledge doc details
+        "404":
+          $ref: "#/components/responses/NotFound"
+    patch:
+      tags: [Admin]
+      summary: Patch knowledge doc title/body/review interval
+      security:
+        - bearerAuth: []
+      parameters:
+        - $ref: "#/components/parameters/IdPath"
+      responses:
+        "200":
+          description: Knowledge doc updated
+        "404":
+          $ref: "#/components/responses/NotFound"
+
+  /api/admin/knowledge-docs/similarity-scan:
+    get:
+      tags: [Admin]
+      summary: Scan knowledge docs for similarity/conflict candidates
+      security:
+        - bearerAuth: []
+      responses:
+        "200":
+          description: Similarity scan result
+        "403":
+          $ref: "#/components/responses/Forbidden"
+
+  /api/admin/knowledge-docs/{id}/embeddings:
+    post:
+      tags: [Admin]
+      summary: Upsert embeddings for a knowledge document
+      security:
+        - bearerAuth: []
+      parameters:
+        - $ref: "#/components/parameters/IdPath"
+      responses:
+        "200":
+          description: Embeddings updated
+        "404":
+          $ref: "#/components/responses/NotFound"
+
+  /api/admin/knowledge-docs/{id}/versions:
+    get:
+      tags: [Admin]
+      summary: List knowledge document versions
+      security:
+        - bearerAuth: []
+      parameters:
+        - $ref: "#/components/parameters/IdPath"
+      responses:
+        "200":
+          description: Version history
+        "404":
+          $ref: "#/components/responses/NotFound"
+
+  /api/admin/knowledge-docs/{id}/review:
+    post:
+      tags: [Admin]
+      summary: Mark knowledge document as reviewed
+      security:
+        - bearerAuth: []
+      parameters:
+        - $ref: "#/components/parameters/IdPath"
+      responses:
+        "200":
+          description: Review timestamp updated
         "404":
           $ref: "#/components/responses/NotFound"
 
@@ -587,6 +777,39 @@ paths:
         "404":
           $ref: "#/components/responses/NotFound"
 
+  /api/prescriptions/{id}/pdf:
+    get:
+      tags: [Prescriptions]
+      summary: Download prescription PDF
+      security:
+        - bearerAuth: []
+      parameters:
+        - $ref: "#/components/parameters/IdPath"
+      responses:
+        "200":
+          description: Prescription PDF stream
+          content:
+            application/pdf:
+              schema:
+                type: string
+                format: binary
+        "404":
+          $ref: "#/components/responses/NotFound"
+
+  /api/prescriptions/{id}:
+    put:
+      tags: [Prescriptions]
+      summary: Update prescription fields
+      security:
+        - bearerAuth: []
+      parameters:
+        - $ref: "#/components/parameters/IdPath"
+      responses:
+        "200":
+          description: Prescription updated
+        "404":
+          $ref: "#/components/responses/NotFound"
+
   /api/messages/unread:
     get:
       tags: [Messaging]
@@ -650,6 +873,22 @@ paths:
       responses:
         "200":
           description: Thread marked read
+
+  /api/messages/ws:
+    get:
+      tags: [Messaging]
+      summary: Open WebSocket messaging stream
+      parameters:
+        - name: token
+          in: query
+          required: true
+          schema:
+            type: string
+      responses:
+        "101":
+          description: WebSocket upgraded
+        "401":
+          $ref: "#/components/responses/Unauthorized"
 
 components:
   securitySchemes:


### PR DESCRIPTION
## Summary
Implements PR-02 backend-only OpenAPI baseline work.

- Extends docs/openapi.yaml to match current route surface, including admin user lifecycle + AI runtime routes and other missing endpoints.
- Adds ackend/cmd/openapi-sync-check to verify route/method coverage from ackend/main.go exists in OpenAPI spec.
- Wires CI step to run sync check and updates CI triggers for dev branch.

## Verification
- go run ./cmd/openapi-sync-check (backend)
- go test ./... (backend)

Made with [Cursor](https://cursor.com)