### PR TITLE
fix(ci): openapi sync for PR-09 to PR-12 routes

### DIFF
--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -253,6 +253,82 @@ paths:
         "403":
           $ref: "#/components/responses/Forbidden"
 
+  /api/admin/user-lifecycle/users:
+    get:
+      tags: [Admin]
+      summary: List users for admin lifecycle management
+      security:
+        - bearerAuth: []
+      responses:
+        "200":
+          description: User list
+        "403":
+          $ref: "#/components/responses/Forbidden"
+    post:
+      tags: [Admin]
+      summary: Create user from admin lifecycle console
+      security:
+        - bearerAuth: []
+      responses:
+        "201":
+          description: User created
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+
+  /api/admin/user-lifecycle/users/{id}:
+    put:
+      tags: [Admin]
+      summary: Update user email/role from admin lifecycle console
+      security:
+        - bearerAuth: []
+      parameters:
+        - $ref: "#/components/parameters/IdPath"
+      responses:
+        "200":
+          description: User updated
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
+
+  /api/admin/user-lifecycle/users/{id}/deactivate:
+    patch:
+      tags: [Admin]
+      summary: Deactivate user account
+      security:
+        - bearerAuth: []
+      parameters:
+        - $ref: "#/components/parameters/IdPath"
+      responses:
+        "200":
+          description: User deactivated
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
+
+  /api/admin/user-lifecycle/users/{id}/reset-password:
+    post:
+      tags: [Admin]
+      summary: Reset user password
+      security:
+        - bearerAuth: []
+      parameters:
+        - $ref: "#/components/parameters/IdPath"
+      responses:
+        "200":
+          description: Password reset completed
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
+
   /api/admin/ai/observability:
     get:
       tags: [Admin]
@@ -626,6 +702,56 @@ paths:
       responses:
         "201":
           description: Comment created
+
+  /api/comments/{contextType}/{contextId}:
+    get:
+      tags: [Appointments]
+      summary: List contextual comments by context type and context id
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: contextType
+          in: path
+          required: true
+          schema:
+            type: string
+            enum: [record, document, knowledge_doc]
+        - name: contextId
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+      responses:
+        "200":
+          description: Context comments list
+        "403":
+          $ref: "#/components/responses/Forbidden"
+    post:
+      tags: [Appointments]
+      summary: Create contextual comment by context type and context id
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: contextType
+          in: path
+          required: true
+          schema:
+            type: string
+            enum: [record, document, knowledge_doc]
+        - name: contextId
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+      responses:
+        "201":
+          description: Context comment created
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "403":
+          $ref: "#/components/responses/Forbidden"
 
   /api/doctors:
     get:


### PR DESCRIPTION
## Summary
- fix backend CI failures for PR-09 to PR-12 by syncing missing routes in `docs/openapi.yaml`
- add admin user lifecycle management endpoints (list/create/update/deactivate/reset-password)
- add contextual comments endpoints for context-type/id comments APIs

## Validation
- [x] `go test ./...` (backend)
- [x] `go run ./cmd/openapi-sync-check` (backend)
- [x] `npm run test:ci` (frontend full unit suite)
- [x] `npm run cypress:e2e` (full e2e)