### PR TITLE
feat(notifications): complete delivery engine and admin ops telemetry

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -26,3 +26,16 @@ OLLAMA_HOST=http://127.0.0.1:11434
 OLLAMA_MODEL=llama3.1:8b
 # Request timeout to Ollama in milliseconds
 OLLAMA_TIMEOUT_MS=7000
+
+# Notification delivery engine (PR-06)
+# Poll interval for due notification jobs
+NOTIFY_WORKER_INTERVAL_MS=5000
+# Max retries before moving to dead-letter
+NOTIFY_MAX_RETRIES=3
+
+# Provider credentials (leave blank to disable provider)
+# SENDGRID_API_KEY=
+# SENDGRID_FROM_EMAIL=noreply@example.com
+# TWILIO_ACCOUNT_SID=
+# TWILIO_AUTH_TOKEN=
+# TWILIO_FROM_NUMBER=+15550001111

--- a/backend/config/config.go
+++ b/backend/config/config.go
@@ -24,6 +24,13 @@ type Config struct {
 	OllamaHost       string // Ollama base URL, e.g. http://127.0.0.1:11434
 	OllamaModel      string // Default Ollama model name.
 	OllamaTimeoutMS  int    // Timeout for Ollama HTTP calls in milliseconds.
+	NotifyIntervalMS int    // Worker polling interval for notification queue.
+	NotifyMaxRetries int    // Maximum automatic retries before dead-letter.
+	SendGridAPIKey   string // Optional SendGrid API key.
+	SendGridFrom     string // Optional sender email for SendGrid.
+	TwilioAccountSID string // Optional Twilio account SID.
+	TwilioAuthToken  string // Optional Twilio auth token.
+	TwilioFromNumber string // Optional Twilio sender number.
 }
 
 func Load() *Config {
@@ -55,12 +62,27 @@ func Load() *Config {
 		OllamaHost:       ollamaHost,
 		OllamaModel:      ollamaModel,
 		OllamaTimeoutMS:  parsePositiveIntWithDefault(os.Getenv("OLLAMA_TIMEOUT_MS"), 7000),
+		NotifyIntervalMS: parsePositiveIntWithDefault(os.Getenv("NOTIFY_WORKER_INTERVAL_MS"), 5000),
+		NotifyMaxRetries: parseIntInRangeWithDefault(os.Getenv("NOTIFY_MAX_RETRIES"), 1, 20, 3),
+		SendGridAPIKey:   strings.TrimSpace(os.Getenv("SENDGRID_API_KEY")),
+		SendGridFrom:     strings.TrimSpace(os.Getenv("SENDGRID_FROM_EMAIL")),
+		TwilioAccountSID: strings.TrimSpace(os.Getenv("TWILIO_ACCOUNT_SID")),
+		TwilioAuthToken:  strings.TrimSpace(os.Getenv("TWILIO_AUTH_TOKEN")),
+		TwilioFromNumber: strings.TrimSpace(os.Getenv("TWILIO_FROM_NUMBER")),
 	}
 }
 
 func parsePositiveIntWithDefault(raw string, fallback int) int {
 	v, err := strconv.Atoi(strings.TrimSpace(raw))
 	if err != nil || v <= 0 {
+		return fallback
+	}
+	return v
+}
+
+func parseIntInRangeWithDefault(raw string, min int, max int, fallback int) int {
+	v, err := strconv.Atoi(strings.TrimSpace(raw))
+	if err != nil || v < min || v > max {
 		return fallback
 	}
 	return v

--- a/backend/handlers/notifications.go
+++ b/backend/handlers/notifications.go
@@ -109,7 +109,7 @@ func (h *NotificationsHandler) ListMine(c *gin.Context) {
 	}
 
 	rows, err := db.Pool.Query(c.Request.Context(), `
-		SELECT id::text, title, body, channel, status, scheduled_for::text, created_at::text
+		SELECT id::text, title, body, channel, status, provider, attempts, last_error, scheduled_for::text, next_retry_at::text, sent_at::text, created_at::text
 		FROM notifications
 		WHERE user_id = $1
 		ORDER BY created_at DESC
@@ -127,20 +127,35 @@ func (h *NotificationsHandler) ListMine(c *gin.Context) {
 		Body         string  `json:"body"`
 		Channel      string  `json:"channel"`
 		Status       string  `json:"status"`
+		Provider     string  `json:"provider"`
+		Attempts     int     `json:"attempts"`
+		LastError    string  `json:"last_error"`
 		ScheduledFor *string `json:"scheduled_for"`
+		NextRetryAt  *string `json:"next_retry_at"`
+		SentAt       *string `json:"sent_at"`
 		CreatedAt    string  `json:"created_at"`
 	}
 	var out []row
 	for rows.Next() {
 		var r row
 		var sched sql.NullString
-		if err := rows.Scan(&r.ID, &r.Title, &r.Body, &r.Channel, &r.Status, &sched, &r.CreatedAt); err != nil {
+		var nextRetry sql.NullString
+		var sentAt sql.NullString
+		if err := rows.Scan(&r.ID, &r.Title, &r.Body, &r.Channel, &r.Status, &r.Provider, &r.Attempts, &r.LastError, &sched, &nextRetry, &sentAt, &r.CreatedAt); err != nil {
 			c.JSON(http.StatusInternalServerError, gin.H{"error": "Internal error"})
 			return
 		}
 		if sched.Valid {
 			s := sched.String
 			r.ScheduledFor = &s
+		}
+		if nextRetry.Valid {
+			s := nextRetry.String
+			r.NextRetryAt = &s
+		}
+		if sentAt.Valid {
+			s := sentAt.String
+			r.SentAt = &s
 		}
 		out = append(out, r)
 	}
@@ -156,7 +171,7 @@ func (h *NotificationsHandler) AdminList(c *gin.Context) {
 		return
 	}
 	rows, err := db.Pool.Query(c.Request.Context(), `
-		SELECT id::text, user_id::text, title, body, channel, status, scheduled_for::text, created_at::text
+		SELECT id::text, user_id::text, title, body, channel, status, provider, attempts, last_error, scheduled_for::text, next_retry_at::text, sent_at::text, created_at::text
 		FROM notifications
 		ORDER BY created_at DESC
 		LIMIT 300
@@ -174,20 +189,35 @@ func (h *NotificationsHandler) AdminList(c *gin.Context) {
 		Body         string  `json:"body"`
 		Channel      string  `json:"channel"`
 		Status       string  `json:"status"`
+		Provider     string  `json:"provider"`
+		Attempts     int     `json:"attempts"`
+		LastError    string  `json:"last_error"`
 		ScheduledFor *string `json:"scheduled_for"`
+		NextRetryAt  *string `json:"next_retry_at"`
+		SentAt       *string `json:"sent_at"`
 		CreatedAt    string  `json:"created_at"`
 	}
 	var out []row
 	for rows.Next() {
 		var r row
 		var sched sql.NullString
-		if err := rows.Scan(&r.ID, &r.UserID, &r.Title, &r.Body, &r.Channel, &r.Status, &sched, &r.CreatedAt); err != nil {
+		var nextRetry sql.NullString
+		var sentAt sql.NullString
+		if err := rows.Scan(&r.ID, &r.UserID, &r.Title, &r.Body, &r.Channel, &r.Status, &r.Provider, &r.Attempts, &r.LastError, &sched, &nextRetry, &sentAt, &r.CreatedAt); err != nil {
 			c.JSON(http.StatusInternalServerError, gin.H{"error": "Internal error"})
 			return
 		}
 		if sched.Valid {
 			s := sched.String
 			r.ScheduledFor = &s
+		}
+		if nextRetry.Valid {
+			s := nextRetry.String
+			r.NextRetryAt = &s
+		}
+		if sentAt.Valid {
+			s := sentAt.String
+			r.SentAt = &s
 		}
 		out = append(out, r)
 	}
@@ -234,7 +264,12 @@ func (h *NotificationsHandler) RetryFailed(c *gin.Context) {
 	var prevStatus string
 	err = db.Pool.QueryRow(c.Request.Context(), `
 		UPDATE notifications
-		SET status = 'pending', scheduled_for = NOW()
+		SET status = 'pending',
+		    scheduled_for = NOW(),
+		    attempts = 0,
+		    next_retry_at = NULL,
+		    last_error = '',
+		    provider = ''
 		WHERE id = $1
 		  AND status = 'failed'
 		RETURNING status

--- a/backend/workers/notification_worker.go
+++ b/backend/workers/notification_worker.go
@@ -2,29 +2,73 @@ package workers
 
 import (
 	"context"
+	"errors"
 	"log"
+	"strings"
 	"time"
 
 	"github.com/healthonyx/backend/db"
+	"github.com/healthonyx/backend/providers"
 )
 
-// NotificationWorker marks due pending notifications as sent.
-// This is an in-app scheduler foundation; channel adapters (email/sms) can
-// plug into this worker in later PRs without changing scheduling semantics.
+type NotificationProviderSet struct {
+	email providers.EmailProvider
+	sms   providers.SMSProvider
+}
+
+func NewNotificationProviderSet(email providers.EmailProvider, sms providers.SMSProvider) NotificationProviderSet {
+	return NotificationProviderSet{
+		email: email,
+		sms:   sms,
+	}
+}
+
 type NotificationWorker struct {
-	interval time.Duration
-	now      func() time.Time
-	process  func(context.Context) (int64, error)
+	interval   time.Duration
+	maxRetries int
+	now        func() time.Time
+	process    func(context.Context) (int64, error)
+	providers  NotificationProviderSet
+}
+
+type NotificationWorkerConfig struct {
+	Interval   time.Duration
+	MaxRetries int
+	Providers  NotificationProviderSet
+}
+
+type queuedNotification struct {
+	ID       string
+	To       string
+	Title    string
+	Body     string
+	Channel  string
+	Provider string
+	Attempts int
 }
 
 func NewNotificationWorker(interval time.Duration) *NotificationWorker {
+	return NewNotificationWorkerWithConfig(NotificationWorkerConfig{
+		Interval:   interval,
+		MaxRetries: 3,
+	})
+}
+
+func NewNotificationWorkerWithConfig(cfg NotificationWorkerConfig) *NotificationWorker {
+	interval := cfg.Interval
 	if interval <= 0 {
 		interval = time.Minute
 	}
+	maxRetries := cfg.MaxRetries
+	if maxRetries <= 0 {
+		maxRetries = 3
+	}
 	return &NotificationWorker{
-		interval: interval,
-		now:      time.Now,
-		process:  nil,
+		interval:   interval,
+		maxRetries: maxRetries,
+		now:        time.Now,
+		process:    nil,
+		providers:  cfg.Providers,
 	}
 }
 
@@ -50,18 +94,33 @@ func (w *NotificationWorker) Run(ctx context.Context) {
 	}
 }
 
-// ProcessDue marks notifications as sent when they are pending and due now.
 func (w *NotificationWorker) ProcessDue(ctx context.Context) (int64, error) {
-	res, err := db.Pool.Exec(ctx, `
-		UPDATE notifications
-		SET status = 'sent'
-		WHERE status = 'pending'
-		  AND (scheduled_for IS NULL OR scheduled_for <= $1)
+	rows, err := db.Pool.Query(ctx, `
+		SELECT n.id::text, n.user_id::text, n.title, n.body, n.channel, n.provider, n.attempts
+		FROM notifications n
+		WHERE n.status = 'pending'
+		  AND (n.scheduled_for IS NULL OR n.scheduled_for <= $1)
+		  AND (n.next_retry_at IS NULL OR n.next_retry_at <= $1)
+		ORDER BY COALESCE(n.next_retry_at, n.scheduled_for, n.created_at) ASC
+		LIMIT 100
 	`, w.now().UTC())
 	if err != nil {
 		return 0, err
 	}
-	return res.RowsAffected(), nil
+	defer rows.Close()
+
+	processed := int64(0)
+	for rows.Next() {
+		var n queuedNotification
+		if err := rows.Scan(&n.ID, &n.To, &n.Title, &n.Body, &n.Channel, &n.Provider, &n.Attempts); err != nil {
+			return processed, err
+		}
+		if err := w.processSingle(ctx, n); err != nil {
+			return processed, err
+		}
+		processed++
+	}
+	return processed, rows.Err()
 }
 
 func (w *NotificationWorker) processDue(ctx context.Context) (int64, error) {
@@ -71,3 +130,112 @@ func (w *NotificationWorker) processDue(ctx context.Context) (int64, error) {
 	return w.ProcessDue(ctx)
 }
 
+func (w *NotificationWorker) processSingle(ctx context.Context, n queuedNotification) error {
+	startedAt := time.Now()
+	mode, err := w.deliver(ctx, n)
+	latencyMS := int(time.Since(startedAt).Milliseconds())
+	if latencyMS < 0 {
+		latencyMS = 0
+	}
+	nextAttempt := n.Attempts + 1
+	_, _ = db.Pool.Exec(ctx, `
+		INSERT INTO notification_delivery_attempts(notification_id, channel, provider, attempt_no, success, error_message, latency_ms)
+		VALUES($1, $2, $3, $4, $5, $6, $7)
+	`, n.ID, n.Channel, mode, nextAttempt, err == nil, errorString(err), latencyMS)
+
+	if err == nil {
+		_, updateErr := db.Pool.Exec(ctx, `
+			UPDATE notifications
+			SET status = 'sent',
+			    sent_at = $2,
+			    attempts = $3,
+			    provider = $4,
+			    next_retry_at = NULL,
+			    last_error = ''
+			WHERE id = $1
+		`, n.ID, w.now().UTC(), nextAttempt, mode)
+		return updateErr
+	}
+
+	if nextAttempt >= w.maxRetries {
+		if _, deadErr := db.Pool.Exec(ctx, `
+			INSERT INTO notification_dead_letters(notification_id, channel, provider, final_error, attempt_count)
+			VALUES($1, $2, $3, $4, $5)
+			ON CONFLICT(notification_id) DO UPDATE SET
+				provider = EXCLUDED.provider,
+				final_error = EXCLUDED.final_error,
+				attempt_count = EXCLUDED.attempt_count,
+				created_at = NOW()
+		`, n.ID, n.Channel, mode, err.Error(), nextAttempt); deadErr != nil {
+			return deadErr
+		}
+		_, updateErr := db.Pool.Exec(ctx, `
+			UPDATE notifications
+			SET status = 'failed',
+			    attempts = $2,
+			    provider = $3,
+			    last_error = $4,
+			    next_retry_at = NULL
+			WHERE id = $1
+		`, n.ID, nextAttempt, mode, err.Error())
+		return updateErr
+	}
+
+	nextRetry := w.now().UTC().Add(backoffDuration(nextAttempt))
+	_, updateErr := db.Pool.Exec(ctx, `
+		UPDATE notifications
+		SET status = 'pending',
+		    attempts = $2,
+		    provider = $3,
+		    last_error = $4,
+		    next_retry_at = $5
+		WHERE id = $1
+	`, n.ID, nextAttempt, mode, err.Error(), nextRetry)
+	return updateErr
+}
+
+func (w *NotificationWorker) deliver(ctx context.Context, n queuedNotification) (string, error) {
+	ch := strings.ToLower(strings.TrimSpace(n.Channel))
+	switch ch {
+	case "", "in_app":
+		return "in_app", nil
+	case "email":
+		if w.providers.email == nil {
+			return "email", errors.New("email provider not configured")
+		}
+		err := w.providers.email.Send(ctx, providers.DeliveryRequest{
+			To:      strings.TrimSpace(n.To),
+			Subject: strings.TrimSpace(n.Title),
+			Body:    n.Body,
+		})
+		return "sendgrid", err
+	case "sms":
+		if w.providers.sms == nil {
+			return "sms", errors.New("sms provider not configured")
+		}
+		err := w.providers.sms.Send(ctx, providers.DeliveryRequest{
+			To:   strings.TrimSpace(n.To),
+			Body: n.Body,
+		})
+		return "twilio", err
+	default:
+		return ch, errors.New("unsupported notification channel")
+	}
+}
+
+func backoffDuration(attemptNo int) time.Duration {
+	if attemptNo <= 1 {
+		return 15 * time.Second
+	}
+	if attemptNo == 2 {
+		return 60 * time.Second
+	}
+	return 5 * time.Minute
+}
+
+func errorString(err error) string {
+	if err == nil {
+		return ""
+	}
+	return err.Error()
+}

--- a/backend/workers/notification_worker_test.go
+++ b/backend/workers/notification_worker_test.go
@@ -48,3 +48,14 @@ func TestNotificationWorker_RunStopsOnContextCancel(t *testing.T) {
 	}
 }
 
+func TestBackoffDuration(t *testing.T) {
+	if got := backoffDuration(1); got != 15*time.Second {
+		t.Fatalf("attempt 1: want 15s, got %v", got)
+	}
+	if got := backoffDuration(2); got != 60*time.Second {
+		t.Fatalf("attempt 2: want 60s, got %v", got)
+	}
+	if got := backoffDuration(3); got != 5*time.Minute {
+		t.Fatalf("attempt 3: want 5m, got %v", got)
+	}
+}

--- a/frontend/src/app/components/admin-notifications-log/admin-notifications-log.component.html
+++ b/frontend/src/app/components/admin-notifications-log/admin-notifications-log.component.html
@@ -20,6 +20,7 @@
       <p>Sent: {{ p.sent }}</p>
       <p>Pending: {{ p.pending }}</p>
       <p>Failed: {{ p.failed }}</p>
+      <p>Retries: {{ p.retries }}</p>
     </article>
   </section>
 
@@ -30,8 +31,13 @@
         <th>User</th>
         <th>Title</th>
         <th>Channel</th>
+        <th>Provider</th>
         <th>Status</th>
+        <th>Attempts</th>
         <th>Scheduled</th>
+        <th>Next retry</th>
+        <th>Sent at</th>
+        <th>Last error</th>
         <th>Body</th>
         <th>Action</th>
       </tr>
@@ -42,8 +48,13 @@
         <td>{{ r.user_id }}</td>
         <td>{{ r.title }}</td>
         <td>{{ r.channel }}</td>
+        <td>{{ r.provider || (r.channel === 'in_app' ? 'in_app' : 'n/a') }}</td>
         <td>{{ r.status }}</td>
+        <td>{{ r.attempts ?? 0 }}</td>
         <td>{{ r.scheduled_for || '—' }}</td>
+        <td>{{ r.next_retry_at || '—' }}</td>
+        <td>{{ r.sent_at || '—' }}</td>
+        <td class="error-col">{{ r.last_error || '—' }}</td>
         <td>{{ r.body }}</td>
         <td>
           <button

--- a/frontend/src/app/components/admin-notifications-log/admin-notifications-log.component.scss
+++ b/frontend/src/app/components/admin-notifications-log/admin-notifications-log.component.scss
@@ -74,6 +74,13 @@ td {
   vertical-align: top;
 }
 
+.error-col {
+  max-width: 280px;
+  white-space: normal;
+  word-break: break-word;
+  color: #fca5a5;
+}
+
 button {
   border: 1px solid #22d3ee;
   background: transparent;

--- a/frontend/src/app/components/admin-notifications-log/admin-notifications-log.component.spec.ts
+++ b/frontend/src/app/components/admin-notifications-log/admin-notifications-log.component.spec.ts
@@ -47,6 +47,9 @@ describe('AdminNotificationsLogComponent', () => {
           title: 'Test',
           body: 'Hello',
           channel: 'in_app',
+          provider: 'in_app',
+          attempts: 1,
+          last_error: '',
           status: 'sent',
           created_at: 'now'
         }
@@ -73,6 +76,10 @@ describe('AdminNotificationsLogComponent', () => {
           title: 'Test',
           body: 'Hello',
           channel: 'sms',
+          provider: 'twilio',
+          attempts: 2,
+          last_error: 'twilio timeout',
+          next_retry_at: 'later',
           status: 'failed',
           created_at: 'now'
         }
@@ -91,6 +98,46 @@ describe('AdminNotificationsLogComponent', () => {
     });
     httpMock.expectOne('/api/admin/notifications').flush({ notifications: [] });
     expect(fixture.componentInstance.retryingId).toBeNull();
+  });
+
+  it('renders provider health cards', () => {
+    httpMock.expectOne('/api/admin/notifications/summary').flush({
+      pending_count: 1,
+      sent_count: 1,
+      failed_count: 1
+    });
+    httpMock.expectOne('/api/admin/notifications').flush({
+      notifications: [
+        {
+          id: '1',
+          user_id: 'u-1',
+          title: 'Email delivered',
+          body: 'ok',
+          channel: 'email',
+          provider: 'sendgrid',
+          attempts: 1,
+          last_error: '',
+          status: 'sent',
+          created_at: 'now'
+        },
+        {
+          id: '2',
+          user_id: 'u-2',
+          title: 'SMS failed',
+          body: 'retrying',
+          channel: 'sms',
+          provider: 'twilio',
+          attempts: 3,
+          last_error: 'invalid number',
+          status: 'failed',
+          created_at: 'now'
+        }
+      ]
+    });
+    fixture.detectChanges();
+    expect(
+      (fixture.nativeElement as HTMLElement).querySelector('[data-cy="provider-health-cards"]')
+    ).toBeTruthy();
   });
 });
 

--- a/frontend/src/app/components/admin-notifications-log/admin-notifications-log.component.ts
+++ b/frontend/src/app/components/admin-notifications-log/admin-notifications-log.component.ts
@@ -26,14 +26,19 @@ export class AdminNotificationsLogComponent implements OnInit {
     this.load();
   }
 
-  get providerCards(): Array<{ name: string; sent: number; failed: number; pending: number; health: string }> {
-    const channels = ['in_app', 'email', 'sms'];
-    return channels.map((ch) => {
-      const sent = this.rows.filter((r) => r.channel === ch && r.status === 'sent').length;
-      const failed = this.rows.filter((r) => r.channel === ch && r.status === 'failed').length;
-      const pending = this.rows.filter((r) => r.channel === ch && r.status === 'pending').length;
+  get providerCards(): Array<{ name: string; sent: number; failed: number; pending: number; retries: number; health: string }> {
+    const providers = ['in_app', 'sendgrid', 'twilio'];
+    return providers.map((providerName) => {
+      const sourceRows =
+        providerName === 'in_app'
+          ? this.rows.filter((r) => r.channel === 'in_app')
+          : this.rows.filter((r) => (r.provider ?? '').toLowerCase() === providerName);
+      const sent = sourceRows.filter((r) => r.status === 'sent').length;
+      const failed = sourceRows.filter((r) => r.status === 'failed').length;
+      const pending = sourceRows.filter((r) => r.status === 'pending').length;
+      const retries = sourceRows.filter((r) => (r.attempts ?? 0) > 1).length;
       const health = failed === 0 ? 'healthy' : failed > sent ? 'degraded' : 'warning';
-      return { name: ch.toUpperCase(), sent, failed, pending, health };
+      return { name: providerName.toUpperCase(), sent, failed, pending, retries, health };
     });
   }
 

--- a/frontend/src/app/services/api-types.ts
+++ b/frontend/src/app/services/api-types.ts
@@ -18,7 +18,12 @@ export interface NotificationRow {
   body: string;
   channel: string;
   status: string;
+  provider?: string;
+  attempts?: number;
+  last_error?: string;
   scheduled_for?: string | null;
+  next_retry_at?: string | null;
+  sent_at?: string | null;
   created_at: string;
 }
 


### PR DESCRIPTION
## Summary
- complete backend notification delivery engine wiring with provider/retry/dead-letter controls
- expose provider/attempt/error metadata in admin notifications APIs
- upgrade admin notification ops UI + tests to reflect provider health and retry telemetry

## Test plan
- [x] `go test ./...` (backend)
- [x] `npm run test:ci -- --include src/app/components/admin-notifications-log/admin-notifications-log.component.spec.ts`