### PR TITLE
CG-06: enforce high-risk action guardrails with reason and double-confirm

### DIFF
--- a/backend/handlers/admin_user_lifecycle.go
+++ b/backend/handlers/admin_user_lifecycle.go
@@ -15,8 +15,10 @@ import (
 type AdminUserLifecycleHandler struct{}
 
 type updateLifecycleSettingsRequest struct {
-	NewUserWindowDays  int `json:"new_user_window_days"`
-	InactiveWindowDays int `json:"inactive_window_days"`
+	NewUserWindowDays  int    `json:"new_user_window_days"`
+	InactiveWindowDays int    `json:"inactive_window_days"`
+	Reason             string `json:"reason"`
+	Confirm            string `json:"confirm"`
 }
 
 type createLifecycleUserRequest struct {
@@ -32,6 +34,13 @@ type updateLifecycleUserRequest struct {
 
 type resetLifecyclePasswordRequest struct {
 	NewPassword string `json:"new_password"`
+	Reason      string `json:"reason"`
+	Confirm     string `json:"confirm"`
+}
+
+type deactivateLifecycleUserRequest struct {
+	Reason  string `json:"reason"`
+	Confirm string `json:"confirm"`
 }
 
 func NewAdminUserLifecycleHandler() *AdminUserLifecycleHandler {
@@ -192,8 +201,17 @@ func (h *AdminUserLifecycleHandler) UpdateSettings(c *gin.Context) {
 		c.JSON(http.StatusBadRequest, gin.H{"error": "inactive_window_days must be between 1 and 3650"})
 		return
 	}
-
-	if _, err := db.Pool.Exec(c.Request.Context(), `
+	if err := validateHighRiskGuardrail(req.Reason, req.Confirm); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+	tx, err := db.Pool.Begin(c.Request.Context())
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Internal error"})
+		return
+	}
+	defer func() { _ = tx.Rollback(c.Request.Context()) }()
+	if _, err := tx.Exec(c.Request.Context(), `
 		UPDATE admin_user_lifecycle_settings
 		SET
 			new_user_window_days = $1,
@@ -202,6 +220,16 @@ func (h *AdminUserLifecycleHandler) UpdateSettings(c *gin.Context) {
 			updated_at = NOW()
 		WHERE id = TRUE
 	`, req.NewUserWindowDays, req.InactiveWindowDays, claims.UserID); err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Internal error"})
+		return
+	}
+	detail := fmt.Sprintf("updated lifecycle settings new_user_window_days=%d inactive_window_days=%d", req.NewUserWindowDays, req.InactiveWindowDays)
+	detail = appendAuditReason(detail, req.Reason)
+	if err := writeAudit(c.Request.Context(), tx, claims.UserID, "admin_user_lifecycle_settings_updated", "admin_user_lifecycle_settings", "singleton", detail); err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Internal error"})
+		return
+	}
+	if err := tx.Commit(c.Request.Context()); err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "Internal error"})
 		return
 	}
@@ -365,6 +393,15 @@ func (h *AdminUserLifecycleHandler) DeactivateUser(c *gin.Context) {
 		c.JSON(http.StatusBadRequest, gin.H{"error": "Cannot deactivate current admin"})
 		return
 	}
+	var req deactivateLifecycleUserRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid request body"})
+		return
+	}
+	if err := validateHighRiskGuardrail(req.Reason, req.Confirm); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
 
 	tx, err := db.Pool.Begin(c.Request.Context())
 	if err != nil {
@@ -391,7 +428,8 @@ func (h *AdminUserLifecycleHandler) DeactivateUser(c *gin.Context) {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "Internal error"})
 		return
 	}
-	if err := writeAudit(c.Request.Context(), tx, claims.UserID, "admin_user_deactivated", "user", userID, "deactivated user "+email); err != nil {
+	detail := appendAuditReason("deactivated user "+email, req.Reason)
+	if err := writeAudit(c.Request.Context(), tx, claims.UserID, "admin_user_deactivated", "user", userID, detail); err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "Internal error"})
 		return
 	}
@@ -421,6 +459,10 @@ func (h *AdminUserLifecycleHandler) ResetPassword(c *gin.Context) {
 		c.JSON(http.StatusBadRequest, gin.H{"error": "new_password must be at least 6 characters"})
 		return
 	}
+	if err := validateHighRiskGuardrail(req.Reason, req.Confirm); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
 	hash, err := bcrypt.GenerateFromPassword([]byte(req.NewPassword), bcrypt.DefaultCost)
 	if err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "Internal error"})
@@ -443,7 +485,8 @@ func (h *AdminUserLifecycleHandler) ResetPassword(c *gin.Context) {
 		c.JSON(http.StatusNotFound, gin.H{"error": "User not found"})
 		return
 	}
-	if err := writeAudit(c.Request.Context(), tx, claims.UserID, "admin_user_password_reset", "user", userID, "password reset by admin"); err != nil {
+	detail := appendAuditReason("password reset by admin", req.Reason)
+	if err := writeAudit(c.Request.Context(), tx, claims.UserID, "admin_user_password_reset", "user", userID, detail); err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "Internal error"})
 		return
 	}

--- a/backend/handlers/admin_user_lifecycle_test.go
+++ b/backend/handlers/admin_user_lifecycle_test.go
@@ -40,6 +40,22 @@ func TestAdminUserLifecycle_UpdateSettings_BadRange(t *testing.T) {
 	}
 }
 
+func TestAdminUserLifecycle_UpdateSettings_RequiresGuardrail(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest("PUT", "/api/admin/user-lifecycle/settings", strings.NewReader(`{"new_user_window_days":30,"inactive_window_days":60,"reason":"short","confirm":"NO"}`))
+	c.Request.Header.Set("Content-Type", "application/json")
+	c.Set("claims", &Claims{UserID: uuid.New(), Role: "admin"})
+
+	h := NewAdminUserLifecycleHandler()
+	h.UpdateSettings(c)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d", w.Code)
+	}
+}
+
 func TestAdminUserLifecycle_ListUsers_Unauthorized(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 	w := httptest.NewRecorder()
@@ -104,12 +120,46 @@ func TestAdminUserLifecycle_DeactivateUser_CannotDeactivateSelf(t *testing.T) {
 	}
 }
 
+func TestAdminUserLifecycle_DeactivateUser_RequiresGuardrailFields(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Params = gin.Params{{Key: "id", Value: uuid.NewString()}}
+	c.Request = httptest.NewRequest("PATCH", "/api/admin/user-lifecycle/users/id/deactivate", strings.NewReader(`{"reason":"short","confirm":"NO"}`))
+	c.Request.Header.Set("Content-Type", "application/json")
+	c.Set("claims", &Claims{UserID: uuid.New(), Role: "admin"})
+
+	h := NewAdminUserLifecycleHandler()
+	h.DeactivateUser(c)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d", w.Code)
+	}
+}
+
 func TestAdminUserLifecycle_ResetPassword_BadPayload(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 	w := httptest.NewRecorder()
 	c, _ := gin.CreateTestContext(w)
 	c.Params = gin.Params{{Key: "id", Value: uuid.NewString()}}
 	c.Request = httptest.NewRequest("POST", "/api/admin/user-lifecycle/users/id/reset-password", strings.NewReader(`{"new_password":"123"}`))
+	c.Request.Header.Set("Content-Type", "application/json")
+	c.Set("claims", &Claims{UserID: uuid.New(), Role: "admin"})
+
+	h := NewAdminUserLifecycleHandler()
+	h.ResetPassword(c)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d", w.Code)
+	}
+}
+
+func TestAdminUserLifecycle_ResetPassword_RequiresGuardrailFields(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Params = gin.Params{{Key: "id", Value: uuid.NewString()}}
+	c.Request = httptest.NewRequest("POST", "/api/admin/user-lifecycle/users/id/reset-password", strings.NewReader(`{"new_password":"newpass123","reason":"ok reason","confirm":"not-confirm"}`))
 	c.Request.Header.Set("Content-Type", "application/json")
 	c.Set("claims", &Claims{UserID: uuid.New(), Role: "admin"})
 

--- a/backend/handlers/high_risk_guardrails.go
+++ b/backend/handlers/high_risk_guardrails.go
@@ -1,0 +1,26 @@
+package handlers
+
+import (
+	"fmt"
+	"strings"
+	"unicode/utf8"
+)
+
+func validateHighRiskGuardrail(reason, confirm string) error {
+	r := strings.TrimSpace(reason)
+	if utf8.RuneCountInString(r) < 8 {
+		return fmt.Errorf("reason must be at least 8 characters")
+	}
+	if strings.ToUpper(strings.TrimSpace(confirm)) != "CONFIRM" {
+		return fmt.Errorf("confirm must equal CONFIRM")
+	}
+	return nil
+}
+
+func appendAuditReason(detail, reason string) string {
+	r := strings.TrimSpace(reason)
+	if r == "" {
+		return strings.TrimSpace(detail)
+	}
+	return fmt.Sprintf("%s | reason=%s", strings.TrimSpace(detail), r)
+}

--- a/backend/handlers/high_risk_guardrails_test.go
+++ b/backend/handlers/high_risk_guardrails_test.go
@@ -1,0 +1,22 @@
+package handlers
+
+import "testing"
+
+func TestValidateHighRiskGuardrail(t *testing.T) {
+	if err := validateHighRiskGuardrail("important clinical reason", "CONFIRM"); err != nil {
+		t.Fatalf("expected valid payload, got %v", err)
+	}
+	if err := validateHighRiskGuardrail("short", "CONFIRM"); err == nil {
+		t.Fatal("expected short reason to fail")
+	}
+	if err := validateHighRiskGuardrail("valid enough reason", "NO"); err == nil {
+		t.Fatal("expected invalid confirm to fail")
+	}
+}
+
+func TestAppendAuditReason(t *testing.T) {
+	d := appendAuditReason("deactivated user demo@healthonyx.com", "duplicate account request")
+	if d == "deactivated user demo@healthonyx.com" {
+		t.Fatal("expected reason to be appended")
+	}
+}

--- a/backend/handlers/prescriptions.go
+++ b/backend/handlers/prescriptions.go
@@ -63,16 +63,16 @@ func (h *PrescriptionsHandler) ListByPatient(c *gin.Context) {
 	defer rows.Close()
 
 	type row struct {
-		ID              uuid.UUID `json:"id"`
-		PatientID       uuid.UUID `json:"patient_id"`
-		DoctorID        uuid.UUID `json:"doctor_id"`
-		MedicationName  string    `json:"medication_name"`
-		Dosage          string    `json:"dosage"`
-		Frequency       string    `json:"frequency"`
-		DurationDays    int       `json:"duration_days"`
-		Instructions    string    `json:"instructions"`
-		Status          string    `json:"status"`
-		CreatedAt       string    `json:"created_at"`
+		ID             uuid.UUID `json:"id"`
+		PatientID      uuid.UUID `json:"patient_id"`
+		DoctorID       uuid.UUID `json:"doctor_id"`
+		MedicationName string    `json:"medication_name"`
+		Dosage         string    `json:"dosage"`
+		Frequency      string    `json:"frequency"`
+		DurationDays   int       `json:"duration_days"`
+		Instructions   string    `json:"instructions"`
+		Status         string    `json:"status"`
+		CreatedAt      string    `json:"created_at"`
 	}
 	var out []row
 	for rows.Next() {
@@ -103,6 +103,11 @@ type updatePrescriptionBody struct {
 	Frequency      *string `json:"frequency"`
 	DurationDays   *int    `json:"duration_days"`
 	Instructions   *string `json:"instructions"`
+}
+
+type revokePrescriptionBody struct {
+	Reason  string `json:"reason"`
+	Confirm string `json:"confirm"`
 }
 
 func reminderTimesForFrequency(frequency string) []string {
@@ -399,6 +404,15 @@ func (h *PrescriptionsHandler) Revoke(c *gin.Context) {
 		c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid id"})
 		return
 	}
+	var body revokePrescriptionBody
+	if err := c.ShouldBindJSON(&body); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid request body"})
+		return
+	}
+	if err := validateHighRiskGuardrail(body.Reason, body.Confirm); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
 
 	var doctorID, patientID uuid.UUID
 	err = db.Pool.QueryRow(c.Request.Context(), `SELECT doctor_id, patient_id FROM prescriptions WHERE id = $1`, id).Scan(&doctorID, &patientID)
@@ -411,15 +425,30 @@ func (h *PrescriptionsHandler) Revoke(c *gin.Context) {
 		return
 	}
 
-	_, err = db.Pool.Exec(c.Request.Context(), `UPDATE prescriptions SET status = 'revoked' WHERE id = $1 AND status = 'active'`, id)
+	tx, err := db.Pool.Begin(c.Request.Context())
 	if err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "Internal error"})
 		return
 	}
-	_, _ = db.Pool.Exec(c.Request.Context(), `
+	defer func() { _ = tx.Rollback(c.Request.Context()) }()
+
+	_, err = tx.Exec(c.Request.Context(), `UPDATE prescriptions SET status = 'revoked' WHERE id = $1 AND status = 'active'`, id)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Internal error"})
+		return
+	}
+	_, _ = tx.Exec(c.Request.Context(), `
 		INSERT INTO notifications (user_id, title, body, channel, status, scheduled_for)
 		VALUES ($1, $2, $3, 'in_app', 'pending', NOW())
 	`, patientID, "Prescription revoked", "One of your prescriptions has been revoked by your care team.")
+	if err := writeAudit(c.Request.Context(), tx, claims.UserID, "prescription_revoked", "prescription", id.String(), appendAuditReason("prescription revoked", body.Reason)); err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Internal error"})
+		return
+	}
+	if err := tx.Commit(c.Request.Context()); err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Internal error"})
+		return
+	}
 	c.JSON(http.StatusOK, gin.H{"id": id, "patient_id": patientID, "status": "revoked"})
 }
 

--- a/backend/handlers/prescriptions_guardrails_test.go
+++ b/backend/handlers/prescriptions_guardrails_test.go
@@ -1,0 +1,28 @@
+package handlers
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
+)
+
+func TestPrescriptions_Revoke_RequiresGuardrailFields(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Params = gin.Params{{Key: "id", Value: uuid.NewString()}}
+	c.Request = httptest.NewRequest("PATCH", "/api/prescriptions/id/revoke", strings.NewReader(`{"reason":"tiny","confirm":"no"}`))
+	c.Request.Header.Set("Content-Type", "application/json")
+	c.Set("claims", &Claims{UserID: uuid.New(), Role: "doctor"})
+
+	h := NewPrescriptionsHandler()
+	h.Revoke(c)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d", w.Code)
+	}
+}

--- a/frontend/src/app/components/admin-management/admin-management.component.html
+++ b/frontend/src/app/components/admin-management/admin-management.component.html
@@ -40,6 +40,14 @@
       />
     </label>
     <p class="muted">Last updated: {{ settings.updated_at || 'n/a' }}</p>
+    <label>
+      <span>Change reason</span>
+      <input type="text" name="settingsReason" [(ngModel)]="settingsGuard.reason" placeholder="Why is this sensitive change needed?" />
+    </label>
+    <label>
+      <span>Type CONFIRM</span>
+      <input type="text" name="settingsConfirm" [(ngModel)]="settingsGuard.confirm" />
+    </label>
     <button type="submit" [disabled]="saving">{{ saving ? 'Saving...' : 'Save settings' }}</button>
   </form>
 
@@ -136,8 +144,48 @@
           >
             Reset password
           </button>
+          <label>
+            <span>Reset reason</span>
+            <input
+              type="text"
+              name="resetReason"
+              [(ngModel)]="resetGuard.reason"
+              [disabled]="!selectedUserId"
+              data-cy="admin-user-reset-reason"
+            />
+          </label>
+          <label>
+            <span>Type CONFIRM</span>
+            <input
+              type="text"
+              name="resetConfirm"
+              [(ngModel)]="resetGuard.confirm"
+              [disabled]="!selectedUserId"
+              data-cy="admin-user-reset-confirm"
+            />
+          </label>
         </form>
 
+        <label>
+          <span>Deactivation reason</span>
+          <input
+            type="text"
+            name="deactivateReason"
+            [(ngModel)]="deactivateGuard.reason"
+            [disabled]="!selectedUserId"
+            data-cy="admin-user-deactivate-reason"
+          />
+        </label>
+        <label>
+          <span>Type CONFIRM</span>
+          <input
+            type="text"
+            name="deactivateConfirm"
+            [(ngModel)]="deactivateGuard.confirm"
+            [disabled]="!selectedUserId"
+            data-cy="admin-user-deactivate-confirm"
+          />
+        </label>
         <button
           type="button"
           class="danger"

--- a/frontend/src/app/components/admin-management/admin-management.component.spec.ts
+++ b/frontend/src/app/components/admin-management/admin-management.component.spec.ts
@@ -126,9 +126,13 @@ describe('AdminManagementComponent', () => {
 
   it('deactivates selected user', () => {
     fixture.componentInstance.selectUser('u1');
+    fixture.componentInstance.deactivateGuard.reason = 'Requested by compliance team';
+    fixture.componentInstance.deactivateGuard.confirm = 'CONFIRM';
     fixture.componentInstance.deactivateSelectedUser();
     const deactivateReq = httpMock.expectOne('/api/admin/user-lifecycle/users/u1/deactivate');
     expect(deactivateReq.request.method).toBe('PATCH');
+    expect(deactivateReq.request.body.reason).toContain('Requested by compliance team');
+    expect(deactivateReq.request.body.confirm).toBe('CONFIRM');
     deactivateReq.flush({
       id: 'u1',
       status: 'deactivated'
@@ -152,15 +156,27 @@ describe('AdminManagementComponent', () => {
   it('resets selected user password', () => {
     fixture.componentInstance.selectUser('u1');
     fixture.componentInstance.resetForm.newPassword = 'newpass123';
+    fixture.componentInstance.resetGuard.reason = 'Compromised credentials report';
+    fixture.componentInstance.resetGuard.confirm = 'CONFIRM';
     fixture.componentInstance.resetSelectedPassword();
     const resetReq = httpMock.expectOne('/api/admin/user-lifecycle/users/u1/reset-password');
     expect(resetReq.request.method).toBe('POST');
+    expect(resetReq.request.body.reason).toContain('Compromised credentials report');
+    expect(resetReq.request.body.confirm).toBe('CONFIRM');
     resetReq.flush({
       id: 'u1',
       password_reset: true
     });
     expect(fixture.componentInstance.resetForm.newPassword).toBe('');
     expect(fixture.componentInstance.success).toBe('Password reset complete.');
+  });
+
+  it('blocks deactivation when reason/confirm missing', () => {
+    fixture.componentInstance.selectUser('u1');
+    fixture.componentInstance.deactivateGuard.reason = 'short';
+    fixture.componentInstance.deactivateGuard.confirm = 'NO';
+    fixture.componentInstance.deactivateSelectedUser();
+    expect(fixture.componentInstance.error).toContain('Deactivate requires a reason');
   });
 });
 

--- a/frontend/src/app/components/admin-management/admin-management.component.ts
+++ b/frontend/src/app/components/admin-management/admin-management.component.ts
@@ -42,6 +42,18 @@ export class AdminManagementComponent implements OnInit {
   resetForm = {
     newPassword: ''
   };
+  settingsGuard = {
+    reason: '',
+    confirm: ''
+  };
+  deactivateGuard = {
+    reason: '',
+    confirm: ''
+  };
+  resetGuard = {
+    reason: '',
+    confirm: ''
+  };
 
   constructor(private readonly api: AdminUserLifecycleService) {}
 
@@ -80,13 +92,19 @@ export class AdminManagementComponent implements OnInit {
   }
 
   save(): void {
+    if (!this.validGuardrail(this.settingsGuard.reason, this.settingsGuard.confirm)) {
+      this.error = 'Settings update requires a reason (min 8 chars) and CONFIRM.';
+      return;
+    }
     this.saving = true;
     this.error = null;
     this.success = null;
     this.api
       .updateSettings({
         new_user_window_days: Number(this.form.new_user_window_days),
-        inactive_window_days: Number(this.form.inactive_window_days)
+        inactive_window_days: Number(this.form.inactive_window_days),
+        reason: this.settingsGuard.reason.trim(),
+        confirm: this.settingsGuard.confirm.trim().toUpperCase()
       })
       .subscribe({
         next: (res) => {
@@ -96,7 +114,7 @@ export class AdminManagementComponent implements OnInit {
           this.saving = false;
         },
         error: () => {
-          this.error = 'Could not update settings.';
+          this.error = 'Could not update settings. Reason + CONFIRM are required.';
           this.saving = false;
         }
       });
@@ -165,39 +183,59 @@ export class AdminManagementComponent implements OnInit {
     if (!this.selectedUserId) {
       return;
     }
+    if (!this.validGuardrail(this.deactivateGuard.reason, this.deactivateGuard.confirm)) {
+      this.error = 'Deactivate requires a reason (min 8 chars) and CONFIRM.';
+      return;
+    }
     this.userBusy = true;
     this.error = null;
     this.success = null;
-    this.api.deactivateUser(this.selectedUserId).subscribe({
+    this.api
+      .deactivateUser(this.selectedUserId, {
+        reason: this.deactivateGuard.reason.trim(),
+        confirm: this.deactivateGuard.confirm.trim().toUpperCase()
+      })
+      .subscribe({
       next: () => {
         this.success = 'User deactivated.';
+        this.deactivateGuard = { reason: '', confirm: '' };
         this.refreshUsers();
       },
       error: () => {
         this.userBusy = false;
         this.error = 'Could not deactivate user.';
       }
-    });
+      });
   }
 
   resetSelectedPassword(): void {
     if (!this.selectedUserId || !this.resetForm.newPassword.trim()) {
       return;
     }
+    if (!this.validGuardrail(this.resetGuard.reason, this.resetGuard.confirm)) {
+      this.error = 'Reset password requires a reason (min 8 chars) and CONFIRM.';
+      return;
+    }
     this.userBusy = true;
     this.error = null;
     this.success = null;
-    this.api.resetPassword(this.selectedUserId, this.resetForm.newPassword).subscribe({
+    this.api
+      .resetPassword(this.selectedUserId, this.resetForm.newPassword, {
+        reason: this.resetGuard.reason.trim(),
+        confirm: this.resetGuard.confirm.trim().toUpperCase()
+      })
+      .subscribe({
       next: () => {
         this.success = 'Password reset complete.';
         this.resetForm.newPassword = '';
+        this.resetGuard = { reason: '', confirm: '' };
         this.userBusy = false;
       },
       error: () => {
         this.userBusy = false;
         this.error = 'Could not reset password.';
       }
-    });
+      });
   }
 
   private refreshUsers(): void {
@@ -217,5 +255,9 @@ export class AdminManagementComponent implements OnInit {
         this.error = 'Could not refresh users.';
       }
     });
+  }
+
+  private validGuardrail(reason: string, confirm: string): boolean {
+    return reason.trim().length >= 8 && confirm.trim().toUpperCase() === 'CONFIRM';
   }
 }

--- a/frontend/src/app/services/admin-user-lifecycle.service.ts
+++ b/frontend/src/app/services/admin-user-lifecycle.service.ts
@@ -26,6 +26,8 @@ export class AdminUserLifecycleService {
   updateSettings(payload: {
     new_user_window_days: number;
     inactive_window_days: number;
+    reason: string;
+    confirm: string;
   }): Observable<AdminLifecycleSettingsKpisResponse> {
     return this.http.put<AdminLifecycleSettingsKpisResponse>(ApiContract.admin.userLifecycleSettings, payload);
   }
@@ -55,14 +57,18 @@ export class AdminUserLifecycleService {
     );
   }
 
-  deactivateUser(id: string): Observable<{ id: string; status: string }> {
-    return this.http.patch<{ id: string; status: string }>(ApiContract.admin.userLifecycleDeactivate(id), {});
+  deactivateUser(id: string, payload: { reason: string; confirm: string }): Observable<{ id: string; status: string }> {
+    return this.http.patch<{ id: string; status: string }>(ApiContract.admin.userLifecycleDeactivate(id), payload);
   }
 
-  resetPassword(id: string, newPassword: string): Observable<{ id: string; password_reset: boolean }> {
+  resetPassword(
+    id: string,
+    newPassword: string,
+    guardrail: { reason: string; confirm: string }
+  ): Observable<{ id: string; password_reset: boolean }> {
     return this.http.post<{ id: string; password_reset: boolean }>(
       ApiContract.admin.userLifecycleResetPassword(id),
-      { new_password: newPassword }
+      { new_password: newPassword, reason: guardrail.reason, confirm: guardrail.confirm }
     );
   }
 }


### PR DESCRIPTION
## Summary
- Enforce backend high-risk guardrail policy requiring `reason` + `CONFIRM` for deactivation, password reset, prescription revoke, and lifecycle settings updates.
- Add backend policy tests and audit-reason assertion tests for guardrail behavior.
- Add admin UI guardrails + interaction tests to require reason and double-confirm before sensitive actions.

## Test plan
- [x] `go test ./...`
- [x] `go run ./cmd/openapi-sync-check`
- [x] `npm run test:ci`