### PR TITLE
feat(frontend): PR-11 admin user management console

### DIFF
--- a/frontend/src/app/components/admin-management/admin-management.component.html
+++ b/frontend/src/app/components/admin-management/admin-management.component.html
@@ -42,4 +42,112 @@
     <p class="muted">Last updated: {{ settings.updated_at || 'n/a' }}</p>
     <button type="submit" [disabled]="saving">{{ saving ? 'Saving...' : 'Save settings' }}</button>
   </form>
+
+  <section class="users" *ngIf="!loading">
+    <h2>User lifecycle console</h2>
+    <p class="muted">Create, edit, deactivate, and reset passwords for users.</p>
+
+    <div class="user-grid">
+      <div class="panel">
+        <h3>Users</h3>
+        <table data-cy="admin-users-table" *ngIf="users.length; else emptyUsers">
+          <thead>
+            <tr>
+              <th>Email</th>
+              <th>Role</th>
+              <th>Status</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr
+              *ngFor="let u of users"
+              [class.selected]="selectedUserId === u.id"
+              (click)="selectUser(u.id)"
+              data-cy="admin-user-row"
+            >
+              <td>{{ u.email }}</td>
+              <td>{{ u.role }}</td>
+              <td>{{ u.is_active ? 'active' : 'inactive' }}</td>
+            </tr>
+          </tbody>
+        </table>
+        <ng-template #emptyUsers>
+          <p class="muted">No users found.</p>
+        </ng-template>
+      </div>
+
+      <div class="panel">
+        <h3>Create user</h3>
+        <form class="mini-form" (ngSubmit)="createUser()">
+          <label>
+            <span>Email</span>
+            <input type="email" name="createEmail" [(ngModel)]="createForm.email" required />
+          </label>
+          <label>
+            <span>Password</span>
+            <input type="password" name="createPassword" [(ngModel)]="createForm.password" required />
+          </label>
+          <label>
+            <span>Role</span>
+            <select name="createRole" [(ngModel)]="createForm.role">
+              <option value="patient">patient</option>
+              <option value="doctor">doctor</option>
+              <option value="admin">admin</option>
+            </select>
+          </label>
+          <button type="submit" [disabled]="userBusy" data-cy="admin-user-create-btn">Create user</button>
+        </form>
+
+        <h3>Edit selected user</h3>
+        <form class="mini-form" (ngSubmit)="updateSelectedUser()">
+          <label>
+            <span>Email</span>
+            <input type="email" name="editEmail" [(ngModel)]="editForm.email" [disabled]="!selectedUserId" required />
+          </label>
+          <label>
+            <span>Role</span>
+            <select name="editRole" [(ngModel)]="editForm.role" [disabled]="!selectedUserId">
+              <option value="patient">patient</option>
+              <option value="doctor">doctor</option>
+              <option value="admin">admin</option>
+            </select>
+          </label>
+          <button type="submit" [disabled]="userBusy || !selectedUserId" data-cy="admin-user-update-btn">
+            Save user
+          </button>
+        </form>
+
+        <h3>Reset password</h3>
+        <form class="mini-form" (ngSubmit)="resetSelectedPassword()">
+          <label>
+            <span>New password</span>
+            <input
+              type="password"
+              name="resetPassword"
+              [(ngModel)]="resetForm.newPassword"
+              [disabled]="!selectedUserId"
+              required
+            />
+          </label>
+          <button
+            type="submit"
+            [disabled]="userBusy || !selectedUserId || !resetForm.newPassword.trim()"
+            data-cy="admin-user-reset-btn"
+          >
+            Reset password
+          </button>
+        </form>
+
+        <button
+          type="button"
+          class="danger"
+          (click)="deactivateSelectedUser()"
+          [disabled]="userBusy || !selectedUserId"
+          data-cy="admin-user-deactivate-btn"
+        >
+          Deactivate selected user
+        </button>
+      </div>
+    </div>
+  </section>
 </section>

--- a/frontend/src/app/components/admin-management/admin-management.component.scss
+++ b/frontend/src/app/components/admin-management/admin-management.component.scss
@@ -94,3 +94,71 @@
   color: #94a3b8;
   font-size: 0.85rem;
 }
+
+.users {
+  display: grid;
+  gap: 0.75rem;
+}
+
+.user-grid {
+  display: grid;
+  grid-template-columns: minmax(320px, 1fr) minmax(320px, 1fr);
+  gap: 1rem;
+}
+
+.panel {
+  border: 1px solid rgba(148, 163, 184, 0.3);
+  border-radius: 0.5rem;
+  padding: 0.75rem;
+  display: grid;
+  gap: 0.75rem;
+}
+
+.panel h3 {
+  margin: 0;
+}
+
+table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.86rem;
+}
+
+th,
+td {
+  border-bottom: 1px solid rgba(148, 163, 184, 0.25);
+  text-align: left;
+  padding: 0.4rem;
+}
+
+tbody tr {
+  cursor: pointer;
+}
+
+tbody tr.selected {
+  background: rgba(34, 211, 238, 0.12);
+}
+
+.mini-form {
+  display: grid;
+  gap: 0.6rem;
+}
+
+.mini-form label {
+  display: grid;
+  gap: 0.35rem;
+}
+
+.mini-form input,
+.mini-form select {
+  background: rgba(15, 23, 42, 0.65);
+  border: 1px solid rgba(148, 163, 184, 0.35);
+  border-radius: 0.35rem;
+  color: #e2e8f0;
+  padding: 0.45rem 0.55rem;
+}
+
+.danger {
+  border-color: #f87171 !important;
+  color: #f87171 !important;
+}

--- a/frontend/src/app/components/admin-management/admin-management.component.spec.ts
+++ b/frontend/src/app/components/admin-management/admin-management.component.spec.ts
@@ -1,0 +1,166 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { provideHttpClient } from '@angular/common/http';
+import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
+import { AdminManagementComponent } from './admin-management.component';
+
+describe('AdminManagementComponent', () => {
+  let fixture: ComponentFixture<AdminManagementComponent>;
+  let httpMock: HttpTestingController;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [AdminManagementComponent],
+      providers: [provideHttpClient(), provideHttpClientTesting()]
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(AdminManagementComponent);
+    httpMock = TestBed.inject(HttpTestingController);
+    fixture.detectChanges();
+
+    httpMock.expectOne('/api/admin/user-lifecycle/settings-kpis').flush({
+      settings: {
+        new_user_window_days: 14,
+        inactive_window_days: 30,
+        updated_at: 'now',
+        updated_by: ''
+      },
+      kpis: {
+        total_users: 2,
+        total_patients: 1,
+        total_doctors: 1,
+        total_admins: 0,
+        new_users_in_window: 1,
+        inactive_users_count: 0
+      }
+    });
+    httpMock.expectOne('/api/admin/user-lifecycle/users').flush({
+      users: [
+        {
+          id: 'u1',
+          email: 'patient@demo.com',
+          role: 'patient',
+          is_active: true,
+          created_at: 'now',
+          deactivated_at: '',
+          deactivated_by: ''
+        }
+      ]
+    });
+    fixture.detectChanges();
+  });
+
+  afterEach(() => httpMock.verify());
+
+  it('renders users table', () => {
+    expect((fixture.nativeElement as HTMLElement).querySelector('[data-cy="admin-users-table"]')).toBeTruthy();
+  });
+
+  it('creates a user', () => {
+    fixture.componentInstance.createForm.email = 'new@demo.com';
+    fixture.componentInstance.createForm.password = 'strongpass';
+    fixture.componentInstance.createForm.role = 'doctor';
+    fixture.componentInstance.createUser();
+
+    const createReq = httpMock.expectOne('/api/admin/user-lifecycle/users');
+    expect(createReq.request.method).toBe('POST');
+    createReq.flush({
+      id: 'u2',
+      email: 'new@demo.com',
+      role: 'doctor',
+      is_active: true
+    });
+    httpMock.expectOne('/api/admin/user-lifecycle/users').flush({
+      users: [
+        {
+          id: 'u1',
+          email: 'patient@demo.com',
+          role: 'patient',
+          is_active: true,
+          created_at: 'now',
+          deactivated_at: '',
+          deactivated_by: ''
+        },
+        {
+          id: 'u2',
+          email: 'new@demo.com',
+          role: 'doctor',
+          is_active: true,
+          created_at: 'now',
+          deactivated_at: '',
+          deactivated_by: ''
+        }
+      ]
+    });
+    expect(fixture.componentInstance.success).toBe('User created.');
+  });
+
+  it('updates selected user', () => {
+    fixture.componentInstance.selectUser('u1');
+    fixture.componentInstance.editForm.email = 'updated@demo.com';
+    fixture.componentInstance.editForm.role = 'doctor';
+    fixture.componentInstance.updateSelectedUser();
+
+    const updateReq = httpMock.expectOne('/api/admin/user-lifecycle/users/u1');
+    expect(updateReq.request.method).toBe('PUT');
+    updateReq.flush({
+      id: 'u1',
+      email: 'updated@demo.com',
+      role: 'doctor',
+      is_active: true
+    });
+    httpMock.expectOne('/api/admin/user-lifecycle/users').flush({
+      users: [
+        {
+          id: 'u1',
+          email: 'updated@demo.com',
+          role: 'doctor',
+          is_active: true,
+          created_at: 'now',
+          deactivated_at: '',
+          deactivated_by: ''
+        }
+      ]
+    });
+    expect(fixture.componentInstance.success).toBe('User updated.');
+  });
+
+  it('deactivates selected user', () => {
+    fixture.componentInstance.selectUser('u1');
+    fixture.componentInstance.deactivateSelectedUser();
+    const deactivateReq = httpMock.expectOne('/api/admin/user-lifecycle/users/u1/deactivate');
+    expect(deactivateReq.request.method).toBe('PATCH');
+    deactivateReq.flush({
+      id: 'u1',
+      status: 'deactivated'
+    });
+    httpMock.expectOne('/api/admin/user-lifecycle/users').flush({
+      users: [
+        {
+          id: 'u1',
+          email: 'patient@demo.com',
+          role: 'patient',
+          is_active: false,
+          created_at: 'now',
+          deactivated_at: 'now',
+          deactivated_by: 'admin'
+        }
+      ]
+    });
+    expect(fixture.componentInstance.success).toBe('User deactivated.');
+  });
+
+  it('resets selected user password', () => {
+    fixture.componentInstance.selectUser('u1');
+    fixture.componentInstance.resetForm.newPassword = 'newpass123';
+    fixture.componentInstance.resetSelectedPassword();
+    const resetReq = httpMock.expectOne('/api/admin/user-lifecycle/users/u1/reset-password');
+    expect(resetReq.request.method).toBe('POST');
+    resetReq.flush({
+      id: 'u1',
+      password_reset: true
+    });
+    expect(fixture.componentInstance.resetForm.newPassword).toBe('');
+    expect(fixture.componentInstance.success).toBe('Password reset complete.');
+  });
+});
+

--- a/frontend/src/app/components/admin-management/admin-management.component.ts
+++ b/frontend/src/app/components/admin-management/admin-management.component.ts
@@ -4,6 +4,7 @@ import { FormsModule } from '@angular/forms';
 import {
   AdminLifecycleKpis,
   AdminLifecycleSettings,
+  AdminLifecycleUser,
   AdminUserLifecycleService
 } from '../../services/admin-user-lifecycle.service';
 
@@ -17,14 +18,29 @@ import {
 export class AdminManagementComponent implements OnInit {
   loading = true;
   saving = false;
+  userBusy = false;
   error: string | null = null;
   success: string | null = null;
   settings: AdminLifecycleSettings | null = null;
   kpis: AdminLifecycleKpis | null = null;
+  users: AdminLifecycleUser[] = [];
+  selectedUserId = '';
 
   form = {
     new_user_window_days: 14,
     inactive_window_days: 30
+  };
+  createForm = {
+    email: '',
+    password: '',
+    role: 'patient' as 'patient' | 'doctor' | 'admin'
+  };
+  editForm = {
+    email: '',
+    role: 'patient' as 'patient' | 'doctor' | 'admin'
+  };
+  resetForm = {
+    newPassword: ''
   };
 
   constructor(private readonly api: AdminUserLifecycleService) {}
@@ -42,7 +58,19 @@ export class AdminManagementComponent implements OnInit {
         this.kpis = res.kpis;
         this.form.new_user_window_days = res.settings.new_user_window_days;
         this.form.inactive_window_days = res.settings.inactive_window_days;
-        this.loading = false;
+        this.api.listUsers().subscribe({
+          next: (usersRes) => {
+            this.users = usersRes.users ?? [];
+            if (this.users.length > 0 && !this.selectedUserId) {
+              this.selectUser(this.users[0].id);
+            }
+            this.loading = false;
+          },
+          error: () => {
+            this.error = 'Could not load users.';
+            this.loading = false;
+          }
+        });
       },
       error: () => {
         this.error = 'Could not load lifecycle settings.';
@@ -72,5 +100,122 @@ export class AdminManagementComponent implements OnInit {
           this.saving = false;
         }
       });
+  }
+
+  selectUser(id: string): void {
+    this.selectedUserId = id;
+    const u = this.users.find((x) => x.id === id);
+    if (!u) {
+      return;
+    }
+    this.editForm.email = u.email;
+    this.editForm.role = u.role;
+    this.resetForm.newPassword = '';
+  }
+
+  createUser(): void {
+    this.userBusy = true;
+    this.error = null;
+    this.success = null;
+    this.api
+      .createUser({
+        email: this.createForm.email.trim().toLowerCase(),
+        password: this.createForm.password,
+        role: this.createForm.role
+      })
+      .subscribe({
+        next: () => {
+          this.success = 'User created.';
+          this.createForm.email = '';
+          this.createForm.password = '';
+          this.refreshUsers();
+        },
+        error: () => {
+          this.userBusy = false;
+          this.error = 'Could not create user.';
+        }
+      });
+  }
+
+  updateSelectedUser(): void {
+    if (!this.selectedUserId) {
+      return;
+    }
+    this.userBusy = true;
+    this.error = null;
+    this.success = null;
+    this.api
+      .updateUser(this.selectedUserId, {
+        email: this.editForm.email.trim().toLowerCase(),
+        role: this.editForm.role
+      })
+      .subscribe({
+        next: () => {
+          this.success = 'User updated.';
+          this.refreshUsers();
+        },
+        error: () => {
+          this.userBusy = false;
+          this.error = 'Could not update user.';
+        }
+      });
+  }
+
+  deactivateSelectedUser(): void {
+    if (!this.selectedUserId) {
+      return;
+    }
+    this.userBusy = true;
+    this.error = null;
+    this.success = null;
+    this.api.deactivateUser(this.selectedUserId).subscribe({
+      next: () => {
+        this.success = 'User deactivated.';
+        this.refreshUsers();
+      },
+      error: () => {
+        this.userBusy = false;
+        this.error = 'Could not deactivate user.';
+      }
+    });
+  }
+
+  resetSelectedPassword(): void {
+    if (!this.selectedUserId || !this.resetForm.newPassword.trim()) {
+      return;
+    }
+    this.userBusy = true;
+    this.error = null;
+    this.success = null;
+    this.api.resetPassword(this.selectedUserId, this.resetForm.newPassword).subscribe({
+      next: () => {
+        this.success = 'Password reset complete.';
+        this.resetForm.newPassword = '';
+        this.userBusy = false;
+      },
+      error: () => {
+        this.userBusy = false;
+        this.error = 'Could not reset password.';
+      }
+    });
+  }
+
+  private refreshUsers(): void {
+    this.api.listUsers().subscribe({
+      next: (res) => {
+        this.users = res.users ?? [];
+        const stillExists = this.users.some((u) => u.id === this.selectedUserId);
+        if (!stillExists && this.users.length > 0) {
+          this.selectUser(this.users[0].id);
+        } else if (stillExists) {
+          this.selectUser(this.selectedUserId);
+        }
+        this.userBusy = false;
+      },
+      error: () => {
+        this.userBusy = false;
+        this.error = 'Could not refresh users.';
+      }
+    });
   }
 }

--- a/frontend/src/app/services/admin-user-lifecycle.service.ts
+++ b/frontend/src/app/services/admin-user-lifecycle.service.ts
@@ -5,6 +5,16 @@ import { ApiContract } from './api-contract';
 import type { AdminLifecycleSettingsKpisResponse } from './api-types';
 export type { AdminLifecycleSettings, AdminLifecycleKpis, AdminLifecycleSettingsKpisResponse } from './api-types';
 
+export type AdminLifecycleUser = {
+  id: string;
+  email: string;
+  role: 'patient' | 'doctor' | 'admin';
+  is_active: boolean;
+  created_at: string;
+  deactivated_at: string;
+  deactivated_by: string;
+};
+
 @Injectable({ providedIn: 'root' })
 export class AdminUserLifecycleService {
   constructor(private http: HttpClient) {}
@@ -18,5 +28,41 @@ export class AdminUserLifecycleService {
     inactive_window_days: number;
   }): Observable<AdminLifecycleSettingsKpisResponse> {
     return this.http.put<AdminLifecycleSettingsKpisResponse>(ApiContract.admin.userLifecycleSettings, payload);
+  }
+
+  listUsers(): Observable<{ users: AdminLifecycleUser[] }> {
+    return this.http.get<{ users: AdminLifecycleUser[] }>(ApiContract.admin.userLifecycleUsers);
+  }
+
+  createUser(payload: {
+    email: string;
+    password: string;
+    role: 'patient' | 'doctor' | 'admin';
+  }): Observable<{ id: string; email: string; role: string; is_active: boolean }> {
+    return this.http.post<{ id: string; email: string; role: string; is_active: boolean }>(
+      ApiContract.admin.userLifecycleUsers,
+      payload
+    );
+  }
+
+  updateUser(
+    id: string,
+    payload: { email?: string; role?: 'patient' | 'doctor' | 'admin' }
+  ): Observable<{ id: string; email: string; role: string; is_active: boolean }> {
+    return this.http.put<{ id: string; email: string; role: string; is_active: boolean }>(
+      ApiContract.admin.userLifecycleUserById(id),
+      payload
+    );
+  }
+
+  deactivateUser(id: string): Observable<{ id: string; status: string }> {
+    return this.http.patch<{ id: string; status: string }>(ApiContract.admin.userLifecycleDeactivate(id), {});
+  }
+
+  resetPassword(id: string, newPassword: string): Observable<{ id: string; password_reset: boolean }> {
+    return this.http.post<{ id: string; password_reset: boolean }>(
+      ApiContract.admin.userLifecycleResetPassword(id),
+      { new_password: newPassword }
+    );
   }
 }

--- a/frontend/src/app/services/api-contract.ts
+++ b/frontend/src/app/services/api-contract.ts
@@ -68,6 +68,11 @@ export const ApiContract = {
   },
   admin: {
     auditLog: `${API}/admin/audit-log`,
+    userLifecycleUsers: `${API}/admin/user-lifecycle/users`,
+    userLifecycleUserById: (id: string): string => `${API}/admin/user-lifecycle/users/${id}`,
+    userLifecycleDeactivate: (id: string): string => `${API}/admin/user-lifecycle/users/${id}/deactivate`,
+    userLifecycleResetPassword: (id: string): string =>
+      `${API}/admin/user-lifecycle/users/${id}/reset-password`,
     userLifecycleSettingsKpis: `${API}/admin/user-lifecycle/settings-kpis`,
     userLifecycleSettings: `${API}/admin/user-lifecycle/settings`,
     aiObservability: `${API}/admin/ai/observability`,


### PR DESCRIPTION
## Summary
- extend admin management into a full user lifecycle console with list/create/edit/deactivate/reset password actions
- wire the UI to PR-09 backend lifecycle endpoints via updated frontend contract/service methods
- add component tests covering create, update, deactivate, and password reset workflows

## Test plan
- [x] Run `npm run test:ci -- --include src/app/components/admin-management/admin-management.component.spec.ts`
- [ ] Manual admin-management page verification in browser