### PR TITLE
CG-04: implement immutable audit event stream with append-only hash chain

### DIFF
--- a/backend/db/db.go
+++ b/backend/db/db.go
@@ -179,6 +179,38 @@ func Migrate(ctx context.Context) error {
 
 		CREATE INDEX IF NOT EXISTS idx_audit_logs_created ON audit_logs(created_at DESC);
 
+		CREATE TABLE IF NOT EXISTS immutable_audit_events (
+			sequence       BIGSERIAL PRIMARY KEY,
+			event_id       UUID NOT NULL DEFAULT gen_random_uuid() UNIQUE,
+			actor_user_id  UUID REFERENCES users(id) ON DELETE SET NULL,
+			action         TEXT NOT NULL,
+			entity_type    TEXT NOT NULL,
+			entity_id      TEXT NOT NULL DEFAULT '',
+			detail         TEXT NOT NULL DEFAULT '',
+			event_time     TIMESTAMPTZ NOT NULL,
+			prev_hash      TEXT NOT NULL DEFAULT '',
+			event_hash     TEXT NOT NULL
+		);
+		CREATE INDEX IF NOT EXISTS idx_immutable_audit_events_time ON immutable_audit_events(event_time DESC);
+		CREATE INDEX IF NOT EXISTS idx_immutable_audit_events_actor ON immutable_audit_events(actor_user_id, event_time DESC);
+
+		CREATE OR REPLACE FUNCTION immutable_audit_events_block_mutation()
+		RETURNS trigger AS $$
+		BEGIN
+			RAISE EXCEPTION 'immutable_audit_events is append-only';
+		END;
+		$$ LANGUAGE plpgsql;
+
+		DROP TRIGGER IF EXISTS immutable_audit_events_no_update ON immutable_audit_events;
+		CREATE TRIGGER immutable_audit_events_no_update
+		BEFORE UPDATE ON immutable_audit_events
+		FOR EACH ROW EXECUTE FUNCTION immutable_audit_events_block_mutation();
+
+		DROP TRIGGER IF EXISTS immutable_audit_events_no_delete ON immutable_audit_events;
+		CREATE TRIGGER immutable_audit_events_no_delete
+		BEFORE DELETE ON immutable_audit_events
+		FOR EACH ROW EXECUTE FUNCTION immutable_audit_events_block_mutation();
+
 		CREATE TABLE IF NOT EXISTS knowledge_docs (
 			id          UUID PRIMARY KEY DEFAULT gen_random_uuid(),
 			title       TEXT NOT NULL,

--- a/backend/handlers/audit_log.go
+++ b/backend/handlers/audit_log.go
@@ -2,15 +2,79 @@ package handlers
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"strings"
+	"time"
 
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5"
 )
+
+type immutableAuditEvent struct {
+	Action     string
+	EntityType string
+	EntityID   string
+	Detail     string
+	EventTime  time.Time
+	PrevHash   string
+	EventHash  string
+}
+
+func computeImmutableAuditHash(prevHash, action, entityType, entityID, detail string, eventTime time.Time) string {
+	// Delimiter-separated canonical payload for deterministic checksum generation.
+	payload := strings.Join([]string{
+		strings.TrimSpace(prevHash),
+		strings.TrimSpace(action),
+		strings.TrimSpace(entityType),
+		strings.TrimSpace(entityID),
+		strings.TrimSpace(detail),
+		eventTime.UTC().Format(time.RFC3339Nano),
+	}, "|")
+	sum := sha256.Sum256([]byte(payload))
+	return hex.EncodeToString(sum[:])
+}
+
+func verifyImmutableAuditChain(events []immutableAuditEvent) error {
+	prev := ""
+	for i, e := range events {
+		expected := computeImmutableAuditHash(prev, e.Action, e.EntityType, e.EntityID, e.Detail, e.EventTime)
+		if e.EventHash != expected {
+			return fmt.Errorf("immutable audit checksum mismatch at index %d", i)
+		}
+		if e.PrevHash != prev {
+			return fmt.Errorf("immutable audit prev_hash mismatch at index %d", i)
+		}
+		prev = e.EventHash
+	}
+	return nil
+}
 
 func writeAudit(ctx context.Context, tx pgx.Tx, actor uuid.UUID, action, entityType, entityID, detail string) error {
 	_, err := tx.Exec(ctx, `
 		INSERT INTO audit_logs (actor_user_id, action, entity_type, entity_id, detail)
 		VALUES ($1, $2, $3, $4, $5)
 	`, actor, action, entityType, entityID, detail)
+	if err != nil {
+		return err
+	}
+
+	var prevHash string
+	_ = tx.QueryRow(ctx, `
+		SELECT COALESCE(event_hash, '')
+		FROM immutable_audit_events
+		ORDER BY sequence DESC
+		LIMIT 1
+	`).Scan(&prevHash)
+
+	eventTime := time.Now().UTC()
+	eventHash := computeImmutableAuditHash(prevHash, action, entityType, entityID, detail, eventTime)
+	_, err = tx.Exec(ctx, `
+		INSERT INTO immutable_audit_events (
+			actor_user_id, action, entity_type, entity_id, detail, event_time, prev_hash, event_hash
+		)
+		VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
+	`, actor, action, entityType, entityID, detail, eventTime, prevHash, eventHash)
 	return err
 }

--- a/backend/handlers/audit_log_chain_test.go
+++ b/backend/handlers/audit_log_chain_test.go
@@ -1,0 +1,89 @@
+package handlers
+
+import (
+	"testing"
+	"time"
+)
+
+func TestVerifyImmutableAuditChain_Valid(t *testing.T) {
+	t0 := time.Date(2026, 4, 28, 23, 0, 0, 0, time.UTC)
+	e1 := immutableAuditEvent{
+		Action:     "admin_user_created",
+		EntityType: "user",
+		EntityID:   "u1",
+		Detail:     "created user",
+		EventTime:  t0,
+		PrevHash:   "",
+	}
+	e1.EventHash = computeImmutableAuditHash(e1.PrevHash, e1.Action, e1.EntityType, e1.EntityID, e1.Detail, e1.EventTime)
+
+	e2 := immutableAuditEvent{
+		Action:     "admin_user_deactivated",
+		EntityType: "user",
+		EntityID:   "u2",
+		Detail:     "deactivated user",
+		EventTime:  t0.Add(1 * time.Minute),
+		PrevHash:   e1.EventHash,
+	}
+	e2.EventHash = computeImmutableAuditHash(e2.PrevHash, e2.Action, e2.EntityType, e2.EntityID, e2.Detail, e2.EventTime)
+
+	if err := verifyImmutableAuditChain([]immutableAuditEvent{e1, e2}); err != nil {
+		t.Fatalf("expected valid chain, got error: %v", err)
+	}
+}
+
+func TestVerifyImmutableAuditChain_DetectsTamper(t *testing.T) {
+	t0 := time.Date(2026, 4, 28, 23, 0, 0, 0, time.UTC)
+	e1 := immutableAuditEvent{
+		Action:     "prescription_updated",
+		EntityType: "prescription",
+		EntityID:   "rx1",
+		Detail:     "updated dosage",
+		EventTime:  t0,
+		PrevHash:   "",
+	}
+	e1.EventHash = computeImmutableAuditHash(e1.PrevHash, e1.Action, e1.EntityType, e1.EntityID, e1.Detail, e1.EventTime)
+
+	e2 := immutableAuditEvent{
+		Action:     "prescription_revoked",
+		EntityType: "prescription",
+		EntityID:   "rx1",
+		Detail:     "revoked",
+		EventTime:  t0.Add(2 * time.Minute),
+		PrevHash:   e1.EventHash,
+	}
+	e2.EventHash = computeImmutableAuditHash(e2.PrevHash, e2.Action, e2.EntityType, e2.EntityID, e2.Detail, e2.EventTime)
+
+	// Tamper detail after checksum creation.
+	e2.Detail = "tampered detail"
+	if err := verifyImmutableAuditChain([]immutableAuditEvent{e1, e2}); err == nil {
+		t.Fatal("expected tamper detection error")
+	}
+}
+
+func TestVerifyImmutableAuditChain_DetectsPrevHashBreak(t *testing.T) {
+	t0 := time.Date(2026, 4, 28, 23, 0, 0, 0, time.UTC)
+	e1 := immutableAuditEvent{
+		Action:     "appointment_status_changed",
+		EntityType: "appointment",
+		EntityID:   "a1",
+		Detail:     "approved",
+		EventTime:  t0,
+		PrevHash:   "",
+	}
+	e1.EventHash = computeImmutableAuditHash(e1.PrevHash, e1.Action, e1.EntityType, e1.EntityID, e1.Detail, e1.EventTime)
+
+	e2 := immutableAuditEvent{
+		Action:     "appointment_status_changed",
+		EntityType: "appointment",
+		EntityID:   "a1",
+		Detail:     "completed",
+		EventTime:  t0.Add(3 * time.Minute),
+		PrevHash:   "broken_prev_hash",
+	}
+	e2.EventHash = computeImmutableAuditHash(e2.PrevHash, e2.Action, e2.EntityType, e2.EntityID, e2.Detail, e2.EventTime)
+
+	if err := verifyImmutableAuditChain([]immutableAuditEvent{e1, e2}); err == nil {
+		t.Fatal("expected prev_hash break detection")
+	}
+}


### PR DESCRIPTION
## Summary
- add `immutable_audit_events` append-only ledger table with mutation-blocking DB triggers
- extend `writeAudit` to append tamper-evident SHA-256 hash-chain events alongside existing `audit_logs`
- add integrity tests for valid chain, tamper detection, and prev-hash break detection

## Test plan
- [x] `go test ./...`

## Definition of done check
- append-only mutation path blocked at DB layer for core immutable table
- checksum chain is deterministic and tamper-evident via test coverage
- existing admin audit query path remains intact (still reading `audit_logs`)