### PR TITLE
CG-01: enforce websocket origin allowlist and token/session hardening

### DIFF
--- a/backend/handlers/auth.go
+++ b/backend/handlers/auth.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"net/http"
 	"strings"
+	"time"
 	"unicode/utf8"
 
 	"github.com/gin-gonic/gin"
@@ -162,23 +163,32 @@ func (h *AuthHandler) Me(c *gin.Context) {
 }
 
 func (h *AuthHandler) createToken(id uuid.UUID, email, role string) (string, error) {
+	now := time.Now().UTC()
 	claims := Claims{
 		UserID: id,
 		Email:  email,
 		Role:   role,
+		RegisteredClaims: jwt.RegisteredClaims{
+			IssuedAt:  jwt.NewNumericDate(now),
+			NotBefore: jwt.NewNumericDate(now.Add(-1 * time.Minute)),
+			ExpiresAt: jwt.NewNumericDate(now.Add(12 * time.Hour)),
+		},
 	}
 	token := jwt.NewWithClaims(jwt.SigningMethodHS256, claims)
 	return token.SignedString(h.JWTSecret)
 }
 
-// ParseJWTClaims validates a raw JWT string (used by WebSocket token auth).
-func (h *AuthHandler) ParseJWTClaims(rawToken string) (*Claims, error) {
+func (h *AuthHandler) parseClaims(rawToken string) (*Claims, error) {
 	token, err := jwt.ParseWithClaims(rawToken, &Claims{}, func(t *jwt.Token) (interface{}, error) {
 		if _, ok := t.Method.(*jwt.SigningMethodHMAC); !ok {
 			return nil, errors.New("unexpected signing method")
 		}
 		return h.JWTSecret, nil
-	})
+	},
+		jwt.WithValidMethods([]string{jwt.SigningMethodHS256.Alg()}),
+		jwt.WithExpirationRequired(),
+		jwt.WithIssuedAt(),
+	)
 	if err != nil {
 		return nil, err
 	}
@@ -187,6 +197,15 @@ func (h *AuthHandler) ParseJWTClaims(rawToken string) (*Claims, error) {
 		return nil, errors.New("invalid claims")
 	}
 	return claims, nil
+}
+
+// ParseJWTClaims validates a raw JWT string (used by WebSocket token auth).
+func (h *AuthHandler) ParseJWTClaims(rawToken string) (*Claims, error) {
+	rawToken = strings.TrimSpace(rawToken)
+	if rawToken == "" {
+		return nil, errors.New("token required")
+	}
+	return h.parseClaims(rawToken)
 }
 
 func (h *AuthHandler) RequireAuth() gin.HandlerFunc {
@@ -203,19 +222,8 @@ func (h *AuthHandler) RequireAuth() gin.HandlerFunc {
 			c.Abort()
 			return
 		}
-		token, err := jwt.ParseWithClaims(parts[1], &Claims{}, func(t *jwt.Token) (interface{}, error) {
-			if _, ok := t.Method.(*jwt.SigningMethodHMAC); !ok {
-				return nil, errors.New("unexpected signing method")
-			}
-			return h.JWTSecret, nil
-		})
+		claims, err := h.parseClaims(parts[1])
 		if err != nil {
-			c.JSON(http.StatusUnauthorized, gin.H{"error": "Invalid token"})
-			c.Abort()
-			return
-		}
-		claims, ok := token.Claims.(*Claims)
-		if !ok || !token.Valid {
 			c.JSON(http.StatusUnauthorized, gin.H{"error": "Invalid token"})
 			c.Abort()
 			return

--- a/backend/handlers/auth_integration_test.go
+++ b/backend/handlers/auth_integration_test.go
@@ -1,11 +1,14 @@
 package handlers
 
 import (
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 
 	"github.com/gin-gonic/gin"
+	"github.com/golang-jwt/jwt/v5"
 	"github.com/google/uuid"
 )
 
@@ -124,5 +127,39 @@ func TestRequireAuthRole_MultiRole_AllowsEither(t *testing.T) {
 	r.ServeHTTP(patientW, patientReq)
 	if patientW.Code != http.StatusForbidden {
 		t.Fatalf("expected patient forbidden (403), got %d", patientW.Code)
+	}
+}
+
+func TestParseJWTClaims_ExpiredTokenRejected(t *testing.T) {
+	auth := NewAuthHandler("test-secret-key-for-jwt-parse-tests-xx")
+	past := time.Now().UTC().Add(-1 * time.Hour)
+	expiredClaims := Claims{
+		UserID: uuid.New(),
+		Email:  "expired@test.local",
+		Role:   "doctor",
+		RegisteredClaims: jwt.RegisteredClaims{
+			IssuedAt:  jwt.NewNumericDate(past.Add(-1 * time.Hour)),
+			NotBefore: jwt.NewNumericDate(past.Add(-1 * time.Hour)),
+			ExpiresAt: jwt.NewNumericDate(past),
+		},
+	}
+	token, err := jwt.NewWithClaims(jwt.SigningMethodHS256, expiredClaims).SignedString(auth.JWTSecret)
+	if err != nil {
+		t.Fatalf("sign expired token: %v", err)
+	}
+	_, err = auth.ParseJWTClaims(token)
+	if err == nil {
+		t.Fatal("expected expired token error")
+	}
+	if !errors.Is(err, jwt.ErrTokenExpired) {
+		t.Fatalf("expected ErrTokenExpired, got %v", err)
+	}
+}
+
+func TestParseJWTClaims_EmptyTokenRejected(t *testing.T) {
+	auth := NewAuthHandler("test-secret-key-for-jwt-parse-tests-xx")
+	_, err := auth.ParseJWTClaims("   ")
+	if err == nil {
+		t.Fatal("expected empty token error")
 	}
 }

--- a/backend/handlers/messaging_ws.go
+++ b/backend/handlers/messaging_ws.go
@@ -1,7 +1,10 @@
 package handlers
 
 import (
+	"net"
 	"net/http"
+	"net/url"
+	"os"
 	"strings"
 	"time"
 
@@ -21,8 +24,48 @@ var wsUpgrader = websocket.Upgrader{
 	ReadBufferSize:  1024,
 	WriteBufferSize: 1024,
 	CheckOrigin: func(r *http.Request) bool {
-		return true // browsers send Origin; tighten alongside API CORS in production
+		return isAllowedWSOrigin(r.Header.Get("Origin"))
 	},
+}
+
+func normalizeOrigin(raw string) (string, bool) {
+	s := strings.TrimSpace(raw)
+	if s == "" {
+		return "", false
+	}
+	u, err := url.Parse(s)
+	if err != nil || u.Scheme == "" || u.Host == "" {
+		return "", false
+	}
+	host := strings.ToLower(u.Hostname())
+	port := u.Port()
+	if port == "" {
+		if strings.EqualFold(u.Scheme, "https") {
+			port = "443"
+		} else if strings.EqualFold(u.Scheme, "http") {
+			port = "80"
+		}
+	}
+	return strings.ToLower(u.Scheme) + "://" + net.JoinHostPort(host, port), true
+}
+
+func isAllowedWSOrigin(origin string) bool {
+	allowedRaw := strings.TrimSpace(os.Getenv("WS_ALLOWED_ORIGINS"))
+	if allowedRaw == "" {
+		// Keep localhost/dev defaults when no explicit policy is configured.
+		allowedRaw = "http://127.0.0.1:4300,http://localhost:4300"
+	}
+	normalizedOrigin, ok := normalizeOrigin(origin)
+	if !ok {
+		return false
+	}
+	for _, item := range strings.Split(allowedRaw, ",") {
+		candidate, ok := normalizeOrigin(item)
+		if ok && candidate == normalizedOrigin {
+			return true
+		}
+	}
+	return false
 }
 
 func (c *wsClient) readPump() {
@@ -71,6 +114,10 @@ func (mh *MessagingHandler) ServeWebSocket(auth *AuthHandler) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		if mh.hub == nil {
 			c.JSON(http.StatusServiceUnavailable, gin.H{"error": "Realtime messaging unavailable"})
+			return
+		}
+		if !isAllowedWSOrigin(c.GetHeader("Origin")) {
+			c.JSON(http.StatusForbidden, gin.H{"error": "Origin not allowed"})
 			return
 		}
 		token := strings.TrimSpace(c.Query("token"))

--- a/backend/handlers/messaging_ws_test.go
+++ b/backend/handlers/messaging_ws_test.go
@@ -3,6 +3,7 @@ package handlers
 import (
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"testing"
 
 	"github.com/gin-gonic/gin"
@@ -18,6 +19,7 @@ func TestServeWebSocket_MissingToken(t *testing.T) {
 	w := httptest.NewRecorder()
 	c, _ := gin.CreateTestContext(w)
 	c.Request = httptest.NewRequest(http.MethodGet, "/api/messages/ws", nil)
+	c.Request.Header.Set("Origin", "http://localhost:4300")
 	h(c)
 	if w.Code != http.StatusUnauthorized {
 		t.Fatalf("expected 401, got %d body=%s", w.Code, w.Body.String())
@@ -32,6 +34,7 @@ func TestServeWebSocket_HubNil(t *testing.T) {
 	w := httptest.NewRecorder()
 	c, _ := gin.CreateTestContext(w)
 	c.Request = httptest.NewRequest(http.MethodGet, "/api/messages/ws?token=x", nil)
+	c.Request.Header.Set("Origin", "http://localhost:4300")
 	h(c)
 	if w.Code != http.StatusServiceUnavailable {
 		t.Fatalf("expected 503, got %d", w.Code)
@@ -51,6 +54,34 @@ func TestServeWebSocket_AdminForbidden(t *testing.T) {
 	w := httptest.NewRecorder()
 	c, _ := gin.CreateTestContext(w)
 	c.Request = httptest.NewRequest(http.MethodGet, "/api/messages/ws?token="+tok, nil)
+	c.Request.Header.Set("Origin", "http://localhost:4300")
+	h(c)
+	if w.Code != http.StatusForbidden {
+		t.Fatalf("expected 403, got %d body=%s", w.Code, w.Body.String())
+	}
+}
+
+func TestServeWebSocket_RejectsDisallowedOrigin(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	auth := NewAuthHandler("test-secret-key-for-jwt-parse-tests-xx")
+	tok, err := auth.createToken(uuid.New(), "doctor@test.local", "doctor")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Setenv("WS_ALLOWED_ORIGINS", "https://trusted.example"); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		_ = os.Unsetenv("WS_ALLOWED_ORIGINS")
+	})
+
+	hub := NewMessagingHub()
+	mh := NewMessagingHandler(hub)
+	h := mh.ServeWebSocket(auth)
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest(http.MethodGet, "/api/messages/ws?token="+tok, nil)
+	c.Request.Header.Set("Origin", "https://evil.example")
 	h(c)
 	if w.Code != http.StatusForbidden {
 		t.Fatalf("expected 403, got %d body=%s", w.Code, w.Body.String())


### PR DESCRIPTION
## Summary
- enforce websocket origin allowlist via `WS_ALLOWED_ORIGINS` with safe localhost defaults
- harden JWT parsing to require expiration/issued-at validation and reject malformed empty tokens
- add security integration tests for origin rejection and expired/invalid token handling

## Test plan
- [x] `go test ./handlers -run (WebSocket|ParseJWTClaims|RequireAuthRole) -v`
- [x] `go test ./...`