### PR TITLE
CG-02: implement PHI encryption-at-rest for files and sensitive fields

### DIFF
--- a/backend/db/db.go
+++ b/backend/db/db.go
@@ -298,6 +298,11 @@ func Migrate(ctx context.Context) error {
 			thread_id  UUID NOT NULL REFERENCES message_threads(id) ON DELETE CASCADE,
 			sender_id  UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
 			body       TEXT NOT NULL,
+			body_is_encrypted BOOLEAN NOT NULL DEFAULT FALSE,
+			body_key_version  INTEGER NOT NULL DEFAULT 0,
+			body_wrapped_key  TEXT NOT NULL DEFAULT '',
+			body_wrapped_nonce TEXT NOT NULL DEFAULT '',
+			body_data_nonce   TEXT NOT NULL DEFAULT '',
 			created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
 		);
 
@@ -349,10 +354,26 @@ func Migrate(ctx context.Context) error {
 			stored_name    TEXT NOT NULL UNIQUE,
 			mime_type      TEXT NOT NULL,
 			byte_size      BIGINT NOT NULL CHECK (byte_size >= 0 AND byte_size <= 5242880),
+			enc_key_version   INTEGER NOT NULL DEFAULT 0,
+			enc_wrapped_key   TEXT NOT NULL DEFAULT '',
+			enc_wrapped_nonce TEXT NOT NULL DEFAULT '',
+			enc_data_nonce    TEXT NOT NULL DEFAULT '',
 			created_at     TIMESTAMPTZ NOT NULL DEFAULT NOW()
 		);
 
 		CREATE INDEX IF NOT EXISTS idx_patient_files_patient ON patient_files(patient_id);
+
+		-- Backward compatible migrations for encryption metadata (safe on existing DBs).
+		ALTER TABLE messages ADD COLUMN IF NOT EXISTS body_is_encrypted BOOLEAN NOT NULL DEFAULT FALSE;
+		ALTER TABLE messages ADD COLUMN IF NOT EXISTS body_key_version INTEGER NOT NULL DEFAULT 0;
+		ALTER TABLE messages ADD COLUMN IF NOT EXISTS body_wrapped_key TEXT NOT NULL DEFAULT '';
+		ALTER TABLE messages ADD COLUMN IF NOT EXISTS body_wrapped_nonce TEXT NOT NULL DEFAULT '';
+		ALTER TABLE messages ADD COLUMN IF NOT EXISTS body_data_nonce TEXT NOT NULL DEFAULT '';
+
+		ALTER TABLE patient_files ADD COLUMN IF NOT EXISTS enc_key_version INTEGER NOT NULL DEFAULT 0;
+		ALTER TABLE patient_files ADD COLUMN IF NOT EXISTS enc_wrapped_key TEXT NOT NULL DEFAULT '';
+		ALTER TABLE patient_files ADD COLUMN IF NOT EXISTS enc_wrapped_nonce TEXT NOT NULL DEFAULT '';
+		ALTER TABLE patient_files ADD COLUMN IF NOT EXISTS enc_data_nonce TEXT NOT NULL DEFAULT '';
 	`)
 	return err
 }

--- a/backend/handlers/messaging.go
+++ b/backend/handlers/messaging.go
@@ -10,6 +10,7 @@ import (
 	"github.com/gin-gonic/gin"
 	"github.com/google/uuid"
 	"github.com/healthonyx/backend/db"
+	"github.com/healthonyx/backend/security"
 	"github.com/jackc/pgx/v5"
 )
 
@@ -74,6 +75,43 @@ type chatMessageRow struct {
 	SenderID  uuid.UUID `json:"sender_id"`
 	Body      string    `json:"body"`
 	CreatedAt time.Time `json:"created_at"`
+}
+
+func decryptMessageBodyIfNeeded(enc bool, keyVersion int, wrappedKeyB64, wrappedNonceB64, dataNonceB64, storedBody string) (string, error) {
+	if !enc {
+		return storedBody, nil
+	}
+	kr, err := security.LoadKeyringFromEnv()
+	if err != nil {
+		return "", err
+	}
+	wrappedKey, err := security.B64Decode(wrappedKeyB64)
+	if err != nil {
+		return "", err
+	}
+	wrappedNonce, err := security.B64Decode(wrappedNonceB64)
+	if err != nil {
+		return "", err
+	}
+	dataNonce, err := security.B64Decode(dataNonceB64)
+	if err != nil {
+		return "", err
+	}
+	cipherBytes, err := security.B64Decode(storedBody)
+	if err != nil {
+		return "", err
+	}
+	plain, err := kr.Decrypt(security.Envelope{
+		KeyVersion:   keyVersion,
+		WrappedKey:   wrappedKey,
+		WrappedNonce: wrappedNonce,
+		DataNonce:    dataNonce,
+		Ciphertext:   cipherBytes,
+	})
+	if err != nil {
+		return "", err
+	}
+	return string(plain), nil
 }
 
 // UnreadTotal implements GET /api/messages/unread
@@ -178,7 +216,9 @@ func (h *MessagingHandler) ListMessages(c *gin.Context) {
 	}
 
 	rows, err := db.Pool.Query(ctx, `
-		SELECT id, thread_id, sender_id, body, created_at
+		SELECT id, thread_id, sender_id, body,
+		       body_is_encrypted, body_key_version, body_wrapped_key, body_wrapped_nonce, body_data_nonce,
+		       created_at
 		FROM messages
 		WHERE thread_id = $1
 		ORDER BY created_at ASC
@@ -192,10 +232,20 @@ func (h *MessagingHandler) ListMessages(c *gin.Context) {
 	var list []chatMessageRow
 	for rows.Next() {
 		var m chatMessageRow
-		if err := rows.Scan(&m.ID, &m.ThreadID, &m.SenderID, &m.Body, &m.CreatedAt); err != nil {
+		var enc bool
+		var keyVersion int
+		var wrappedKeyB64, wrappedNonceB64, dataNonceB64 string
+		var storedBody string
+		if err := rows.Scan(&m.ID, &m.ThreadID, &m.SenderID, &storedBody, &enc, &keyVersion, &wrappedKeyB64, &wrappedNonceB64, &dataNonceB64, &m.CreatedAt); err != nil {
 			c.JSON(http.StatusInternalServerError, gin.H{"error": "Unable to load messages"})
 			return
 		}
+		body, decErr := decryptMessageBodyIfNeeded(enc, keyVersion, wrappedKeyB64, wrappedNonceB64, dataNonceB64, storedBody)
+		if decErr != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "Unable to decrypt messages"})
+			return
+		}
+		m.Body = body
 		list = append(list, m)
 	}
 	if list == nil {
@@ -235,21 +285,38 @@ func (h *MessagingHandler) SendMessage(c *gin.Context) {
 		return
 	}
 
+	kr, krErr := security.LoadKeyringFromEnv()
+	if krErr != nil {
+		c.JSON(http.StatusServiceUnavailable, gin.H{"error": "Encryption keyring not configured"})
+		return
+	}
+	env, encErr := kr.Encrypt([]byte(body))
+	if encErr != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Unable to encrypt message"})
+		return
+	}
+
 	var msg chatMessageRow
 	err = db.Pool.QueryRow(ctx, `
-		INSERT INTO messages (thread_id, sender_id, body)
-		VALUES ($1, $2, $3)
-		RETURNING id, thread_id, sender_id, body, created_at
-	`, threadID, claims.UserID, body).Scan(&msg.ID, &msg.ThreadID, &msg.SenderID, &msg.Body, &msg.CreatedAt)
+		INSERT INTO messages (
+			thread_id, sender_id, body,
+			body_is_encrypted, body_key_version, body_wrapped_key, body_wrapped_nonce, body_data_nonce
+		)
+		VALUES ($1, $2, $3, TRUE, $4, $5, $6, $7)
+		RETURNING id, thread_id, sender_id, created_at
+	`, threadID, claims.UserID, security.B64Encode(env.Ciphertext),
+		env.KeyVersion, security.B64Encode(env.WrappedKey), security.B64Encode(env.WrappedNonce), security.B64Encode(env.DataNonce),
+	).Scan(&msg.ID, &msg.ThreadID, &msg.SenderID, &msg.CreatedAt)
 	if err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "Unable to send message"})
 		return
 	}
+	msg.Body = body
 	_, _ = db.Pool.Exec(ctx, `
 		UPDATE message_threads
 		SET last_message_at = $2, last_preview = $3
 		WHERE id = $1
-	`, threadID, msg.CreatedAt, previewText(body))
+	`, threadID, msg.CreatedAt, "New message")
 
 	if h.hub != nil {
 		h.hub.NotifyNewMessage(ctx, threadID, msg)
@@ -322,27 +389,46 @@ func (h *MessagingHandler) CreateThread(c *gin.Context) {
 			INSERT INTO message_threads (patient_id, doctor_id, last_message_at, last_preview)
 			VALUES ($1, $2, NOW(), $3)
 			RETURNING id
-		`, patientID, doctorID, previewText(body)).Scan(&threadID)
+		`, patientID, doctorID, "New message").Scan(&threadID)
 	}
 	if err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "Unable to create thread"})
 		return
 	}
 
-	var msgTime time.Time
+	kr, krErr := security.LoadKeyringFromEnv()
+	if krErr != nil {
+		c.JSON(http.StatusServiceUnavailable, gin.H{"error": "Encryption keyring not configured"})
+		return
+	}
+	env, encErr := kr.Encrypt([]byte(body))
+	if encErr != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Unable to encrypt message"})
+		return
+	}
+
+	var msg chatMessageRow
 	err = tx.QueryRow(ctx, `
-		INSERT INTO messages (thread_id, sender_id, body)
-		VALUES ($1, $2, $3)
-		RETURNING created_at
-	`, threadID, claims.UserID, body).Scan(&msgTime)
+		INSERT INTO messages (
+			thread_id, sender_id, body,
+			body_is_encrypted, body_key_version, body_wrapped_key, body_wrapped_nonce, body_data_nonce
+		)
+		VALUES ($1, $2, $3, TRUE, $4, $5, $6, $7)
+		RETURNING id, created_at
+	`, threadID, claims.UserID, security.B64Encode(env.Ciphertext),
+		env.KeyVersion, security.B64Encode(env.WrappedKey), security.B64Encode(env.WrappedNonce), security.B64Encode(env.DataNonce),
+	).Scan(&msg.ID, &msg.CreatedAt)
 	if err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "Unable to send first message"})
 		return
 	}
+	msg.ThreadID = threadID
+	msg.SenderID = claims.UserID
+	msg.Body = body
 
 	_, err = tx.Exec(ctx, `
 		UPDATE message_threads SET last_message_at = $2, last_preview = $3 WHERE id = $1
-	`, threadID, msgTime, previewText(body))
+	`, threadID, msg.CreatedAt, "New message")
 	if err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "Unable to update thread"})
 		return
@@ -382,16 +468,7 @@ func (h *MessagingHandler) CreateThread(c *gin.Context) {
 	}
 
 	if h.hub != nil {
-		var msg chatMessageRow
-		if qerr := db.Pool.QueryRow(ctx, `
-			SELECT id, thread_id, sender_id, body, created_at
-			FROM messages
-			WHERE thread_id = $1
-			ORDER BY created_at DESC
-			LIMIT 1
-		`, threadID).Scan(&msg.ID, &msg.ThreadID, &msg.SenderID, &msg.Body, &msg.CreatedAt); qerr == nil {
-			h.hub.NotifyNewMessage(ctx, threadID, msg)
-		}
+		h.hub.NotifyNewMessage(ctx, threadID, msg)
 	}
 
 	c.JSON(http.StatusCreated, row)

--- a/backend/handlers/patient_files.go
+++ b/backend/handlers/patient_files.go
@@ -1,6 +1,7 @@
 package handlers
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -11,6 +12,7 @@ import (
 	"github.com/gin-gonic/gin"
 	"github.com/google/uuid"
 	"github.com/healthonyx/backend/db"
+	"github.com/healthonyx/backend/security"
 )
 
 const patientFileMaxBytes = 5 << 20 // 5 MiB (matches DB check)
@@ -145,6 +147,21 @@ func (h *PatientFilesHandler) Upload(c *gin.Context) {
 		return
 	}
 
+	kr, krErr := security.LoadKeyringFromEnv()
+	if krErr != nil {
+		if errors.Is(krErr, security.ErrKeyringNotConfigured) {
+			c.JSON(http.StatusServiceUnavailable, gin.H{"error": "Encryption keyring not configured"})
+			return
+		}
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Internal error"})
+		return
+	}
+	env, encErr := kr.Encrypt(body)
+	if encErr != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Could not encrypt file"})
+		return
+	}
+
 	stored := uuid.New().String()
 	ext := strings.ToLower(filepath.Ext(fh.Filename))
 	if ext != ".pdf" && ext != ".jpg" && ext != ".jpeg" && ext != ".png" {
@@ -161,7 +178,7 @@ func (h *PatientFilesHandler) Upload(c *gin.Context) {
 	}
 	storedName := stored + ext
 	destPath := filepath.Join(h.Root, storedName)
-	if err := os.WriteFile(destPath, body, 0o640); err != nil {
+	if err := os.WriteFile(destPath, env.Ciphertext, 0o640); err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "Could not store file"})
 		return
 	}
@@ -174,10 +191,15 @@ func (h *PatientFilesHandler) Upload(c *gin.Context) {
 	size := int64(len(body))
 	var id uuid.UUID
 	err = db.Pool.QueryRow(c.Request.Context(), `
-		INSERT INTO patient_files (patient_id, uploaded_by, description, original_name, stored_name, mime_type, byte_size)
-		VALUES ($1, $2, $3, $4, $5, $6, $7)
+		INSERT INTO patient_files (
+			patient_id, uploaded_by, description, original_name, stored_name, mime_type, byte_size,
+			enc_key_version, enc_wrapped_key, enc_wrapped_nonce, enc_data_nonce
+		)
+		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)
 		RETURNING id
-	`, patientID, claims.UserID, desc, fh.Filename, storedName, mime, size).Scan(&id)
+	`, patientID, claims.UserID, desc, fh.Filename, storedName, mime, size,
+		env.KeyVersion, security.B64Encode(env.WrappedKey), security.B64Encode(env.WrappedNonce), security.B64Encode(env.DataNonce),
+	).Scan(&id)
 	if err != nil {
 		_ = os.Remove(destPath)
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "Internal error"})
@@ -208,10 +230,13 @@ func (h *PatientFilesHandler) Download(c *gin.Context) {
 
 	var patientID uuid.UUID
 	var storedName, orig, mime string
+	var keyVersion int
+	var wrappedKeyB64, wrappedNonceB64, dataNonceB64 string
 	err = db.Pool.QueryRow(c.Request.Context(), `
-		SELECT patient_id, stored_name, original_name, mime_type
+		SELECT patient_id, stored_name, original_name, mime_type,
+		       enc_key_version, enc_wrapped_key, enc_wrapped_nonce, enc_data_nonce
 		FROM patient_files WHERE id = $1
-	`, id).Scan(&patientID, &storedName, &orig, &mime)
+	`, id).Scan(&patientID, &storedName, &orig, &mime, &keyVersion, &wrappedKeyB64, &wrappedNonceB64, &dataNonceB64)
 	if err != nil {
 		c.JSON(http.StatusNotFound, gin.H{"error": "Not found"})
 		return
@@ -232,7 +257,49 @@ func (h *PatientFilesHandler) Download(c *gin.Context) {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "Invalid path"})
 		return
 	}
+
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Unable to read file"})
+		return
+	}
+	out := raw
+	if keyVersion > 0 {
+		kr, krErr := security.LoadKeyringFromEnv()
+		if krErr != nil {
+			c.JSON(http.StatusServiceUnavailable, gin.H{"error": "Encryption keyring not configured"})
+			return
+		}
+		wrappedKey, err := security.B64Decode(wrappedKeyB64)
+		if err != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "Unable to decode file metadata"})
+			return
+		}
+		wrappedNonce, err := security.B64Decode(wrappedNonceB64)
+		if err != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "Unable to decode file metadata"})
+			return
+		}
+		dataNonce, err := security.B64Decode(dataNonceB64)
+		if err != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "Unable to decode file metadata"})
+			return
+		}
+		plain, decErr := kr.Decrypt(security.Envelope{
+			KeyVersion:   keyVersion,
+			WrappedKey:   wrappedKey,
+			WrappedNonce: wrappedNonce,
+			DataNonce:    dataNonce,
+			Ciphertext:   raw,
+		})
+		if decErr != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "Unable to decrypt file"})
+			return
+		}
+		out = plain
+	}
+
 	c.Header("Content-Type", mime)
 	c.Header("Content-Disposition", fmt.Sprintf(`attachment; filename="%s"`, strings.ReplaceAll(orig, `"`, ``)))
-	c.File(path)
+	c.Data(http.StatusOK, mime, out)
 }

--- a/backend/security/envelope.go
+++ b/backend/security/envelope.go
@@ -1,0 +1,184 @@
+package security
+
+import (
+	"crypto/aes"
+	"crypto/cipher"
+	"crypto/rand"
+	"encoding/base64"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"sort"
+	"strconv"
+	"strings"
+)
+
+// Envelope contains ciphertext plus the minimal metadata required to decrypt.
+// WrappedKey is the per-payload DEK encrypted ("wrapped") by a KEK (versioned keyring).
+type Envelope struct {
+	KeyVersion   int
+	WrappedKey   []byte
+	WrappedNonce []byte
+	DataNonce    []byte
+	Ciphertext   []byte
+}
+
+type Keyring struct {
+	activeVersion int
+	keys          map[int][]byte
+}
+
+var (
+	ErrKeyringNotConfigured = errors.New("encryption keyring not configured")
+	ErrUnknownKeyVersion    = errors.New("unknown key version")
+)
+
+// LoadKeyringFromEnv loads a versioned keyring from environment variables.
+//
+// - PHI_ENCRYPTION_KEYS: comma-separated list "1:<b64>,2:<b64>" where each key is 32 bytes (AES-256).
+// - PHI_ENCRYPTION_ACTIVE_VERSION: optional; if absent uses highest version in PHI_ENCRYPTION_KEYS.
+func LoadKeyringFromEnv() (*Keyring, error) {
+	raw := strings.TrimSpace(os.Getenv("PHI_ENCRYPTION_KEYS"))
+	if raw == "" {
+		return nil, ErrKeyringNotConfigured
+	}
+	keys := map[int][]byte{}
+	var versions []int
+	for _, part := range strings.Split(raw, ",") {
+		part = strings.TrimSpace(part)
+		if part == "" {
+			continue
+		}
+		pair := strings.SplitN(part, ":", 2)
+		if len(pair) != 2 {
+			return nil, fmt.Errorf("invalid PHI_ENCRYPTION_KEYS entry: %q", part)
+		}
+		v, err := strconv.Atoi(strings.TrimSpace(pair[0]))
+		if err != nil || v <= 0 {
+			return nil, fmt.Errorf("invalid key version: %q", pair[0])
+		}
+		keyRaw, err := base64.StdEncoding.DecodeString(strings.TrimSpace(pair[1]))
+		if err != nil {
+			return nil, fmt.Errorf("invalid key b64 for version %d", v)
+		}
+		if len(keyRaw) != 32 {
+			return nil, fmt.Errorf("version %d key must be 32 bytes (got %d)", v, len(keyRaw))
+		}
+		keys[v] = keyRaw
+		versions = append(versions, v)
+	}
+	if len(keys) == 0 {
+		return nil, ErrKeyringNotConfigured
+	}
+	sort.Ints(versions)
+	active := versions[len(versions)-1]
+	if av := strings.TrimSpace(os.Getenv("PHI_ENCRYPTION_ACTIVE_VERSION")); av != "" {
+		v, err := strconv.Atoi(av)
+		if err != nil || v <= 0 {
+			return nil, fmt.Errorf("invalid PHI_ENCRYPTION_ACTIVE_VERSION: %q", av)
+		}
+		if _, ok := keys[v]; !ok {
+			return nil, fmt.Errorf("%w: %d", ErrUnknownKeyVersion, v)
+		}
+		active = v
+	}
+	return &Keyring{activeVersion: active, keys: keys}, nil
+}
+
+func randomBytes(n int) ([]byte, error) {
+	b := make([]byte, n)
+	if _, err := io.ReadFull(rand.Reader, b); err != nil {
+		return nil, err
+	}
+	return b, nil
+}
+
+func aesgcm(key []byte) (cipher.AEAD, error) {
+	block, err := aes.NewCipher(key)
+	if err != nil {
+		return nil, err
+	}
+	return cipher.NewGCM(block)
+}
+
+func (kr *Keyring) Encrypt(plaintext []byte) (*Envelope, error) {
+	if kr == nil || len(kr.keys) == 0 {
+		return nil, ErrKeyringNotConfigured
+	}
+	kek, ok := kr.keys[kr.activeVersion]
+	if !ok {
+		return nil, fmt.Errorf("%w: %d", ErrUnknownKeyVersion, kr.activeVersion)
+	}
+
+	dek, err := randomBytes(32)
+	if err != nil {
+		return nil, err
+	}
+
+	dataAead, err := aesgcm(dek)
+	if err != nil {
+		return nil, err
+	}
+	dataNonce, err := randomBytes(dataAead.NonceSize())
+	if err != nil {
+		return nil, err
+	}
+	ciphertext := dataAead.Seal(nil, dataNonce, plaintext, nil)
+
+	wrapAead, err := aesgcm(kek)
+	if err != nil {
+		return nil, err
+	}
+	wrapNonce, err := randomBytes(wrapAead.NonceSize())
+	if err != nil {
+		return nil, err
+	}
+	wrappedKey := wrapAead.Seal(nil, wrapNonce, dek, nil)
+
+	return &Envelope{
+		KeyVersion:   kr.activeVersion,
+		WrappedKey:   wrappedKey,
+		WrappedNonce: wrapNonce,
+		DataNonce:    dataNonce,
+		Ciphertext:   ciphertext,
+	}, nil
+}
+
+func (kr *Keyring) Decrypt(env Envelope) ([]byte, error) {
+	if kr == nil || len(kr.keys) == 0 {
+		return nil, ErrKeyringNotConfigured
+	}
+	kek, ok := kr.keys[env.KeyVersion]
+	if !ok {
+		return nil, fmt.Errorf("%w: %d", ErrUnknownKeyVersion, env.KeyVersion)
+	}
+	wrapAead, err := aesgcm(kek)
+	if err != nil {
+		return nil, err
+	}
+	dek, err := wrapAead.Open(nil, env.WrappedNonce, env.WrappedKey, nil)
+	if err != nil {
+		return nil, err
+	}
+	dataAead, err := aesgcm(dek)
+	if err != nil {
+		return nil, err
+	}
+	return dataAead.Open(nil, env.DataNonce, env.Ciphertext, nil)
+}
+
+func B64Encode(b []byte) string {
+	if len(b) == 0 {
+		return ""
+	}
+	return base64.StdEncoding.EncodeToString(b)
+}
+
+func B64Decode(s string) ([]byte, error) {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return nil, nil
+	}
+	return base64.StdEncoding.DecodeString(s)
+}

--- a/backend/security/envelope_test.go
+++ b/backend/security/envelope_test.go
@@ -1,0 +1,89 @@
+package security
+
+import (
+	"bytes"
+	"os"
+	"testing"
+)
+
+func TestEnvelopeEncryptDecrypt_RoundTrip(t *testing.T) {
+	_ = os.Setenv("PHI_ENCRYPTION_KEYS", "1:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=")
+	_ = os.Setenv("PHI_ENCRYPTION_ACTIVE_VERSION", "1")
+	t.Cleanup(func() {
+		_ = os.Unsetenv("PHI_ENCRYPTION_KEYS")
+		_ = os.Unsetenv("PHI_ENCRYPTION_ACTIVE_VERSION")
+	})
+
+	kr, err := LoadKeyringFromEnv()
+	if err != nil {
+		t.Fatalf("LoadKeyringFromEnv: %v", err)
+	}
+
+	plain := []byte("hello phi payload")
+	env, err := kr.Encrypt(plain)
+	if err != nil {
+		t.Fatalf("Encrypt: %v", err)
+	}
+	out, err := kr.Decrypt(*env)
+	if err != nil {
+		t.Fatalf("Decrypt: %v", err)
+	}
+	if !bytes.Equal(out, plain) {
+		t.Fatalf("round trip mismatch")
+	}
+	if bytes.Equal(env.Ciphertext, plain) {
+		t.Fatalf("ciphertext must not equal plaintext")
+	}
+}
+
+func TestEnvelopeDecrypt_BackwardCompatibleKeyRotation(t *testing.T) {
+	// Two-key keyring; active is v2, but we must still decrypt v1 envelopes.
+	_ = os.Setenv("PHI_ENCRYPTION_KEYS", "1:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=,2:BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB=")
+	_ = os.Setenv("PHI_ENCRYPTION_ACTIVE_VERSION", "2")
+	t.Cleanup(func() {
+		_ = os.Unsetenv("PHI_ENCRYPTION_KEYS")
+		_ = os.Unsetenv("PHI_ENCRYPTION_ACTIVE_VERSION")
+	})
+
+	kr, err := LoadKeyringFromEnv()
+	if err != nil {
+		t.Fatalf("LoadKeyringFromEnv: %v", err)
+	}
+
+	// Force v1 encryption by overriding activeVersion.
+	krV1 := *kr
+	krV1.activeVersion = 1
+
+	env, err := krV1.Encrypt([]byte("v1 secret"))
+	if err != nil {
+		t.Fatalf("Encrypt v1: %v", err)
+	}
+	if env.KeyVersion != 1 {
+		t.Fatalf("expected v1 envelope")
+	}
+
+	// Decrypt with full keyring (active v2).
+	out, err := kr.Decrypt(*env)
+	if err != nil {
+		t.Fatalf("Decrypt: %v", err)
+	}
+	if string(out) != "v1 secret" {
+		t.Fatalf("unexpected plaintext: %q", string(out))
+	}
+
+	// Encrypt with v2 and verify decrypt works.
+	env2, err := kr.Encrypt([]byte("v2 secret"))
+	if err != nil {
+		t.Fatalf("Encrypt v2: %v", err)
+	}
+	if env2.KeyVersion != 2 {
+		t.Fatalf("expected v2 envelope")
+	}
+	out2, err := kr.Decrypt(*env2)
+	if err != nil {
+		t.Fatalf("Decrypt v2: %v", err)
+	}
+	if string(out2) != "v2 secret" {
+		t.Fatalf("unexpected plaintext: %q", string(out2))
+	}
+}


### PR DESCRIPTION
## Summary
- add envelope encryption utilities (AES-256-GCM DEK wrapped by versioned KEK)
- encrypt patient file payloads on disk and decrypt on download, storing key version + nonces in DB metadata
- encrypt message bodies at rest (stored as base64 ciphertext) and decrypt on read APIs; avoid storing PHI previews by using a fixed preview label
- add key rotation + backward-compatibility tests

## Config
- `PHI_ENCRYPTION_KEYS` = `1:<base64-32B>,2:<base64-32B>,...`
- `PHI_ENCRYPTION_ACTIVE_VERSION` = active version (optional; defaults to highest)

## Test plan
- [x] `go test ./...`