### PR TITLE
refactor(frontend): PR-04 API contract alignment pass

### DIFF
--- a/frontend/src/app/services/admin-ai-runtime.service.ts
+++ b/frontend/src/app/services/admin-ai-runtime.service.ts
@@ -2,58 +2,14 @@ import { Injectable } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
 import { Observable } from 'rxjs';
 import { ApiContract } from './api-contract';
-
-export type AdminAiRuntimeSettings = {
-  ollama_enabled: boolean;
-  fallback_enabled: boolean;
-  rate_limit_enabled: boolean;
-  rate_limit_per_minute: number;
-  cache_enabled: boolean;
-  cache_ttl_seconds: number;
-  ollama_model: string;
-  updated_at: string;
-  updated_by: string;
-};
-
-export type AdminAiObservability = {
-  queued_jobs_24h: number;
-  completed_jobs_24h: number;
-  failed_jobs_24h: number;
-  avg_latency_seconds: number;
-  cache_ready_count: number;
-  pending_docs_count: number;
-  failed_docs_count: number;
-};
-
-export type AdminAiObservabilityResponse = {
-  settings: AdminAiRuntimeSettings;
-  observability: AdminAiObservability;
-  runtime?: {
-    ai_enabled: boolean;
-    ollama_host: string;
-    configured_model: string;
-    ollama_reachable: boolean;
-    model_available: boolean;
-    active_mode: string;
-  };
-};
-
-export type AdminAiEvalResponse = {
-  eval: {
-    model_name: string;
-    samples_evaluated: number;
-    success_rate: number;
-    quality_score: number;
-  };
-  runtime?: {
-    ai_enabled: boolean;
-    ollama_host: string;
-    configured_model: string;
-    ollama_reachable: boolean;
-    model_available: boolean;
-    active_mode: string;
-  };
-};
+import type { AdminAiEvalResponse, AdminAiObservabilityResponse } from './api-types';
+export type {
+  AdminAiRuntimeSettings,
+  AdminAiObservability,
+  AdminAiRuntimeStatus,
+  AdminAiObservabilityResponse,
+  AdminAiEvalResponse
+} from './api-types';
 
 @Injectable({ providedIn: 'root' })
 export class AdminAiRuntimeService {

--- a/frontend/src/app/services/admin-audit.service.ts
+++ b/frontend/src/app/services/admin-audit.service.ts
@@ -2,22 +2,14 @@ import { Injectable } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
 import { Observable } from 'rxjs';
 import { ApiContract } from './api-contract';
-
-export interface AuditLogEntry {
-  id: string;
-  actor_user_id: string;
-  action: string;
-  entity_type: string;
-  entity_id: string;
-  detail: string;
-  created_at: string;
-}
+import type { ApiListResponse, AuditLogEntry } from './api-types';
+export type { AuditLogEntry } from './api-types';
 
 @Injectable({ providedIn: 'root' })
 export class AdminAuditService {
   constructor(private http: HttpClient) {}
 
-  list(): Observable<{ entries: AuditLogEntry[] }> {
-    return this.http.get<{ entries: AuditLogEntry[] }>(ApiContract.admin.auditLog);
+  list(): Observable<ApiListResponse<AuditLogEntry, 'entries'>> {
+    return this.http.get<ApiListResponse<AuditLogEntry, 'entries'>>(ApiContract.admin.auditLog);
   }
 }

--- a/frontend/src/app/services/admin-user-lifecycle.service.ts
+++ b/frontend/src/app/services/admin-user-lifecycle.service.ts
@@ -2,27 +2,8 @@ import { Injectable } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
 import { Observable } from 'rxjs';
 import { ApiContract } from './api-contract';
-
-export type AdminLifecycleSettings = {
-  new_user_window_days: number;
-  inactive_window_days: number;
-  updated_at: string;
-  updated_by: string;
-};
-
-export type AdminLifecycleKpis = {
-  total_users: number;
-  total_patients: number;
-  total_doctors: number;
-  total_admins: number;
-  new_users_in_window: number;
-  inactive_users_count: number;
-};
-
-export type AdminLifecycleSettingsKpisResponse = {
-  settings: AdminLifecycleSettings;
-  kpis: AdminLifecycleKpis;
-};
+import type { AdminLifecycleSettingsKpisResponse } from './api-types';
+export type { AdminLifecycleSettings, AdminLifecycleKpis, AdminLifecycleSettingsKpisResponse } from './api-types';
 
 @Injectable({ providedIn: 'root' })
 export class AdminUserLifecycleService {

--- a/frontend/src/app/services/api-types.ts
+++ b/frontend/src/app/services/api-types.ts
@@ -1,0 +1,161 @@
+export type ApiListResponse<TItem, TKey extends string = 'items'> = {
+  [P in TKey]: TItem[];
+};
+
+export interface AuditLogEntry {
+  id: string;
+  actor_user_id: string;
+  action: string;
+  entity_type: string;
+  entity_id: string;
+  detail: string;
+  created_at: string;
+}
+
+export interface NotificationRow {
+  id: string;
+  title: string;
+  body: string;
+  channel: string;
+  status: string;
+  scheduled_for?: string | null;
+  created_at: string;
+}
+
+export interface NotificationPreferenceRow {
+  category: string;
+  enabled: boolean;
+  email_enabled: boolean;
+  sms_enabled: boolean;
+  in_app_enabled: boolean;
+}
+
+export type AdminLifecycleSettings = {
+  new_user_window_days: number;
+  inactive_window_days: number;
+  updated_at: string;
+  updated_by: string;
+};
+
+export type AdminLifecycleKpis = {
+  total_users: number;
+  total_patients: number;
+  total_doctors: number;
+  total_admins: number;
+  new_users_in_window: number;
+  inactive_users_count: number;
+};
+
+export type AdminLifecycleSettingsKpisResponse = {
+  settings: AdminLifecycleSettings;
+  kpis: AdminLifecycleKpis;
+};
+
+export type AdminAiRuntimeSettings = {
+  ollama_enabled: boolean;
+  fallback_enabled: boolean;
+  rate_limit_enabled: boolean;
+  rate_limit_per_minute: number;
+  cache_enabled: boolean;
+  cache_ttl_seconds: number;
+  ollama_model: string;
+  updated_at: string;
+  updated_by: string;
+};
+
+export type AdminAiObservability = {
+  queued_jobs_24h: number;
+  completed_jobs_24h: number;
+  failed_jobs_24h: number;
+  avg_latency_seconds: number;
+  cache_ready_count: number;
+  pending_docs_count: number;
+  failed_docs_count: number;
+};
+
+export type AdminAiRuntimeStatus = {
+  ai_enabled: boolean;
+  ollama_host: string;
+  configured_model: string;
+  ollama_reachable: boolean;
+  model_available: boolean;
+  active_mode: string;
+};
+
+export type AdminAiObservabilityResponse = {
+  settings: AdminAiRuntimeSettings;
+  observability: AdminAiObservability;
+  runtime?: AdminAiRuntimeStatus;
+};
+
+export type AdminAiEvalResponse = {
+  eval: {
+    model_name: string;
+    samples_evaluated: number;
+    success_rate: number;
+    quality_score: number;
+  };
+  runtime?: AdminAiRuntimeStatus;
+};
+
+export interface KnowledgeListDocument {
+  id: string;
+  title: string;
+  excerpt: string;
+  created_at: string;
+  updated_at: string;
+  current_version?: number;
+  review_interval_days?: number;
+  last_reviewed_at?: string;
+  days_since_review?: number;
+  health_score?: number;
+  is_stale?: boolean;
+}
+
+export interface KnowledgeDocumentsListResponse {
+  documents: KnowledgeListDocument[];
+}
+
+export interface KnowledgeDetail {
+  id: string;
+  title: string;
+  body: string;
+  updated_at: string;
+  current_version: number;
+  review_interval_days: number;
+  last_reviewed_at?: string;
+  days_since_review: number;
+  health_score: number;
+  is_stale: boolean;
+}
+
+export interface KnowledgeVersionRow {
+  version: number;
+  title: string;
+  excerpt: string;
+  created_at: string;
+  created_by: string;
+}
+
+export interface KnowledgeVersionsResponse {
+  versions: KnowledgeVersionRow[];
+}
+
+export interface SimilarityPair {
+  similarity: number;
+  document_a_id: string;
+  document_b_id: string;
+  title_a: string;
+  title_b: string;
+  chunk_a_index: number;
+  chunk_b_index: number;
+  excerpt_a: string;
+  excerpt_b: string;
+  conflict_hint: string;
+}
+
+export interface SimilarityScanResponse {
+  threshold: number;
+  chunks_scanned: number;
+  pairs: SimilarityPair[];
+}

--- a/frontend/src/app/services/knowledge-admin.service.ts
+++ b/frontend/src/app/services/knowledge-admin.service.ts
@@ -2,69 +2,21 @@ import { Injectable } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
 import { Observable } from 'rxjs';
 import { ApiContract } from './api-contract';
-
-export interface KnowledgeListDocument {
-  id: string;
-  title: string;
-  excerpt: string;
-  created_at: string;
-  updated_at: string;
-  current_version?: number;
-  review_interval_days?: number;
-  last_reviewed_at?: string;
-  days_since_review?: number;
-  health_score?: number;
-  is_stale?: boolean;
-}
-
-export interface KnowledgeDocumentsListResponse {
-  documents: KnowledgeListDocument[];
-}
-
-/** GET /admin/knowledge-docs/:id (PR-28) */
-export interface KnowledgeDetail {
-  id: string;
-  title: string;
-  body: string;
-  updated_at: string;
-  current_version: number;
-  review_interval_days: number;
-  last_reviewed_at?: string;
-  days_since_review: number;
-  health_score: number;
-  is_stale: boolean;
-}
-
-export interface KnowledgeVersionRow {
-  version: number;
-  title: string;
-  excerpt: string;
-  created_at: string;
-  created_by: string;
-}
-
-export interface KnowledgeVersionsResponse {
-  versions: KnowledgeVersionRow[];
-}
-
-export interface SimilarityPair {
-  similarity: number;
-  document_a_id: string;
-  document_b_id: string;
-  title_a: string;
-  title_b: string;
-  chunk_a_index: number;
-  chunk_b_index: number;
-  excerpt_a: string;
-  excerpt_b: string;
-  conflict_hint: string;
-}
-
-export interface SimilarityScanResponse {
-  threshold: number;
-  chunks_scanned: number;
-  pairs: SimilarityPair[];
-}
+import type {
+  KnowledgeDetail,
+  KnowledgeDocumentsListResponse,
+  KnowledgeVersionsResponse,
+  SimilarityScanResponse
+} from './api-types';
+export type {
+  KnowledgeListDocument,
+  KnowledgeDocumentsListResponse,
+  KnowledgeDetail,
+  KnowledgeVersionRow,
+  KnowledgeVersionsResponse,
+  SimilarityPair,
+  SimilarityScanResponse
+} from './api-types';
 
 @Injectable({ providedIn: 'root' })
 export class KnowledgeAdminService {

--- a/frontend/src/app/services/notifications.service.ts
+++ b/frontend/src/app/services/notifications.service.ts
@@ -2,35 +2,21 @@ import { Injectable } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
 import { Observable } from 'rxjs';
 import { ApiContract } from './api-contract';
-
-export interface NotificationRow {
-  id: string;
-  title: string;
-  body: string;
-  channel: string;
-  status: string;
-  scheduled_for?: string | null;
-  created_at: string;
-}
-
-export interface NotificationPreferenceRow {
-  category: string;
-  enabled: boolean;
-  email_enabled: boolean;
-  sms_enabled: boolean;
-  in_app_enabled: boolean;
-}
+import type { ApiListResponse, NotificationPreferenceRow, NotificationRow } from './api-types';
+export type { NotificationRow, NotificationPreferenceRow } from './api-types';
 
 @Injectable({ providedIn: 'root' })
 export class NotificationsInboxService {
   constructor(private http: HttpClient) {}
 
-  listMine(): Observable<{ notifications: NotificationRow[] }> {
-    return this.http.get<{ notifications: NotificationRow[] }>(ApiContract.notifications.listMine);
+  listMine(): Observable<ApiListResponse<NotificationRow, 'notifications'>> {
+    return this.http.get<ApiListResponse<NotificationRow, 'notifications'>>(
+      ApiContract.notifications.listMine
+    );
   }
 
-  listPreferences(): Observable<{ preferences: NotificationPreferenceRow[] }> {
-    return this.http.get<{ preferences: NotificationPreferenceRow[] }>(
+  listPreferences(): Observable<ApiListResponse<NotificationPreferenceRow, 'preferences'>> {
+    return this.http.get<ApiListResponse<NotificationPreferenceRow, 'preferences'>>(
       ApiContract.notifications.listPreferences
     );
   }


### PR DESCRIPTION
## Summary
Implements PR-04 frontend-only API contract alignment prep (no behavior changes).

- Adds centralized service-level API type module (pi-types.ts) for admin/notification/knowledge domains.
- Refactors target services to import centralized contracts and re-export types for compatibility.
- Keeps request paths/runtime behavior unchanged while preparing typed contracts for Wave-2 expansion.

## Verification
- 
pm run test:ci
- 
pm run build

Made with [Cursor](https://cursor.com)