### PR TITLE
CG-03: add consent provenance ledger with policy versioning

### DIFF
--- a/backend/handlers/notifications.go
+++ b/backend/handlers/notifications.go
@@ -4,6 +4,7 @@ import (
 	"database/sql"
 	"errors"
 	"net/http"
+	"os"
 	"strings"
 
 	"github.com/gin-gonic/gin"
@@ -27,7 +28,9 @@ type NotificationPreference struct {
 }
 
 type upsertNotificationPreferencesBody struct {
-	Preferences []NotificationPreference `json:"preferences"`
+	Preferences   []NotificationPreference `json:"preferences"`
+	ConsentSource string                   `json:"consent_source"`
+	PolicyVersion string                   `json:"policy_version"`
 }
 
 var defaultNotificationPreferences = []NotificationPreference{
@@ -60,6 +63,31 @@ func normalizeNotificationPreference(input NotificationPreference) (Notification
 	}, nil
 }
 
+func normalizeConsentSource(raw string) string {
+	s := strings.TrimSpace(strings.ToLower(raw))
+	if s == "" {
+		return "self_service_portal"
+	}
+	switch s {
+	case "self_service_portal", "admin_console", "support_assisted", "api":
+		return s
+	default:
+		return "unknown"
+	}
+}
+
+func normalizePolicyVersion(raw string) string {
+	s := strings.TrimSpace(raw)
+	if s != "" {
+		return s
+	}
+	env := strings.TrimSpace(os.Getenv("NOTIFICATION_POLICY_VERSION"))
+	if env != "" {
+		return env
+	}
+	return "v1"
+}
+
 func (h *NotificationsHandler) ensurePreferencesSchema(c *gin.Context) error {
 	_, err := db.Pool.Exec(c.Request.Context(), `
 		CREATE TABLE IF NOT EXISTS notification_preferences (
@@ -75,6 +103,27 @@ func (h *NotificationsHandler) ensurePreferencesSchema(c *gin.Context) error {
 				category IN ('appointment_reminders', 'medication_reminders', 'lab_result_alerts', 'announcements')
 			)
 		)
+
+		CREATE TABLE IF NOT EXISTS notification_consent_events (
+			id                 UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+			user_id            UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+			actor_user_id      UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+			actor_role         TEXT NOT NULL,
+			actor_source       TEXT NOT NULL DEFAULT 'self_service_portal',
+			policy_version     TEXT NOT NULL DEFAULT 'v1',
+			category           TEXT NOT NULL,
+			prev_enabled       BOOLEAN NOT NULL,
+			prev_email_enabled BOOLEAN NOT NULL,
+			prev_sms_enabled   BOOLEAN NOT NULL,
+			prev_in_app_enabled BOOLEAN NOT NULL,
+			new_enabled        BOOLEAN NOT NULL,
+			new_email_enabled  BOOLEAN NOT NULL,
+			new_sms_enabled    BOOLEAN NOT NULL,
+			new_in_app_enabled BOOLEAN NOT NULL,
+			created_at         TIMESTAMPTZ NOT NULL DEFAULT NOW()
+		);
+		CREATE INDEX IF NOT EXISTS idx_notification_consent_events_user ON notification_consent_events(user_id, created_at DESC);
+		CREATE INDEX IF NOT EXISTS idx_notification_consent_events_actor ON notification_consent_events(actor_user_id, created_at DESC);
 	`)
 	return err
 }
@@ -350,6 +399,29 @@ func (h *NotificationsHandler) UpsertPreferences(c *gin.Context) {
 		c.JSON(http.StatusBadRequest, gin.H{"error": "preferences are required"})
 		return
 	}
+	consentSource := normalizeConsentSource(body.ConsentSource)
+	policyVersion := normalizePolicyVersion(body.PolicyVersion)
+
+	currentRows, err := db.Pool.Query(c.Request.Context(), `
+		SELECT category, enabled, email_enabled, sms_enabled, in_app_enabled
+		FROM notification_preferences
+		WHERE user_id = $1
+	`, claims.UserID)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Internal error"})
+		return
+	}
+	current := map[string]NotificationPreference{}
+	for currentRows.Next() {
+		var row NotificationPreference
+		if err := currentRows.Scan(&row.Category, &row.Enabled, &row.EmailEnabled, &row.SmsEnabled, &row.InAppEnabled); err != nil {
+			currentRows.Close()
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "Internal error"})
+			return
+		}
+		current[row.Category] = row
+	}
+	currentRows.Close()
 
 	for _, raw := range body.Preferences {
 		pref, err := normalizeNotificationPreference(raw)
@@ -372,7 +444,100 @@ func (h *NotificationsHandler) UpsertPreferences(c *gin.Context) {
 			c.JSON(http.StatusInternalServerError, gin.H{"error": "Internal error"})
 			return
 		}
+
+		prev, ok := current[pref.Category]
+		if !ok {
+			prev = NotificationPreference{
+				Category:     pref.Category,
+				Enabled:      true,
+				EmailEnabled: true,
+				SmsEnabled:   false,
+				InAppEnabled: true,
+			}
+		}
+		changed := prev.Enabled != pref.Enabled ||
+			prev.EmailEnabled != pref.EmailEnabled ||
+			prev.SmsEnabled != pref.SmsEnabled ||
+			prev.InAppEnabled != pref.InAppEnabled
+		if changed {
+			_, err = db.Pool.Exec(c.Request.Context(), `
+				INSERT INTO notification_consent_events (
+					user_id, actor_user_id, actor_role, actor_source, policy_version, category,
+					prev_enabled, prev_email_enabled, prev_sms_enabled, prev_in_app_enabled,
+					new_enabled, new_email_enabled, new_sms_enabled, new_in_app_enabled
+				)
+				VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14)
+			`,
+				claims.UserID, claims.UserID, claims.Role, consentSource, policyVersion, pref.Category,
+				prev.Enabled, prev.EmailEnabled, prev.SmsEnabled, prev.InAppEnabled,
+				pref.Enabled, pref.EmailEnabled, pref.SmsEnabled, pref.InAppEnabled,
+			)
+			if err != nil {
+				c.JSON(http.StatusInternalServerError, gin.H{"error": "Internal error"})
+				return
+			}
+		}
 	}
 
-	c.JSON(http.StatusOK, gin.H{"updated": len(body.Preferences)})
+	c.JSON(http.StatusOK, gin.H{"updated": len(body.Preferences), "policy_version": policyVersion})
+}
+
+// AdminConsentHistory GET /api/admin/notifications/consent-history
+func (h *NotificationsHandler) AdminConsentHistory(c *gin.Context) {
+	if _, ok := getClaims(c); !ok {
+		return
+	}
+	if err := h.ensurePreferencesSchema(c); err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Internal error"})
+		return
+	}
+	rows, err := db.Pool.Query(c.Request.Context(), `
+		SELECT id::text, user_id::text, actor_user_id::text, actor_role, actor_source, policy_version,
+		       category, prev_enabled, prev_email_enabled, prev_sms_enabled, prev_in_app_enabled,
+		       new_enabled, new_email_enabled, new_sms_enabled, new_in_app_enabled, created_at::text
+		FROM notification_consent_events
+		ORDER BY created_at DESC
+		LIMIT 300
+	`)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Internal error"})
+		return
+	}
+	defer rows.Close()
+
+	type row struct {
+		ID              string `json:"id"`
+		UserID          string `json:"user_id"`
+		ActorUserID     string `json:"actor_user_id"`
+		ActorRole       string `json:"actor_role"`
+		ActorSource     string `json:"actor_source"`
+		PolicyVersion   string `json:"policy_version"`
+		Category        string `json:"category"`
+		PrevEnabled     bool   `json:"prev_enabled"`
+		PrevEmail       bool   `json:"prev_email_enabled"`
+		PrevSMS         bool   `json:"prev_sms_enabled"`
+		PrevInApp       bool   `json:"prev_in_app_enabled"`
+		NewEnabled      bool   `json:"new_enabled"`
+		NewEmail        bool   `json:"new_email_enabled"`
+		NewSMS          bool   `json:"new_sms_enabled"`
+		NewInApp        bool   `json:"new_in_app_enabled"`
+		CreatedAt       string `json:"created_at"`
+	}
+	var out []row
+	for rows.Next() {
+		var r row
+		if err := rows.Scan(
+			&r.ID, &r.UserID, &r.ActorUserID, &r.ActorRole, &r.ActorSource, &r.PolicyVersion,
+			&r.Category, &r.PrevEnabled, &r.PrevEmail, &r.PrevSMS, &r.PrevInApp,
+			&r.NewEnabled, &r.NewEmail, &r.NewSMS, &r.NewInApp, &r.CreatedAt,
+		); err != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "Internal error"})
+			return
+		}
+		out = append(out, r)
+	}
+	if out == nil {
+		out = []row{}
+	}
+	c.JSON(http.StatusOK, gin.H{"events": out})
 }

--- a/backend/handlers/notifications_test.go
+++ b/backend/handlers/notifications_test.go
@@ -131,3 +131,26 @@ func TestNotifications_RetryFailed_InvalidID(t *testing.T) {
 		t.Fatalf("expected 400, got %d", w.Code)
 	}
 }
+
+func TestNotifications_AdminConsentHistory_Unauthorized(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest("GET", "/api/admin/notifications/consent-history", nil)
+
+	h := NewNotificationsHandler()
+	h.AdminConsentHistory(c)
+
+	if w.Code != http.StatusUnauthorized {
+		t.Fatalf("expected 401, got %d", w.Code)
+	}
+}
+
+func TestNormalizeConsentDefaults(t *testing.T) {
+	if got := normalizeConsentSource(""); got != "self_service_portal" {
+		t.Fatalf("unexpected consent source default: %s", got)
+	}
+	if got := normalizeConsentSource("ADMIN_CONSOLE"); got != "admin_console" {
+		t.Fatalf("unexpected normalized source: %s", got)
+	}
+}

--- a/backend/main.go
+++ b/backend/main.go
@@ -109,6 +109,7 @@ func main() {
 		api.POST("/admin/ai/eval", auth.RequireAuth(), auth.RequireRole("admin"), aiRuntime.RunEval)
 		api.GET("/admin/notifications", auth.RequireAuth(), auth.RequireRole("admin"), notifications.AdminList)
 		api.GET("/admin/notifications/summary", auth.RequireAuth(), auth.RequireRole("admin"), notifications.AdminSummary)
+		api.GET("/admin/notifications/consent-history", auth.RequireAuth(), auth.RequireRole("admin"), notifications.AdminConsentHistory)
 		api.POST("/admin/notifications/:id/retry", auth.RequireAuth(), auth.RequireRole("admin"), notifications.RetryFailed)
 		api.GET("/admin/knowledge-docs", auth.RequireAuth(), auth.RequireRole("admin"), knowledge.List)
 		api.POST("/admin/knowledge-docs", auth.RequireAuth(), auth.RequireRole("admin"), knowledge.Create)

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -391,6 +391,18 @@ paths:
         "403":
           $ref: "#/components/responses/Forbidden"
 
+  /api/admin/notifications/consent-history:
+    get:
+      tags: [Admin]
+      summary: List notification consent provenance events
+      security:
+        - bearerAuth: []
+      responses:
+        "200":
+          description: Notification consent history list
+        "403":
+          $ref: "#/components/responses/Forbidden"
+
   /api/admin/notifications/{id}/retry:
     post:
       tags: [Admin]

--- a/frontend/src/app/components/admin-notifications-log/admin-notifications-log.component.html
+++ b/frontend/src/app/components/admin-notifications-log/admin-notifications-log.component.html
@@ -71,5 +71,38 @@
     </tbody>
   </table>
 
+  <section *ngIf="!loading && consentRows.length" data-cy="admin-consent-history">
+    <h2>Consent provenance ledger</h2>
+    <table>
+      <thead>
+        <tr>
+          <th>When</th>
+          <th>User</th>
+          <th>Actor</th>
+          <th>Source</th>
+          <th>Policy version</th>
+          <th>Category</th>
+          <th>Change</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr *ngFor="let e of consentRows">
+          <td>{{ e.created_at }}</td>
+          <td>{{ e.user_id }}</td>
+          <td>{{ e.actor_user_id }} ({{ e.actor_role }})</td>
+          <td>{{ e.actor_source }}</td>
+          <td>{{ e.policy_version }}</td>
+          <td>{{ e.category }}</td>
+          <td>
+            enabled: {{ e.prev_enabled }} → {{ e.new_enabled }},
+            email: {{ e.prev_email_enabled }} → {{ e.new_email_enabled }},
+            sms: {{ e.prev_sms_enabled }} → {{ e.new_sms_enabled }},
+            in-app: {{ e.prev_in_app_enabled }} → {{ e.new_in_app_enabled }}
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  </section>
+
   <p *ngIf="!loading && !error && !rows.length" data-cy="admin-notifications-empty">No notifications yet.</p>
 </section>

--- a/frontend/src/app/components/admin-notifications-log/admin-notifications-log.component.spec.ts
+++ b/frontend/src/app/components/admin-notifications-log/admin-notifications-log.component.spec.ts
@@ -27,6 +27,7 @@ describe('AdminNotificationsLogComponent', () => {
       failed_count: 0
     });
     httpMock.expectOne('/api/admin/notifications').flush({ notifications: [] });
+    httpMock.expectOne('/api/admin/notifications/consent-history').flush({ events: [] });
     fixture.detectChanges();
     expect(
       (fixture.nativeElement as HTMLElement).querySelector('[data-cy="admin-notifications-empty"]')
@@ -55,6 +56,7 @@ describe('AdminNotificationsLogComponent', () => {
         }
       ]
     });
+    httpMock.expectOne('/api/admin/notifications/consent-history').flush({ events: [] });
     fixture.detectChanges();
     expect(
       (fixture.nativeElement as HTMLElement).querySelectorAll('[data-cy="admin-notifications-row"]')
@@ -85,6 +87,7 @@ describe('AdminNotificationsLogComponent', () => {
         }
       ]
     });
+    httpMock.expectOne('/api/admin/notifications/consent-history').flush({ events: [] });
     fixture.detectChanges();
     (fixture.nativeElement as HTMLElement).querySelector('[data-cy="retry-failed-notification"]')?.dispatchEvent(
       new Event('click')
@@ -97,6 +100,7 @@ describe('AdminNotificationsLogComponent', () => {
       failed_count: 0
     });
     httpMock.expectOne('/api/admin/notifications').flush({ notifications: [] });
+    httpMock.expectOne('/api/admin/notifications/consent-history').flush({ events: [] });
     expect(fixture.componentInstance.retryingId).toBeNull();
   });
 
@@ -134,9 +138,34 @@ describe('AdminNotificationsLogComponent', () => {
         }
       ]
     });
+    httpMock.expectOne('/api/admin/notifications/consent-history').flush({
+      events: [
+        {
+          id: 'ce-1',
+          user_id: 'u-1',
+          actor_user_id: 'u-1',
+          actor_role: 'patient',
+          actor_source: 'self_service_portal',
+          policy_version: 'v2',
+          category: 'appointment_reminders',
+          prev_enabled: true,
+          prev_email_enabled: true,
+          prev_sms_enabled: false,
+          prev_in_app_enabled: true,
+          new_enabled: false,
+          new_email_enabled: true,
+          new_sms_enabled: false,
+          new_in_app_enabled: true,
+          created_at: 'now'
+        }
+      ]
+    });
     fixture.detectChanges();
     expect(
       (fixture.nativeElement as HTMLElement).querySelector('[data-cy="provider-health-cards"]')
+    ).toBeTruthy();
+    expect(
+      (fixture.nativeElement as HTMLElement).querySelector('[data-cy="admin-consent-history"]')
     ).toBeTruthy();
   });
 });

--- a/frontend/src/app/components/admin-notifications-log/admin-notifications-log.component.ts
+++ b/frontend/src/app/components/admin-notifications-log/admin-notifications-log.component.ts
@@ -3,6 +3,7 @@ import { CommonModule } from '@angular/common';
 import {
   AdminNotificationRow,
   AdminNotificationsSummary,
+  NotificationConsentEventRow,
   NotificationsInboxService
 } from '../../services/notifications.service';
 
@@ -15,6 +16,7 @@ import {
 })
 export class AdminNotificationsLogComponent implements OnInit {
   rows: AdminNotificationRow[] = [];
+  consentRows: NotificationConsentEventRow[] = [];
   summary: AdminNotificationsSummary | null = null;
   loading = true;
   retryingId: string | null = null;
@@ -65,7 +67,16 @@ export class AdminNotificationsLogComponent implements OnInit {
         this.api.listAdminNotifications().subscribe({
           next: (r) => {
             this.rows = r.notifications ?? [];
-            this.loading = false;
+            this.api.listAdminConsentHistory().subscribe({
+              next: (consent) => {
+                this.consentRows = consent.events ?? [];
+                this.loading = false;
+              },
+              error: () => {
+                this.error = 'Could not load consent history.';
+                this.loading = false;
+              }
+            });
           },
           error: () => {
             this.error = 'Could not load notification log.';

--- a/frontend/src/app/services/api-contract.ts
+++ b/frontend/src/app/services/api-contract.ts
@@ -83,6 +83,7 @@ export const ApiContract = {
     aiEval: `${API}/admin/ai/eval`,
     notifications: `${API}/admin/notifications`,
     notificationsSummary: `${API}/admin/notifications/summary`,
+    notificationsConsentHistory: `${API}/admin/notifications/consent-history`,
     notificationRetry: (id: string): string => `${API}/admin/notifications/${id}/retry`,
     knowledgeDocs: `${API}/admin/knowledge-docs`,
     knowledgeSimilarityScan: `${API}/admin/knowledge-docs/similarity-scan`,

--- a/frontend/src/app/services/api-types.ts
+++ b/frontend/src/app/services/api-types.ts
@@ -45,6 +45,25 @@ export interface AdminNotificationsSummary {
   failed_count: number;
 }
 
+export interface NotificationConsentEventRow {
+  id: string;
+  user_id: string;
+  actor_user_id: string;
+  actor_role: string;
+  actor_source: string;
+  policy_version: string;
+  category: string;
+  prev_enabled: boolean;
+  prev_email_enabled: boolean;
+  prev_sms_enabled: boolean;
+  prev_in_app_enabled: boolean;
+  new_enabled: boolean;
+  new_email_enabled: boolean;
+  new_sms_enabled: boolean;
+  new_in_app_enabled: boolean;
+  created_at: string;
+}
+
 export type AdminLifecycleSettings = {
   new_user_window_days: number;
   inactive_window_days: number;

--- a/frontend/src/app/services/notifications.service.ts
+++ b/frontend/src/app/services/notifications.service.ts
@@ -6,6 +6,7 @@ import type {
   AdminNotificationRow,
   AdminNotificationsSummary,
   ApiListResponse,
+  NotificationConsentEventRow,
   NotificationPreferenceRow,
   NotificationRow
 } from './api-types';
@@ -13,7 +14,8 @@ export type {
   NotificationRow,
   NotificationPreferenceRow,
   AdminNotificationRow,
-  AdminNotificationsSummary
+  AdminNotificationsSummary,
+  NotificationConsentEventRow
 } from './api-types';
 
 @Injectable({ providedIn: 'root' })
@@ -46,6 +48,12 @@ export class NotificationsInboxService {
 
   adminSummary(): Observable<AdminNotificationsSummary> {
     return this.http.get<AdminNotificationsSummary>(ApiContract.admin.notificationsSummary);
+  }
+
+  listAdminConsentHistory(): Observable<ApiListResponse<NotificationConsentEventRow, 'events'>> {
+    return this.http.get<ApiListResponse<NotificationConsentEventRow, 'events'>>(
+      ApiContract.admin.notificationsConsentHistory
+    );
   }
 
   retryFailedNotification(id: string): Observable<{ id: string; status: string }> {


### PR DESCRIPTION
## Summary
- persist a notification consent provenance ledger with actor source and policy version metadata on preference changes
- expose admin consent history API for traceability and update OpenAPI route contract
- add admin UI section to display consent history with policy version and before/after preference state

## Test plan
- [x] `go test ./...`
- [x] `go run ./cmd/openapi-sync-check`
- [x] `npm run test:ci -- --include src/app/components/admin-notifications-log/admin-notifications-log.component.spec.ts`