### PR TITLE
feat(backend): PR-05 eval harness + prompt versioning

### DIFF
--- a/backend/db/db.go
+++ b/backend/db/db.go
@@ -47,12 +47,46 @@ func Migrate(ctx context.Context) error {
 			cache_enabled           BOOLEAN NOT NULL DEFAULT TRUE,
 			cache_ttl_seconds       INTEGER NOT NULL DEFAULT 900 CHECK (cache_ttl_seconds >= 30 AND cache_ttl_seconds <= 604800),
 			ollama_model            TEXT NOT NULL DEFAULT 'llama3.1:8b',
+			prompt_version          TEXT NOT NULL DEFAULT 'v1',
 			updated_by              UUID REFERENCES users(id) ON DELETE SET NULL,
 			updated_at              TIMESTAMPTZ NOT NULL DEFAULT NOW()
 		);
+		ALTER TABLE admin_ai_runtime_settings ADD COLUMN IF NOT EXISTS prompt_version TEXT NOT NULL DEFAULT 'v1';
 		INSERT INTO admin_ai_runtime_settings (id)
 		VALUES (TRUE)
 		ON CONFLICT (id) DO NOTHING;
+
+		CREATE TABLE IF NOT EXISTS admin_ai_eval_runs (
+			id                 UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+			model_name         TEXT NOT NULL,
+			prompt_version     TEXT NOT NULL,
+			fixture_count      INTEGER NOT NULL DEFAULT 0,
+			passed_count       INTEGER NOT NULL DEFAULT 0,
+			success_rate       DOUBLE PRECISION NOT NULL DEFAULT 0,
+			quality_score      DOUBLE PRECISION NOT NULL DEFAULT 0,
+			runtime_mode       TEXT NOT NULL DEFAULT 'fallback_local',
+			ai_enabled         BOOLEAN NOT NULL DEFAULT FALSE,
+			ollama_reachable   BOOLEAN NOT NULL DEFAULT FALSE,
+			model_available    BOOLEAN NOT NULL DEFAULT FALSE,
+			created_by         UUID REFERENCES users(id) ON DELETE SET NULL,
+			started_at         TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+			finished_at        TIMESTAMPTZ NOT NULL DEFAULT NOW()
+		);
+		CREATE INDEX IF NOT EXISTS idx_admin_ai_eval_runs_started ON admin_ai_eval_runs(started_at DESC);
+
+		CREATE TABLE IF NOT EXISTS admin_ai_eval_cases (
+			id                 UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+			run_id             UUID NOT NULL REFERENCES admin_ai_eval_runs(id) ON DELETE CASCADE,
+			fixture_id         TEXT NOT NULL,
+			input_excerpt      TEXT NOT NULL DEFAULT '',
+			expected_keywords  JSONB NOT NULL,
+			summary_excerpt    TEXT NOT NULL DEFAULT '',
+			keyword_coverage   DOUBLE PRECISION NOT NULL DEFAULT 0,
+			passed             BOOLEAN NOT NULL DEFAULT FALSE,
+			created_at         TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+			CONSTRAINT admin_ai_eval_cases_expected_keywords_is_array CHECK (jsonb_typeof(expected_keywords) = 'array')
+		);
+		CREATE INDEX IF NOT EXISTS idx_admin_ai_eval_cases_run ON admin_ai_eval_cases(run_id);
 
 		CREATE TABLE IF NOT EXISTS appointments (
 			id           UUID PRIMARY KEY DEFAULT gen_random_uuid(),

--- a/backend/handlers/admin_ai_eval_harness.go
+++ b/backend/handlers/admin_ai_eval_harness.go
@@ -1,0 +1,72 @@
+package handlers
+
+import (
+	"strings"
+)
+
+type aiEvalFixture struct {
+	ID               string
+	Input            string
+	ExpectedKeywords []string
+	MinCoverage      float64
+}
+
+type aiEvalCaseResult struct {
+	FixtureID        string
+	InputExcerpt     string
+	ExpectedKeywords []string
+	SummaryExcerpt   string
+	KeywordCoverage  float64
+	Passed           bool
+}
+
+var aiEvalFixtures = []aiEvalFixture{
+	{
+		ID:               "cbc-anemia-risk",
+		Input:            "CBC report shows hemoglobin 9.1 g/dL with low MCV, ferritin 8 ng/mL and mild fatigue symptoms.",
+		ExpectedKeywords: []string{"hemoglobin", "low", "ferritin", "fatigue"},
+		MinCoverage:      0.5,
+	},
+	{
+		ID:               "lipid-followup",
+		Input:            "Lipid profile indicates LDL 170 mg/dL, triglycerides 220 mg/dL. Recommend diet change and follow-up in 6 weeks.",
+		ExpectedKeywords: []string{"ldl", "triglycerides", "diet", "follow-up"},
+		MinCoverage:      0.5,
+	},
+	{
+		ID:               "bp-monitoring",
+		Input:            "Home blood pressure logs average 152/96 across 10 days. Consider medication adjustment and sodium reduction.",
+		ExpectedKeywords: []string{"blood pressure", "average", "medication", "sodium"},
+		MinCoverage:      0.5,
+	},
+}
+
+func evaluateSummaryAgainstFixture(summary string, fixture aiEvalFixture) aiEvalCaseResult {
+	lowerSummary := strings.ToLower(summary)
+	matched := 0
+	for _, kw := range fixture.ExpectedKeywords {
+		if strings.Contains(lowerSummary, strings.ToLower(kw)) {
+			matched++
+		}
+	}
+	coverage := 0.0
+	if len(fixture.ExpectedKeywords) > 0 {
+		coverage = float64(matched) / float64(len(fixture.ExpectedKeywords))
+	}
+	inputExcerpt := fixture.Input
+	if len(inputExcerpt) > 180 {
+		inputExcerpt = inputExcerpt[:180] + "..."
+	}
+	summaryExcerpt := summary
+	if len(summaryExcerpt) > 220 {
+		summaryExcerpt = summaryExcerpt[:220] + "..."
+	}
+	return aiEvalCaseResult{
+		FixtureID:        fixture.ID,
+		InputExcerpt:     inputExcerpt,
+		ExpectedKeywords: fixture.ExpectedKeywords,
+		SummaryExcerpt:   summaryExcerpt,
+		KeywordCoverage:  coverage,
+		Passed:           coverage >= fixture.MinCoverage,
+	}
+}

--- a/backend/handlers/admin_ai_eval_harness_test.go
+++ b/backend/handlers/admin_ai_eval_harness_test.go
@@ -1,0 +1,22 @@
+package handlers
+
+import "testing"
+
+func TestEvaluateSummaryAgainstFixture(t *testing.T) {
+	fixture := aiEvalFixture{
+		ID:               "f1",
+		Input:            "input text",
+		ExpectedKeywords: []string{"ldl", "diet", "follow-up"},
+		MinCoverage:      0.5,
+	}
+	result := evaluateSummaryAgainstFixture("LDL elevated. Diet change advised.", fixture)
+	if result.FixtureID != "f1" {
+		t.Fatalf("unexpected fixture id: %s", result.FixtureID)
+	}
+	if result.KeywordCoverage <= 0 {
+		t.Fatalf("expected positive coverage, got %f", result.KeywordCoverage)
+	}
+	if !result.Passed {
+		t.Fatalf("expected fixture to pass")
+	}
+}

--- a/backend/handlers/admin_ai_runtime.go
+++ b/backend/handlers/admin_ai_runtime.go
@@ -2,10 +2,12 @@ package handlers
 
 import (
 	"context"
+	"encoding/json"
 	"net/http"
 	"strings"
 
 	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
 	"github.com/healthonyx/backend/db"
 )
 
@@ -19,6 +21,7 @@ type adminAIRuntimeSettings struct {
 	CacheEnabled       bool   `json:"cache_enabled"`
 	CacheTTLSeconds    int    `json:"cache_ttl_seconds"`
 	OllamaModel        string `json:"ollama_model"`
+	PromptVersion      string `json:"prompt_version"`
 	UpdatedAt          string `json:"updated_at"`
 	UpdatedBy          string `json:"updated_by"`
 }
@@ -38,6 +41,23 @@ type adminAIEvalResult struct {
 	SamplesEvaluated int     `json:"samples_evaluated"`
 	SuccessRate      float64 `json:"success_rate"`
 	QualityScore     float64 `json:"quality_score"`
+	PromptVersion    string  `json:"prompt_version"`
+	RunID            string  `json:"run_id,omitempty"`
+}
+
+type adminAIEvalRunSummary struct {
+	ID              string  `json:"id"`
+	ModelName       string  `json:"model_name"`
+	PromptVersion   string  `json:"prompt_version"`
+	FixtureCount    int     `json:"fixture_count"`
+	PassedCount     int     `json:"passed_count"`
+	SuccessRate     float64 `json:"success_rate"`
+	QualityScore    float64 `json:"quality_score"`
+	RuntimeMode     string  `json:"runtime_mode"`
+	OllamaReachable bool    `json:"ollama_reachable"`
+	ModelAvailable  bool    `json:"model_available"`
+	StartedAt       string  `json:"started_at"`
+	FinishedAt      string  `json:"finished_at"`
 }
 
 type updateAIRuntimeSettingsRequest struct {
@@ -48,6 +68,7 @@ type updateAIRuntimeSettingsRequest struct {
 	CacheEnabled       bool   `json:"cache_enabled"`
 	CacheTTLSeconds    int    `json:"cache_ttl_seconds"`
 	OllamaModel        string `json:"ollama_model"`
+	PromptVersion      string `json:"prompt_version"`
 }
 
 func NewAdminAIRuntimeHandler() *AdminAIRuntimeHandler {
@@ -70,11 +91,13 @@ func (h *AdminAIRuntimeHandler) GetObservability(c *gin.Context) {
 		return
 	}
 	runtime := getOllamaRuntimeStatus(c.Request.Context(), settings)
+	recentRuns, _ := loadRecentEvalRuns(c.Request.Context(), 5)
 
 	c.JSON(http.StatusOK, gin.H{
 		"settings":      settings,
 		"observability": obs,
 		"runtime":       runtime,
+		"recent_evals":  recentRuns,
 	})
 }
 
@@ -102,6 +125,10 @@ func (h *AdminAIRuntimeHandler) UpdateSettings(c *gin.Context) {
 		c.JSON(http.StatusBadRequest, gin.H{"error": "ollama_model is required"})
 		return
 	}
+	promptVersion := strings.TrimSpace(req.PromptVersion)
+	if promptVersion == "" {
+		promptVersion = "v1"
+	}
 
 	_, err := db.Pool.Exec(c.Request.Context(), `
 		UPDATE admin_ai_runtime_settings
@@ -113,10 +140,11 @@ func (h *AdminAIRuntimeHandler) UpdateSettings(c *gin.Context) {
 			cache_enabled = $5,
 			cache_ttl_seconds = $6,
 			ollama_model = $7,
-			updated_by = $8,
+			prompt_version = $8,
+			updated_by = $9,
 			updated_at = NOW()
 		WHERE id = TRUE
-	`, req.OllamaEnabled, req.FallbackEnabled, req.RateLimitEnabled, req.RateLimitPerMinute, req.CacheEnabled, req.CacheTTLSeconds, model, claims.UserID)
+	`, req.OllamaEnabled, req.FallbackEnabled, req.RateLimitEnabled, req.RateLimitPerMinute, req.CacheEnabled, req.CacheTTLSeconds, model, promptVersion, claims.UserID)
 	if err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "Internal error"})
 		return
@@ -126,7 +154,8 @@ func (h *AdminAIRuntimeHandler) UpdateSettings(c *gin.Context) {
 }
 
 func (h *AdminAIRuntimeHandler) RunEval(c *gin.Context) {
-	if _, ok := getClaims(c); !ok {
+	claims, ok := getClaims(c)
+	if !ok {
 		return
 	}
 
@@ -136,35 +165,51 @@ func (h *AdminAIRuntimeHandler) RunEval(c *gin.Context) {
 		return
 	}
 
-	var samples, doneCount int
-	if err := db.Pool.QueryRow(c.Request.Context(), `
-		SELECT
-			COUNT(*)::int,
-			COUNT(*) FILTER (WHERE status = 'done')::int
-		FROM (
-			SELECT status
-			FROM document_summary_jobs
-			ORDER BY created_at DESC
-			LIMIT 50
-		) s
-	`).Scan(&samples, &doneCount); err != nil {
+	runtime := getOllamaRuntimeStatus(c.Request.Context(), settings)
+	caseResults := make([]aiEvalCaseResult, 0, len(aiEvalFixtures))
+	passedCount := 0
+	coverageSum := 0.0
+	runtimeMode := "fallback_local"
+	for _, fixture := range aiEvalFixtures {
+		summary, mode, evalErr := GenerateSummaryWithAIRuntime(c.Request.Context(), settings, fixture.ID+".txt", int64(len(fixture.Input)), fixture.Input)
+		if evalErr != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "Internal error"})
+			return
+		}
+		if mode == "ollama" {
+			runtimeMode = "ollama"
+		}
+		result := evaluateSummaryAgainstFixture(summary, fixture)
+		caseResults = append(caseResults, result)
+		coverageSum += result.KeywordCoverage
+		if result.Passed {
+			passedCount++
+		}
+	}
+	samples := len(caseResults)
+	successRate := 0.0
+	qualityScore := 0.0
+	if samples > 0 {
+		successRate = float64(passedCount) / float64(samples)
+		qualityScore = (coverageSum / float64(samples)) * 100
+	}
+	runID, persistErr := persistEvalRun(c.Request.Context(), settings, runtime, runtimeMode, claims.UserID, samples, passedCount, successRate, qualityScore, caseResults)
+	if persistErr != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "Internal error"})
 		return
 	}
-
 	result := adminAIEvalResult{
 		ModelName:        settings.OllamaModel,
 		SamplesEvaluated: samples,
-		SuccessRate:      0,
-		QualityScore:     0,
-	}
-	if samples > 0 {
-		result.SuccessRate = float64(doneCount) / float64(samples)
-		result.QualityScore = result.SuccessRate * 100
+		SuccessRate:      successRate,
+		QualityScore:     qualityScore,
+		PromptVersion:    settings.PromptVersion,
+		RunID:            runID.String(),
 	}
 	c.JSON(http.StatusOK, gin.H{
 		"eval":    result,
-		"runtime": getOllamaRuntimeStatus(c.Request.Context(), settings),
+		"runtime": runtime,
+		"cases":   caseResults,
 	})
 }
 
@@ -179,6 +224,7 @@ func loadAIRuntimeSettings(c *gin.Context) (adminAIRuntimeSettings, error) {
 			cache_enabled,
 			cache_ttl_seconds,
 			ollama_model,
+			prompt_version,
 			updated_at::text,
 			COALESCE(updated_by::text, '')
 		FROM admin_ai_runtime_settings
@@ -191,6 +237,7 @@ func loadAIRuntimeSettings(c *gin.Context) (adminAIRuntimeSettings, error) {
 		&out.CacheEnabled,
 		&out.CacheTTLSeconds,
 		&out.OllamaModel,
+		&out.PromptVersion,
 		&out.UpdatedAt,
 		&out.UpdatedBy,
 	)
@@ -208,6 +255,7 @@ func LoadAIRuntimeSettingsForWorker(ctx context.Context) (adminAIRuntimeSettings
 			cache_enabled,
 			cache_ttl_seconds,
 			ollama_model,
+			prompt_version,
 			updated_at::text,
 			COALESCE(updated_by::text, '')
 		FROM admin_ai_runtime_settings
@@ -220,10 +268,78 @@ func LoadAIRuntimeSettingsForWorker(ctx context.Context) (adminAIRuntimeSettings
 		&out.CacheEnabled,
 		&out.CacheTTLSeconds,
 		&out.OllamaModel,
+		&out.PromptVersion,
 		&out.UpdatedAt,
 		&out.UpdatedBy,
 	)
 	return out, err
+}
+
+func persistEvalRun(
+	ctx context.Context,
+	settings adminAIRuntimeSettings,
+	runtime ollamaRuntimeStatus,
+	runtimeMode string,
+	userID uuid.UUID,
+	fixtureCount int,
+	passedCount int,
+	successRate float64,
+	qualityScore float64,
+	cases []aiEvalCaseResult,
+) (uuid.UUID, error) {
+	var runID uuid.UUID
+	if err := db.Pool.QueryRow(ctx, `
+		INSERT INTO admin_ai_eval_runs (
+			model_name, prompt_version, fixture_count, passed_count, success_rate, quality_score,
+			runtime_mode, ai_enabled, ollama_reachable, model_available, created_by, started_at, finished_at
+		) VALUES (
+			$1, $2, $3, $4, $5, $6,
+			$7, $8, $9, $10, $11, NOW(), NOW()
+		)
+		RETURNING id
+	`, settings.OllamaModel, settings.PromptVersion, fixtureCount, passedCount, successRate, qualityScore, runtimeMode, runtime.AIEnabled, runtime.OllamaReachable, runtime.ModelAvailable, userID).Scan(&runID); err != nil {
+		return uuid.Nil, err
+	}
+	for _, c := range cases {
+		keywordsJSON, err := json.Marshal(c.ExpectedKeywords)
+		if err != nil {
+			return uuid.Nil, err
+		}
+		if _, err := db.Pool.Exec(ctx, `
+			INSERT INTO admin_ai_eval_cases (
+				run_id, fixture_id, input_excerpt, expected_keywords, summary_excerpt, keyword_coverage, passed
+			) VALUES ($1, $2, $3, $4::jsonb, $5, $6, $7)
+		`, runID, c.FixtureID, c.InputExcerpt, string(keywordsJSON), c.SummaryExcerpt, c.KeywordCoverage, c.Passed); err != nil {
+			return uuid.Nil, err
+		}
+	}
+	return runID, nil
+}
+
+func loadRecentEvalRuns(ctx context.Context, limit int) ([]adminAIEvalRunSummary, error) {
+	if limit <= 0 {
+		limit = 5
+	}
+	rows, err := db.Pool.Query(ctx, `
+		SELECT id::text, model_name, prompt_version, fixture_count, passed_count, success_rate, quality_score,
+		       runtime_mode, ollama_reachable, model_available, started_at::text, finished_at::text
+		FROM admin_ai_eval_runs
+		ORDER BY started_at DESC
+		LIMIT $1
+	`, limit)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	out := []adminAIEvalRunSummary{}
+	for rows.Next() {
+		var r adminAIEvalRunSummary
+		if err := rows.Scan(&r.ID, &r.ModelName, &r.PromptVersion, &r.FixtureCount, &r.PassedCount, &r.SuccessRate, &r.QualityScore, &r.RuntimeMode, &r.OllamaReachable, &r.ModelAvailable, &r.StartedAt, &r.FinishedAt); err != nil {
+			return nil, err
+		}
+		out = append(out, r)
+	}
+	return out, nil
 }
 
 func loadAIObservability(c *gin.Context) (adminAIObservability, error) {


### PR DESCRIPTION
## Summary
Implements PR-05 backend scope.

- Adds fixture-based eval harness with deterministic keyword-coverage score schema.
- Adds prompt version metadata support in AI runtime settings.
- Persists eval runs and per-case outputs for dashboard read surfaces (ecent_evals) and returns run/case data from eval endpoint.

## Verification
- go test ./...
- go build ./...

Made with [Cursor](https://cursor.com)