### PR TITLE
feat(frontend): PR-03 admin AI observability V2 runtime health UI

### DIFF
--- a/frontend/src/app/components/admin-ai-observability/admin-ai-observability.component.html
+++ b/frontend/src/app/components/admin-ai-observability/admin-ai-observability.component.html
@@ -7,6 +7,37 @@
   <p *ngIf="loading">Loading AI controls...</p>
   <p *ngIf="!loading && error" class="err">{{ error }}</p>
   <p *ngIf="!loading && success" class="ok">{{ success }}</p>
+  <p *ngIf="!loading && runtimeIssue" class="warn">{{ runtimeIssue }}</p>
+
+  <section class="runtime-health" *ngIf="!loading && runtime" data-cy="ai-runtime-health">
+    <h2>Runtime health</h2>
+    <div class="runtime-grid">
+      <article>
+        <span>Global AI enabled</span>
+        <strong [class.bad]="!runtime.ai_enabled">{{ runtime.ai_enabled ? 'Yes' : 'No' }}</strong>
+      </article>
+      <article>
+        <span>Ollama reachable</span>
+        <strong [class.bad]="!runtime.ollama_reachable">{{ runtime.ollama_reachable ? 'Yes' : 'No' }}</strong>
+      </article>
+      <article>
+        <span>Model available</span>
+        <strong [class.bad]="!runtime.model_available">{{ runtime.model_available ? 'Yes' : 'No' }}</strong>
+      </article>
+      <article>
+        <span>Active mode</span>
+        <strong>{{ runtime.active_mode }}</strong>
+      </article>
+      <article>
+        <span>Configured model</span>
+        <strong>{{ runtime.configured_model }}</strong>
+      </article>
+      <article>
+        <span>Ollama host</span>
+        <strong>{{ runtime.ollama_host }}</strong>
+      </article>
+    </div>
+  </section>
 
   <div class="metrics" *ngIf="!loading && obs">
     <article><span>Queued jobs (24h)</span><strong>{{ obs.queued_jobs_24h }}</strong></article>

--- a/frontend/src/app/components/admin-ai-observability/admin-ai-observability.component.scss
+++ b/frontend/src/app/components/admin-ai-observability/admin-ai-observability.component.scss
@@ -16,6 +16,50 @@ header p {
   color: #34d399;
 }
 
+.warn {
+  color: #fbbf24;
+}
+
+.runtime-health {
+  border: 1px solid rgba(148, 163, 184, 0.3);
+  border-radius: 0.5rem;
+  padding: 0.9rem;
+  background: rgba(15, 23, 42, 0.25);
+}
+
+.runtime-health h2 {
+  margin: 0 0 0.65rem;
+  font-size: 1rem;
+}
+
+.runtime-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  gap: 0.6rem;
+}
+
+.runtime-grid article {
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  border-radius: 0.45rem;
+  padding: 0.55rem;
+  display: grid;
+  gap: 0.2rem;
+}
+
+.runtime-grid span {
+  color: #94a3b8;
+  font-size: 0.78rem;
+}
+
+.runtime-grid strong {
+  font-size: 0.92rem;
+  word-break: break-word;
+}
+
+.runtime-grid strong.bad {
+  color: #f87171;
+}
+
 .metrics {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));

--- a/frontend/src/app/components/admin-ai-observability/admin-ai-observability.component.spec.ts
+++ b/frontend/src/app/components/admin-ai-observability/admin-ai-observability.component.spec.ts
@@ -34,6 +34,14 @@ describe('AdminAiObservabilityComponent', () => {
           cache_ready_count: 4,
           pending_docs_count: 1,
           failed_docs_count: 0
+        },
+        runtime: {
+          ai_enabled: true,
+          ollama_host: 'http://127.0.0.1:11434',
+          configured_model: 'llama3.1:8b',
+          ollama_reachable: true,
+          model_available: true,
+          active_mode: 'ollama'
         }
       })
     );
@@ -51,6 +59,7 @@ describe('AdminAiObservabilityComponent', () => {
     const el = fixture.nativeElement as HTMLElement;
     expect(serviceSpy.getObservability).toHaveBeenCalled();
     expect(el.querySelector('[data-cy="admin-ai-observability-page"]')).toBeTruthy();
+    expect(el.querySelector('[data-cy="ai-runtime-health"]')).toBeTruthy();
   });
 
   it('saves settings', () => {

--- a/frontend/src/app/components/admin-ai-observability/admin-ai-observability.component.ts
+++ b/frontend/src/app/components/admin-ai-observability/admin-ai-observability.component.ts
@@ -3,6 +3,7 @@ import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 import {
   AdminAiObservability,
+  AdminAiObservabilityResponse,
   AdminAiRuntimeService,
   AdminAiRuntimeSettings
 } from '../../services/admin-ai-runtime.service';
@@ -22,6 +23,7 @@ export class AdminAiObservabilityComponent implements OnInit {
   success: string | null = null;
   settings: AdminAiRuntimeSettings | null = null;
   obs: AdminAiObservability | null = null;
+  runtime: AdminAiObservabilityResponse['runtime'] | null = null;
   evalResult: { model_name: string; samples_evaluated: number; success_rate: number; quality_score: number } | null =
     null;
 
@@ -41,6 +43,22 @@ export class AdminAiObservabilityComponent implements OnInit {
     this.load();
   }
 
+  get runtimeIssue(): string | null {
+    if (!this.runtime) {
+      return null;
+    }
+    if (!this.runtime.ai_enabled) {
+      return 'Global AI is disabled by backend config (AI_ENABLED=false).';
+    }
+    if (!this.runtime.ollama_reachable) {
+      return 'Ollama server is not reachable from backend.';
+    }
+    if (!this.runtime.model_available) {
+      return `Configured model "${this.runtime.configured_model}" is not available in Ollama tags.`;
+    }
+    return null;
+  }
+
   load(): void {
     this.loading = true;
     this.error = null;
@@ -48,6 +66,7 @@ export class AdminAiObservabilityComponent implements OnInit {
       next: (res) => {
         this.settings = res.settings;
         this.obs = res.observability;
+        this.runtime = res.runtime ?? null;
         this.form = {
           ollama_enabled: res.settings.ollama_enabled,
           fallback_enabled: res.settings.fallback_enabled,
@@ -80,6 +99,7 @@ export class AdminAiObservabilityComponent implements OnInit {
         next: (res) => {
           this.settings = res.settings;
           this.obs = res.observability;
+          this.runtime = res.runtime ?? null;
           this.success = 'AI runtime settings updated.';
           this.saving = false;
         },
@@ -96,6 +116,7 @@ export class AdminAiObservabilityComponent implements OnInit {
     this.api.runEval().subscribe({
       next: (res) => {
         this.evalResult = res.eval;
+        this.runtime = res.runtime ?? this.runtime;
         this.runningEval = false;
       },
       error: () => {

--- a/frontend/src/app/services/admin-ai-runtime.service.ts
+++ b/frontend/src/app/services/admin-ai-runtime.service.ts
@@ -28,6 +28,14 @@ export type AdminAiObservability = {
 export type AdminAiObservabilityResponse = {
   settings: AdminAiRuntimeSettings;
   observability: AdminAiObservability;
+  runtime?: {
+    ai_enabled: boolean;
+    ollama_host: string;
+    configured_model: string;
+    ollama_reachable: boolean;
+    model_available: boolean;
+    active_mode: string;
+  };
 };
 
 export type AdminAiEvalResponse = {
@@ -36,6 +44,14 @@ export type AdminAiEvalResponse = {
     samples_evaluated: number;
     success_rate: number;
     quality_score: number;
+  };
+  runtime?: {
+    ai_enabled: boolean;
+    ollama_host: string;
+    configured_model: string;
+    ollama_reachable: boolean;
+    model_available: boolean;
+    active_mode: string;
   };
 };
 


### PR DESCRIPTION
## Summary
Implements PR-03 frontend scope consuming PR-01 backend runtime payloads.

- Enriches Admin AI page with runtime health cards (AI enabled, Ollama reachable, model availability, active mode, configured host/model).
- Adds warning/error surface for runtime misconfiguration and unavailable model/server states.
- Keeps existing settings/eval flows and updates component spec coverage for runtime health rendering.

## Verification
- 
pm run test:ci
- 
pm run build

Made with [Cursor](https://cursor.com)