### PR TITLE
feat(frontend): PR-12 contextual comments UI pack

### DIFF
--- a/frontend/src/app/components/admin-knowledge/admin-knowledge.component.html
+++ b/frontend/src/app/components/admin-knowledge/admin-knowledge.component.html
@@ -202,6 +202,17 @@
           </li>
         </ul>
       </div>
+      <div class="detail-actions">
+        <button type="button" class="btn-secondary" (click)="toggleDetailComments()" data-cy="kb-comments-toggle">
+          {{ showDetailComments ? 'Hide comments' : 'Show comments' }}
+        </button>
+      </div>
+      <app-contextual-comments-panel
+        *ngIf="showDetailComments && selectedId"
+        [contextType]="'knowledge_doc'"
+        [contextId]="selectedId"
+        panelTitle="KB document comments"
+      />
     </ng-container>
   </section>
 </section>

--- a/frontend/src/app/components/admin-knowledge/admin-knowledge.component.ts
+++ b/frontend/src/app/components/admin-knowledge/admin-knowledge.component.ts
@@ -8,11 +8,12 @@ import {
   KnowledgeListDocument,
   SimilarityPair
 } from '../../services/knowledge-admin.service';
+import { ContextualCommentsPanelComponent } from '../contextual-comments-panel/contextual-comments-panel.component';
 
 @Component({
   selector: 'app-admin-knowledge',
   standalone: true,
-  imports: [CommonModule, FormsModule],
+  imports: [CommonModule, FormsModule, ContextualCommentsPanelComponent],
   templateUrl: './admin-knowledge.component.html',
   styleUrl: './admin-knowledge.component.scss'
 })
@@ -42,6 +43,7 @@ export class AdminKnowledgeComponent implements OnInit {
   scanLoading = false;
   scanPairs: SimilarityPair[] = [];
   scanMeta: { chunks_scanned: number; threshold: number } | null = null;
+  showDetailComments = false;
 
   constructor(private kb: KnowledgeAdminService) {}
 
@@ -137,6 +139,7 @@ export class AdminKnowledgeComponent implements OnInit {
     this.detail = null;
     this.versions = [];
     this.versionsOpen = false;
+    this.showDetailComments = false;
   }
 
   savePatch(): void {
@@ -263,5 +266,9 @@ export class AdminKnowledgeComponent implements OnInit {
       return 'badge--purple';
     }
     return 'badge--info';
+  }
+
+  toggleDetailComments(): void {
+    this.showDetailComments = !this.showDetailComments;
   }
 }

--- a/frontend/src/app/components/contextual-comments-panel/contextual-comments-panel.component.spec.ts
+++ b/frontend/src/app/components/contextual-comments-panel/contextual-comments-panel.component.spec.ts
@@ -1,0 +1,72 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { provideHttpClient } from '@angular/common/http';
+import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
+import { provideRouter } from '@angular/router';
+import { SimpleChange } from '@angular/core';
+import { ContextualCommentsPanelComponent } from './contextual-comments-panel.component';
+import { AuthService } from '../../services/auth.service';
+
+describe('ContextualCommentsPanelComponent', () => {
+  let fixture: ComponentFixture<ContextualCommentsPanelComponent>;
+  let httpMock: HttpTestingController;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [ContextualCommentsPanelComponent],
+      providers: [provideHttpClient(), provideHttpClientTesting(), provideRouter([]), AuthService]
+    }).compileComponents();
+
+    localStorage.setItem('user', JSON.stringify({ id: 'u1', email: 'admin@demo.com', role: 'admin' }));
+    fixture = TestBed.createComponent(ContextualCommentsPanelComponent);
+    httpMock = TestBed.inject(HttpTestingController);
+    fixture.componentInstance.contextType = 'document';
+    fixture.componentInstance.contextId = 'd1';
+    fixture.componentInstance.ngOnChanges({
+      contextType: new SimpleChange(undefined, 'document', true),
+      contextId: new SimpleChange(undefined, 'd1', true)
+    });
+    fixture.detectChanges();
+  });
+
+  afterEach(() => {
+    localStorage.removeItem('user');
+    httpMock.verify();
+  });
+
+  it('loads comments for context', () => {
+    httpMock.expectOne('/api/comments/document/d1').flush({
+      comments: []
+    });
+    fixture.detectChanges();
+    expect((fixture.nativeElement as HTMLElement).querySelector('[data-cy="context-comments-panel"]')).toBeTruthy();
+  });
+
+  it('creates a comment and reloads list', () => {
+    httpMock.expectOne('/api/comments/document/d1').flush({
+      comments: []
+    });
+    fixture.componentInstance.newBody = 'Follow-up required';
+    fixture.componentInstance.newVisibility = 'care_team';
+    fixture.componentInstance.create();
+
+    const createReq = httpMock.expectOne('/api/comments/document/d1');
+    expect(createReq.request.method).toBe('POST');
+    createReq.flush({ id: 'c1', visibility: 'care_team' });
+
+    httpMock.expectOne('/api/comments/document/d1').flush({
+      comments: [
+        {
+          id: 'c1',
+          context_type: 'document',
+          context_id: 'd1',
+          author_user_id: 'u1',
+          body: 'Follow-up required',
+          visibility: 'care_team',
+          created_at: 'now'
+        }
+      ]
+    });
+    expect(fixture.componentInstance.comments.length).toBe(1);
+  });
+});
+

--- a/frontend/src/app/components/contextual-comments-panel/contextual-comments-panel.component.ts
+++ b/frontend/src/app/components/contextual-comments-panel/contextual-comments-panel.component.ts
@@ -1,0 +1,178 @@
+import { CommonModule } from '@angular/common';
+import { Component, Input, OnChanges, SimpleChanges } from '@angular/core';
+import { FormsModule } from '@angular/forms';
+import { AuthService } from '../../services/auth.service';
+import {
+  CommentVisibility,
+  ContextType,
+  ContextualCommentRow,
+  ContextualCommentsService
+} from '../../services/contextual-comments.service';
+
+@Component({
+  selector: 'app-contextual-comments-panel',
+  standalone: true,
+  imports: [CommonModule, FormsModule],
+  template: `
+    <section class="panel" data-cy="context-comments-panel">
+      <h3>{{ panelTitle }}</h3>
+      <p class="err" *ngIf="error">{{ error }}</p>
+
+      <div class="composer">
+        <textarea
+          rows="3"
+          name="commentBody"
+          [(ngModel)]="newBody"
+          placeholder="Add comment"
+          data-cy="context-comments-body"
+        ></textarea>
+        <div class="composer-row">
+          <select
+            name="commentVisibility"
+            [(ngModel)]="newVisibility"
+            [disabled]="visibilityOptions.length <= 1"
+            data-cy="context-comments-visibility"
+          >
+            <option *ngFor="let v of visibilityOptions" [value]="v">{{ v }}</option>
+          </select>
+          <button type="button" (click)="create()" [disabled]="saving || !newBody.trim()" data-cy="context-comments-add">
+            {{ saving ? 'Posting...' : 'Add comment' }}
+          </button>
+        </div>
+      </div>
+
+      <p *ngIf="loading">Loading comments...</p>
+      <ul *ngIf="!loading && comments.length" class="comment-list" data-cy="context-comments-list">
+        <li *ngFor="let c of comments" data-cy="context-comment-row">
+          <div class="meta">
+            <span>{{ c.visibility }}</span>
+            <small>{{ c.created_at }}</small>
+          </div>
+          <p>{{ c.body }}</p>
+        </li>
+      </ul>
+      <p *ngIf="!loading && !comments.length" class="muted">No comments yet.</p>
+    </section>
+  `,
+  styles: [
+    `
+      .panel {
+        border: 1px solid rgba(148, 163, 184, 0.28);
+        border-radius: 0.5rem;
+        padding: 0.75rem;
+        margin-top: 0.75rem;
+      }
+      .composer {
+        display: grid;
+        gap: 0.4rem;
+        margin-bottom: 0.65rem;
+      }
+      textarea,
+      select {
+        background: rgba(15, 23, 42, 0.65);
+        border: 1px solid rgba(148, 163, 184, 0.35);
+        border-radius: 0.35rem;
+        color: #e2e8f0;
+        padding: 0.45rem 0.55rem;
+      }
+      .composer-row {
+        display: flex;
+        gap: 0.5rem;
+        justify-content: space-between;
+      }
+      .comment-list {
+        list-style: none;
+        margin: 0;
+        padding: 0;
+        display: grid;
+        gap: 0.45rem;
+      }
+      .comment-list li {
+        border: 1px solid rgba(148, 163, 184, 0.25);
+        border-radius: 0.4rem;
+        padding: 0.45rem 0.55rem;
+      }
+      .meta {
+        display: flex;
+        justify-content: space-between;
+        color: #94a3b8;
+        font-size: 0.8rem;
+      }
+      .err {
+        color: #f87171;
+      }
+      .muted {
+        color: #94a3b8;
+      }
+    `
+  ]
+})
+export class ContextualCommentsPanelComponent implements OnChanges {
+  @Input({ required: true }) contextType!: ContextType;
+  @Input({ required: true }) contextId!: string;
+  @Input() panelTitle = 'Comments';
+
+  loading = false;
+  saving = false;
+  error: string | null = null;
+  comments: ContextualCommentRow[] = [];
+  newBody = '';
+  newVisibility: CommentVisibility = 'patient_visible';
+
+  constructor(
+    private api: ContextualCommentsService,
+    private auth: AuthService
+  ) {}
+
+  get visibilityOptions(): CommentVisibility[] {
+    const role = this.auth.getUser()?.role ?? '';
+    if (role === 'patient') {
+      return ['patient_visible'];
+    }
+    return ['patient_visible', 'care_team', 'internal'];
+  }
+
+  ngOnChanges(changes: SimpleChanges): void {
+    if ((changes['contextType'] || changes['contextId']) && this.contextType && this.contextId) {
+      this.newVisibility = this.visibilityOptions[0];
+      this.load();
+    }
+  }
+
+  load(): void {
+    this.loading = true;
+    this.error = null;
+    this.api.list(this.contextType, this.contextId).subscribe({
+      next: (res) => {
+        this.comments = res.comments ?? [];
+        this.loading = false;
+      },
+      error: () => {
+        this.loading = false;
+        this.error = 'Could not load comments.';
+      }
+    });
+  }
+
+  create(): void {
+    this.saving = true;
+    this.error = null;
+    this.api
+      .create(this.contextType, this.contextId, {
+        body: this.newBody.trim(),
+        visibility: this.newVisibility
+      })
+      .subscribe({
+        next: () => {
+          this.newBody = '';
+          this.saving = false;
+          this.load();
+        },
+        error: () => {
+          this.saving = false;
+          this.error = 'Could not post comment.';
+        }
+      });
+  }
+}
+

--- a/frontend/src/app/components/doctor-document-detail/doctor-document-detail.component.html
+++ b/frontend/src/app/components/doctor-document-detail/doctor-document-detail.component.html
@@ -125,5 +125,20 @@
         configured).
       </p>
     </div>
+
+    <div class="summary-section glass" data-cy="doctor-document-comments-pack">
+      <div class="summary-head">
+        <h2>Comments</h2>
+        <button type="button" class="btn-ghost" (click)="toggleComments()" data-cy="doctor-document-comments-toggle">
+          {{ showComments ? 'Hide comments' : 'Show comments' }}
+        </button>
+      </div>
+      <app-contextual-comments-panel
+        *ngIf="showComments"
+        [contextType]="'document'"
+        [contextId]="d.id"
+        panelTitle="Document discussion"
+      />
+    </div>
   </ng-container>
 </section>

--- a/frontend/src/app/components/doctor-document-detail/doctor-document-detail.component.ts
+++ b/frontend/src/app/components/doctor-document-detail/doctor-document-detail.component.ts
@@ -5,11 +5,12 @@ import { ActivatedRoute, Router, RouterModule } from '@angular/router';
 import { Subscription, timer } from 'rxjs';
 import { finalize } from 'rxjs/operators';
 import { DoctorDocumentDetail, DoctorDocumentsService } from '../../services/doctor-documents.service';
+import { ContextualCommentsPanelComponent } from '../contextual-comments-panel/contextual-comments-panel.component';
 
 @Component({
   selector: 'app-doctor-document-detail',
   standalone: true,
-  imports: [CommonModule, RouterModule, DatePipe],
+  imports: [CommonModule, RouterModule, DatePipe, ContextualCommentsPanelComponent],
   templateUrl: './doctor-document-detail.component.html',
   styleUrl: './doctor-document-detail.component.scss'
 })
@@ -21,6 +22,7 @@ export class DoctorDocumentDetailComponent implements OnInit, OnDestroy {
   /** Last error from POST /summarize (shown inline; distinct from page load error). */
   summaryRequestError = '';
   summarizeInfo = '';
+  showComments = false;
   private documentId = '';
   private pollSub?: Subscription;
 
@@ -213,5 +215,9 @@ export class DoctorDocumentDetailComponent implements OnInit, OnDestroy {
 
   primarySummaryDisabled(d: DoctorDocumentDetail): boolean {
     return this.summarizeLoading || d.summary_status === 'pending';
+  }
+
+  toggleComments(): void {
+    this.showComments = !this.showComments;
   }
 }

--- a/frontend/src/app/components/patient-prescriptions/patient-prescriptions.component.ts
+++ b/frontend/src/app/components/patient-prescriptions/patient-prescriptions.component.ts
@@ -2,11 +2,12 @@ import { Component, OnInit } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { PrescriptionsService, PrescriptionRow } from '../../services/prescriptions.service';
 import { AuthService } from '../../services/auth.service';
+import { ContextualCommentsPanelComponent } from '../contextual-comments-panel/contextual-comments-panel.component';
 
 @Component({
   selector: 'app-patient-prescriptions',
   standalone: true,
-  imports: [CommonModule],
+  imports: [CommonModule, ContextualCommentsPanelComponent],
   template: `
     <section data-cy="patient-prescriptions-page">
       <h1>My prescriptions</h1>
@@ -62,6 +63,15 @@ import { AuthService } from '../../services/auth.service';
             </button>
           </div>
           <small>Prescribed {{ r.created_at }}</small>
+          <button type="button" class="toggle-btn mt-2" (click)="toggleComments(r.id)" data-cy="rx-comments-toggle">
+            {{ commentsOpen(r.id) ? 'Hide comments' : 'Show comments' }}
+          </button>
+          <app-contextual-comments-panel
+            *ngIf="commentsOpen(r.id)"
+            [contextType]="'record'"
+            [contextId]="r.id"
+            panelTitle="Prescription comments"
+          />
         </li>
       </ul>
 
@@ -87,6 +97,20 @@ import { AuthService } from '../../services/auth.service';
             </button>
           </div>
           <small>Prescribed {{ r.created_at }}</small>
+          <button
+            type="button"
+            class="toggle-btn mt-2"
+            (click)="toggleComments(r.id)"
+            data-cy="rx-history-comments-toggle"
+          >
+            {{ commentsOpen(r.id) ? 'Hide comments' : 'Show comments' }}
+          </button>
+          <app-contextual-comments-panel
+            *ngIf="commentsOpen(r.id)"
+            [contextType]="'record'"
+            [contextId]="r.id"
+            panelTitle="Prescription comments"
+          />
         </li>
       </ul>
 
@@ -184,6 +208,9 @@ import { AuthService } from '../../services/auth.service';
       .mt {
         margin-top: 1rem;
       }
+      .mt-2 {
+        margin-top: 0.45rem;
+      }
     `
   ]
 })
@@ -196,6 +223,7 @@ export class PatientPrescriptionsComponent implements OnInit {
   pdfError: string | null = null;
   downloading: Record<string, boolean> = {};
   reminderToggles: Record<string, boolean> = {};
+  openCommentsById: Record<string, boolean> = {};
 
   constructor(
     private rx: PrescriptionsService,
@@ -235,6 +263,17 @@ export class PatientPrescriptionsComponent implements OnInit {
       [id]: !this.remindersEnabled(id)
     };
     this.saveReminderToggles();
+  }
+
+  commentsOpen(id: string): boolean {
+    return this.openCommentsById[id] ?? false;
+  }
+
+  toggleComments(id: string): void {
+    this.openCommentsById = {
+      ...this.openCommentsById,
+      [id]: !this.commentsOpen(id)
+    };
   }
 
   isDownloading(id: string): boolean {

--- a/frontend/src/app/services/api-contract.ts
+++ b/frontend/src/app/services/api-contract.ts
@@ -66,6 +66,9 @@ export const ApiContract = {
     sendMessage: (threadId: string): string => `${API}/messages/threads/${threadId}/messages`,
     markRead: (threadId: string): string => `${API}/messages/threads/${threadId}/read`
   },
+  contextualComments: {
+    byContext: (contextType: string, contextId: string): string => `${API}/comments/${contextType}/${contextId}`
+  },
   admin: {
     auditLog: `${API}/admin/audit-log`,
     userLifecycleUsers: `${API}/admin/user-lifecycle/users`,

--- a/frontend/src/app/services/contextual-comments.service.ts
+++ b/frontend/src/app/services/contextual-comments.service.ts
@@ -1,0 +1,40 @@
+import { Injectable } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { Observable } from 'rxjs';
+import { ApiContract } from './api-contract';
+
+export type ContextType = 'record' | 'document' | 'knowledge_doc';
+export type CommentVisibility = 'internal' | 'care_team' | 'patient_visible';
+
+export interface ContextualCommentRow {
+  id: string;
+  context_type: ContextType;
+  context_id: string;
+  author_user_id: string;
+  body: string;
+  visibility: CommentVisibility;
+  created_at: string;
+}
+
+@Injectable({ providedIn: 'root' })
+export class ContextualCommentsService {
+  constructor(private http: HttpClient) {}
+
+  list(contextType: ContextType, contextId: string): Observable<{ comments: ContextualCommentRow[] }> {
+    return this.http.get<{ comments: ContextualCommentRow[] }>(
+      ApiContract.contextualComments.byContext(contextType, encodeURIComponent(contextId))
+    );
+  }
+
+  create(
+    contextType: ContextType,
+    contextId: string,
+    payload: { body: string; visibility: CommentVisibility }
+  ): Observable<{ id: string; visibility: CommentVisibility }> {
+    return this.http.post<{ id: string; visibility: CommentVisibility }>(
+      ApiContract.contextualComments.byContext(contextType, encodeURIComponent(contextId)),
+      payload
+    );
+  }
+}
+


### PR DESCRIPTION
## Summary
- add a reusable contextual comments panel component wired to PR-10 generic comments APIs
- integrate comments pack into document detail, knowledge-base detail, and prescription record views
- add focused panel tests and validate impacted feature specs

## Test plan
- [x] Run `npm run test:ci -- --include src/app/components/contextual-comments-panel/contextual-comments-panel.component.spec.ts --include src/app/components/patient-prescriptions/patient-prescriptions.component.spec.ts --include src/app/components/doctor-document-detail/doctor-document-detail.component.spec.ts --include src/app/components/admin-knowledge/admin-knowledge.component.spec.ts`
- [ ] Manual role-based visibility check across patient/doctor/admin