### PR TITLE
CG-07: implement provider callback ingestion and suppression handling

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -36,6 +36,8 @@ NOTIFY_MAX_RETRIES=3
 # Provider credentials (leave blank to disable provider)
 # SENDGRID_API_KEY=
 # SENDGRID_FROM_EMAIL=noreply@example.com
+# SENDGRID_WEBHOOK_SECRET=replace-with-sendgrid-webhook-secret
 # TWILIO_ACCOUNT_SID=
 # TWILIO_AUTH_TOKEN=
 # TWILIO_FROM_NUMBER=+15550001111
+# TWILIO_WEBHOOK_SECRET=replace-with-twilio-webhook-secret

--- a/backend/config/config.go
+++ b/backend/config/config.go
@@ -13,24 +13,26 @@ func init() {
 }
 
 type Config struct {
-	DatabaseURL      string
-	JWTSecret        string
-	Port             string
-	CORSOrigins      string // Comma-separated, e.g. "http://localhost:4200,http://localhost:3000"
-	NominatimBaseURL string // OpenStreetMap Nominatim (or self-hosted). Empty = public default.
-	GeocodeUserAgent string // Required-style identification for Nominatim; override in production.
-	UploadDir        string // Patient file uploads (filesystem); default data/uploads
-	AIEnabled        bool   // Global AI kill switch. false => always use fallback behavior.
-	OllamaHost       string // Ollama base URL, e.g. http://127.0.0.1:11434
-	OllamaModel      string // Default Ollama model name.
-	OllamaTimeoutMS  int    // Timeout for Ollama HTTP calls in milliseconds.
-	NotifyIntervalMS int    // Worker polling interval for notification queue.
-	NotifyMaxRetries int    // Maximum automatic retries before dead-letter.
-	SendGridAPIKey   string // Optional SendGrid API key.
-	SendGridFrom     string // Optional sender email for SendGrid.
-	TwilioAccountSID string // Optional Twilio account SID.
-	TwilioAuthToken  string // Optional Twilio auth token.
-	TwilioFromNumber string // Optional Twilio sender number.
+	DatabaseURL           string
+	JWTSecret             string
+	Port                  string
+	CORSOrigins           string // Comma-separated, e.g. "http://localhost:4200,http://localhost:3000"
+	NominatimBaseURL      string // OpenStreetMap Nominatim (or self-hosted). Empty = public default.
+	GeocodeUserAgent      string // Required-style identification for Nominatim; override in production.
+	UploadDir             string // Patient file uploads (filesystem); default data/uploads
+	AIEnabled             bool   // Global AI kill switch. false => always use fallback behavior.
+	OllamaHost            string // Ollama base URL, e.g. http://127.0.0.1:11434
+	OllamaModel           string // Default Ollama model name.
+	OllamaTimeoutMS       int    // Timeout for Ollama HTTP calls in milliseconds.
+	NotifyIntervalMS      int    // Worker polling interval for notification queue.
+	NotifyMaxRetries      int    // Maximum automatic retries before dead-letter.
+	SendGridAPIKey        string // Optional SendGrid API key.
+	SendGridFrom          string // Optional sender email for SendGrid.
+	SendGridWebhookSecret string // Optional webhook HMAC secret for SendGrid callbacks.
+	TwilioAccountSID      string // Optional Twilio account SID.
+	TwilioAuthToken       string // Optional Twilio auth token.
+	TwilioFromNumber      string // Optional Twilio sender number.
+	TwilioWebhookSecret   string // Optional webhook HMAC secret for Twilio callbacks.
 }
 
 func Load() *Config {
@@ -51,24 +53,26 @@ func Load() *Config {
 		ollamaModel = "llama3.1:8b"
 	}
 	return &Config{
-		DatabaseURL:      os.Getenv("DATABASE_URL"),
-		JWTSecret:        os.Getenv("JWT_SECRET"),
-		Port:             port,
-		CORSOrigins:      os.Getenv("CORS_ORIGINS"),
-		NominatimBaseURL: os.Getenv("NOMINATIM_BASE_URL"),
-		GeocodeUserAgent: os.Getenv("GEOCODE_USER_AGENT"),
-		UploadDir:        uploadDir,
-		AIEnabled:        strings.EqualFold(strings.TrimSpace(os.Getenv("AI_ENABLED")), "true"),
-		OllamaHost:       ollamaHost,
-		OllamaModel:      ollamaModel,
-		OllamaTimeoutMS:  parsePositiveIntWithDefault(os.Getenv("OLLAMA_TIMEOUT_MS"), 7000),
-		NotifyIntervalMS: parsePositiveIntWithDefault(os.Getenv("NOTIFY_WORKER_INTERVAL_MS"), 5000),
-		NotifyMaxRetries: parseIntInRangeWithDefault(os.Getenv("NOTIFY_MAX_RETRIES"), 1, 20, 3),
-		SendGridAPIKey:   strings.TrimSpace(os.Getenv("SENDGRID_API_KEY")),
-		SendGridFrom:     strings.TrimSpace(os.Getenv("SENDGRID_FROM_EMAIL")),
-		TwilioAccountSID: strings.TrimSpace(os.Getenv("TWILIO_ACCOUNT_SID")),
-		TwilioAuthToken:  strings.TrimSpace(os.Getenv("TWILIO_AUTH_TOKEN")),
-		TwilioFromNumber: strings.TrimSpace(os.Getenv("TWILIO_FROM_NUMBER")),
+		DatabaseURL:           os.Getenv("DATABASE_URL"),
+		JWTSecret:             os.Getenv("JWT_SECRET"),
+		Port:                  port,
+		CORSOrigins:           os.Getenv("CORS_ORIGINS"),
+		NominatimBaseURL:      os.Getenv("NOMINATIM_BASE_URL"),
+		GeocodeUserAgent:      os.Getenv("GEOCODE_USER_AGENT"),
+		UploadDir:             uploadDir,
+		AIEnabled:             strings.EqualFold(strings.TrimSpace(os.Getenv("AI_ENABLED")), "true"),
+		OllamaHost:            ollamaHost,
+		OllamaModel:           ollamaModel,
+		OllamaTimeoutMS:       parsePositiveIntWithDefault(os.Getenv("OLLAMA_TIMEOUT_MS"), 7000),
+		NotifyIntervalMS:      parsePositiveIntWithDefault(os.Getenv("NOTIFY_WORKER_INTERVAL_MS"), 5000),
+		NotifyMaxRetries:      parseIntInRangeWithDefault(os.Getenv("NOTIFY_MAX_RETRIES"), 1, 20, 3),
+		SendGridAPIKey:        strings.TrimSpace(os.Getenv("SENDGRID_API_KEY")),
+		SendGridFrom:          strings.TrimSpace(os.Getenv("SENDGRID_FROM_EMAIL")),
+		SendGridWebhookSecret: strings.TrimSpace(os.Getenv("SENDGRID_WEBHOOK_SECRET")),
+		TwilioAccountSID:      strings.TrimSpace(os.Getenv("TWILIO_ACCOUNT_SID")),
+		TwilioAuthToken:       strings.TrimSpace(os.Getenv("TWILIO_AUTH_TOKEN")),
+		TwilioFromNumber:      strings.TrimSpace(os.Getenv("TWILIO_FROM_NUMBER")),
+		TwilioWebhookSecret:   strings.TrimSpace(os.Getenv("TWILIO_WEBHOOK_SECRET")),
 	}
 }
 

--- a/backend/db/db.go
+++ b/backend/db/db.go
@@ -391,6 +391,36 @@ func Migrate(ctx context.Context) error {
 
 		CREATE INDEX IF NOT EXISTS idx_notifications_user ON notifications(user_id);
 
+		CREATE TABLE IF NOT EXISTS provider_callback_events (
+			id               UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+			provider         TEXT NOT NULL CHECK (provider IN ('sendgrid', 'twilio')),
+			event_id         TEXT NOT NULL,
+			event_type       TEXT NOT NULL,
+			notification_id  UUID REFERENCES notifications(id) ON DELETE SET NULL,
+			recipient        TEXT NOT NULL DEFAULT '',
+			signature_valid  BOOLEAN NOT NULL DEFAULT FALSE,
+			payload_json     JSONB NOT NULL,
+			occurred_at      TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+			created_at       TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+			UNIQUE(provider, event_id)
+		);
+		CREATE INDEX IF NOT EXISTS idx_provider_callback_events_notification ON provider_callback_events(notification_id, created_at DESC);
+		CREATE INDEX IF NOT EXISTS idx_provider_callback_events_provider_time ON provider_callback_events(provider, created_at DESC);
+
+		CREATE TABLE IF NOT EXISTS notification_suppressions (
+			id             UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+			provider       TEXT NOT NULL CHECK (provider IN ('sendgrid', 'twilio')),
+			recipient      TEXT NOT NULL,
+			reason_code    TEXT NOT NULL,
+			reason_detail  TEXT NOT NULL DEFAULT '',
+			active         BOOLEAN NOT NULL DEFAULT TRUE,
+			last_event_at  TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+			created_at     TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+			updated_at     TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+			UNIQUE(provider, recipient)
+		);
+		CREATE INDEX IF NOT EXISTS idx_notification_suppressions_active ON notification_suppressions(provider, recipient) WHERE active = TRUE;
+
 		CREATE TABLE IF NOT EXISTS message_thread_reads (
 			thread_id    UUID NOT NULL REFERENCES message_threads(id) ON DELETE CASCADE,
 			user_id      UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,

--- a/backend/handlers/provider_callbacks.go
+++ b/backend/handlers/provider_callbacks.go
@@ -1,0 +1,273 @@
+package handlers
+
+import (
+	"crypto/hmac"
+	"crypto/sha1"
+	"crypto/sha256"
+	"database/sql"
+	"encoding/base64"
+	"encoding/hex"
+	"encoding/json"
+	"net/http"
+	"strings"
+
+	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
+	"github.com/healthonyx/backend/db"
+)
+
+type ProviderCallbacksHandler struct {
+	sendGridSecret string
+	twilioSecret   string
+}
+
+func NewProviderCallbacksHandler(sendGridSecret, twilioSecret string) *ProviderCallbacksHandler {
+	return &ProviderCallbacksHandler{
+		sendGridSecret: strings.TrimSpace(sendGridSecret),
+		twilioSecret:   strings.TrimSpace(twilioSecret),
+	}
+}
+
+type sendGridEvent struct {
+	Event      string            `json:"event"`
+	Timestamp  int64             `json:"timestamp"`
+	Email      string            `json:"email"`
+	Reason     string            `json:"reason"`
+	SGMessage  string            `json:"sg_message_id"`
+	UniqueArgs map[string]string `json:"unique_args"`
+}
+
+func verifySendGridSignature(secret, ts, body, gotSig string) bool {
+	if strings.TrimSpace(secret) == "" {
+		return false
+	}
+	mac := hmac.New(sha256.New, []byte(secret))
+	_, _ = mac.Write([]byte(strings.TrimSpace(ts) + "." + body))
+	wantHex := hex.EncodeToString(mac.Sum(nil))
+	got := strings.ToLower(strings.TrimSpace(gotSig))
+	return hmac.Equal([]byte(wantHex), []byte(got))
+}
+
+func verifyTwilioSignature(secret, body, gotSig string) bool {
+	if strings.TrimSpace(secret) == "" {
+		return false
+	}
+	mac := hmac.New(sha1.New, []byte(secret))
+	_, _ = mac.Write([]byte(body))
+	want := base64.StdEncoding.EncodeToString(mac.Sum(nil))
+	return hmac.Equal([]byte(strings.TrimSpace(want)), []byte(strings.TrimSpace(gotSig)))
+}
+
+func sendGridFailureTaxonomy(event string) (reason string, suppress bool) {
+	switch strings.ToLower(strings.TrimSpace(event)) {
+	case "bounce":
+		return "bounce", true
+	case "dropped":
+		return "dropped", true
+	case "spamreport":
+		return "spam_report", true
+	case "blocked":
+		return "blocked", true
+	case "deferred":
+		return "deferred", false
+	default:
+		return "provider_failure", false
+	}
+}
+
+func twilioFailureTaxonomy(status string) (reason string, suppress bool) {
+	switch strings.ToLower(strings.TrimSpace(status)) {
+	case "undelivered":
+		return "undelivered", true
+	case "failed":
+		return "failed", true
+	default:
+		return "provider_failure", false
+	}
+}
+
+func (h *ProviderCallbacksHandler) SendGridWebhook(c *gin.Context) {
+	bodyBytes, err := c.GetRawData()
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid payload"})
+		return
+	}
+	body := string(bodyBytes)
+	ts := c.GetHeader("X-Twilio-Email-Event-Webhook-Timestamp")
+	sig := c.GetHeader("X-Twilio-Email-Event-Webhook-Signature")
+	valid := verifySendGridSignature(h.sendGridSecret, ts, body, sig)
+	if !valid {
+		c.JSON(http.StatusUnauthorized, gin.H{"error": "invalid webhook signature"})
+		return
+	}
+
+	var events []sendGridEvent
+	if err := json.Unmarshal(bodyBytes, &events); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid payload"})
+		return
+	}
+	processed := 0
+	duplicates := 0
+	for _, e := range events {
+		eventID := strings.TrimSpace(e.SGMessage)
+		if eventID == "" {
+			continue
+		}
+		var notifID *uuid.UUID
+		if e.UniqueArgs != nil {
+			if rawID := strings.TrimSpace(e.UniqueArgs["notification_id"]); rawID != "" {
+				if id, parseErr := uuid.Parse(rawID); parseErr == nil {
+					notifID = &id
+				}
+			}
+		}
+		payloadJSON, _ := json.Marshal(e)
+		cmd, insErr := db.Pool.Exec(c.Request.Context(), `
+			INSERT INTO provider_callback_events(provider, event_id, event_type, notification_id, recipient, signature_valid, payload_json, occurred_at)
+			VALUES ('sendgrid', $1, $2, $3, $4, TRUE, $5, to_timestamp($6))
+			ON CONFLICT(provider, event_id) DO NOTHING
+		`, eventID, strings.ToLower(strings.TrimSpace(e.Event)), nullableUUID(notifID), strings.TrimSpace(strings.ToLower(e.Email)), payloadJSON, e.Timestamp)
+		if insErr != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "internal error"})
+			return
+		}
+		if cmd.RowsAffected() == 0 {
+			duplicates++
+			continue
+		}
+		processed++
+		h.reconcileSendGridEvent(c, e, notifID)
+	}
+	c.JSON(http.StatusOK, gin.H{"processed": processed, "duplicates": duplicates})
+}
+
+func (h *ProviderCallbacksHandler) reconcileSendGridEvent(c *gin.Context, e sendGridEvent, notifID *uuid.UUID) {
+	event := strings.ToLower(strings.TrimSpace(e.Event))
+	if notifID != nil {
+		switch event {
+		case "delivered", "processed":
+			_, _ = db.Pool.Exec(c.Request.Context(), `
+				UPDATE notifications
+				SET status = 'sent', provider = 'sendgrid', sent_at = NOW(), last_error = ''
+				WHERE id = $1
+			`, *notifID)
+		default:
+			reason, suppress := sendGridFailureTaxonomy(event)
+			_, _ = db.Pool.Exec(c.Request.Context(), `
+				UPDATE notifications
+				SET status = 'failed', provider = 'sendgrid', last_error = $2, next_retry_at = NULL
+				WHERE id = $1
+			`, *notifID, reason+":"+strings.TrimSpace(e.Reason))
+			if suppress {
+				_, _ = db.Pool.Exec(c.Request.Context(), `
+					INSERT INTO notification_dead_letters(notification_id, channel, provider, final_error, attempt_count)
+					VALUES($1, 'email', 'sendgrid', $2, 1)
+					ON CONFLICT(notification_id) DO UPDATE SET final_error = EXCLUDED.final_error, provider = EXCLUDED.provider, attempt_count = GREATEST(notification_dead_letters.attempt_count, EXCLUDED.attempt_count), created_at = NOW()
+				`, *notifID, reason+":"+strings.TrimSpace(e.Reason))
+			}
+		}
+	}
+	reason, suppress := sendGridFailureTaxonomy(event)
+	if suppress && strings.TrimSpace(e.Email) != "" {
+		_, _ = db.Pool.Exec(c.Request.Context(), `
+			INSERT INTO notification_suppressions(provider, recipient, reason_code, reason_detail, active, last_event_at, updated_at)
+			VALUES('sendgrid', $1, $2, $3, TRUE, NOW(), NOW())
+			ON CONFLICT(provider, recipient)
+			DO UPDATE SET reason_code = EXCLUDED.reason_code, reason_detail = EXCLUDED.reason_detail, active = TRUE, last_event_at = NOW(), updated_at = NOW()
+		`, strings.TrimSpace(strings.ToLower(e.Email)), reason, strings.TrimSpace(e.Reason))
+	}
+}
+
+func (h *ProviderCallbacksHandler) TwilioWebhook(c *gin.Context) {
+	bodyBytes, err := c.GetRawData()
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid payload"})
+		return
+	}
+	body := string(bodyBytes)
+	sig := c.GetHeader("X-Twilio-Signature")
+	if !verifyTwilioSignature(h.twilioSecret, body, sig) {
+		c.JSON(http.StatusUnauthorized, gin.H{"error": "invalid webhook signature"})
+		return
+	}
+	messageSID := strings.TrimSpace(c.PostForm("MessageSid"))
+	if messageSID == "" {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "missing MessageSid"})
+		return
+	}
+	status := strings.ToLower(strings.TrimSpace(c.PostForm("MessageStatus")))
+	to := strings.TrimSpace(c.PostForm("To"))
+	errMsg := strings.TrimSpace(c.PostForm("ErrorMessage"))
+	notificationIDRaw := strings.TrimSpace(c.PostForm("NotificationId"))
+	var notifID *uuid.UUID
+	if notificationIDRaw != "" {
+		if id, parseErr := uuid.Parse(notificationIDRaw); parseErr == nil {
+			notifID = &id
+		}
+	}
+	payloadJSON, _ := json.Marshal(map[string]string{
+		"message_sid":     messageSID,
+		"message_status":  status,
+		"to":              to,
+		"error_message":   errMsg,
+		"notification_id": notificationIDRaw,
+	})
+	cmd, insErr := db.Pool.Exec(c.Request.Context(), `
+		INSERT INTO provider_callback_events(provider, event_id, event_type, notification_id, recipient, signature_valid, payload_json, occurred_at)
+		VALUES('twilio', $1, $2, $3, $4, TRUE, $5, NOW())
+		ON CONFLICT(provider, event_id) DO NOTHING
+	`, messageSID, status, nullableUUID(notifID), to, payloadJSON)
+	if insErr != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "internal error"})
+		return
+	}
+	if cmd.RowsAffected() == 0 {
+		c.JSON(http.StatusOK, gin.H{"processed": 0, "duplicates": 1})
+		return
+	}
+	h.reconcileTwilioEvent(c, status, to, errMsg, notifID)
+	c.JSON(http.StatusOK, gin.H{"processed": 1, "duplicates": 0})
+}
+
+func (h *ProviderCallbacksHandler) reconcileTwilioEvent(c *gin.Context, status, to, errMsg string, notifID *uuid.UUID) {
+	if notifID != nil {
+		switch status {
+		case "delivered", "sent":
+			_, _ = db.Pool.Exec(c.Request.Context(), `
+				UPDATE notifications
+				SET status = 'sent', provider = 'twilio', sent_at = NOW(), last_error = ''
+				WHERE id = $1
+			`, *notifID)
+		default:
+			reason, suppress := twilioFailureTaxonomy(status)
+			_, _ = db.Pool.Exec(c.Request.Context(), `
+				UPDATE notifications
+				SET status = 'failed', provider = 'twilio', last_error = $2, next_retry_at = NULL
+				WHERE id = $1
+			`, *notifID, reason+":"+errMsg)
+			if suppress {
+				_, _ = db.Pool.Exec(c.Request.Context(), `
+					INSERT INTO notification_dead_letters(notification_id, channel, provider, final_error, attempt_count)
+					VALUES($1, 'sms', 'twilio', $2, 1)
+					ON CONFLICT(notification_id) DO UPDATE SET final_error = EXCLUDED.final_error, provider = EXCLUDED.provider, attempt_count = GREATEST(notification_dead_letters.attempt_count, EXCLUDED.attempt_count), created_at = NOW()
+				`, *notifID, reason+":"+errMsg)
+			}
+		}
+	}
+	reason, suppress := twilioFailureTaxonomy(status)
+	if suppress && strings.TrimSpace(to) != "" {
+		_, _ = db.Pool.Exec(c.Request.Context(), `
+			INSERT INTO notification_suppressions(provider, recipient, reason_code, reason_detail, active, last_event_at, updated_at)
+			VALUES('twilio', $1, $2, $3, TRUE, NOW(), NOW())
+			ON CONFLICT(provider, recipient)
+			DO UPDATE SET reason_code = EXCLUDED.reason_code, reason_detail = EXCLUDED.reason_detail, active = TRUE, last_event_at = NOW(), updated_at = NOW()
+		`, strings.TrimSpace(to), reason, strings.TrimSpace(errMsg))
+	}
+}
+
+func nullableUUID(id *uuid.UUID) any {
+	if id == nil {
+		return sql.NullString{}
+	}
+	return *id
+}

--- a/backend/handlers/provider_callbacks_test.go
+++ b/backend/handlers/provider_callbacks_test.go
@@ -1,0 +1,50 @@
+package handlers
+
+import (
+	"crypto/hmac"
+	"crypto/sha1"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/hex"
+	"testing"
+)
+
+func TestVerifySendGridSignature(t *testing.T) {
+	secret := "sg-secret"
+	ts := "1714412000"
+	body := `[{"event":"bounce"}]`
+	mac := hmac.New(sha256.New, []byte(secret))
+	_, _ = mac.Write([]byte(ts + "." + body))
+	sig := hex.EncodeToString(mac.Sum(nil))
+
+	if !verifySendGridSignature(secret, ts, body, sig) {
+		t.Fatal("expected valid sendgrid signature")
+	}
+	if verifySendGridSignature(secret, ts, body, "bad-signature") {
+		t.Fatal("expected invalid sendgrid signature")
+	}
+}
+
+func TestVerifyTwilioSignature(t *testing.T) {
+	secret := "tw-secret"
+	body := "MessageSid=SM123&MessageStatus=delivered"
+	mac := hmac.New(sha1.New, []byte(secret))
+	_, _ = mac.Write([]byte(body))
+	sig := base64.StdEncoding.EncodeToString(mac.Sum(nil))
+
+	if !verifyTwilioSignature(secret, body, sig) {
+		t.Fatal("expected valid twilio signature")
+	}
+	if verifyTwilioSignature(secret, body, "bad-signature") {
+		t.Fatal("expected invalid twilio signature")
+	}
+}
+
+func TestCallbackFailureTaxonomy(t *testing.T) {
+	if reason, suppress := sendGridFailureTaxonomy("bounce"); reason != "bounce" || !suppress {
+		t.Fatalf("unexpected sendgrid taxonomy: %s %v", reason, suppress)
+	}
+	if reason, suppress := twilioFailureTaxonomy("undelivered"); reason != "undelivered" || !suppress {
+		t.Fatalf("unexpected twilio taxonomy: %s %v", reason, suppress)
+	}
+}

--- a/backend/main.go
+++ b/backend/main.go
@@ -13,6 +13,7 @@ import (
 	"github.com/healthonyx/backend/db"
 	"github.com/healthonyx/backend/handlers"
 	"github.com/healthonyx/backend/middleware"
+	"github.com/healthonyx/backend/providers"
 	"github.com/healthonyx/backend/workers"
 )
 
@@ -47,6 +48,7 @@ func main() {
 	messaging := handlers.NewMessagingHandler(msgHub)
 	prescriptions := handlers.NewPrescriptionsHandler()
 	notifications := handlers.NewNotificationsHandler()
+	providerCallbacks := handlers.NewProviderCallbacksHandler(cfg.SendGridWebhookSecret, cfg.TwilioWebhookSecret)
 	criticalEscalations := handlers.NewCriticalEscalationsHandler()
 	geo := handlers.NewGeoBookingHandler()
 	geocode := handlers.NewGeocodeHandler(cfg.NominatimBaseURL, cfg.GeocodeUserAgent)
@@ -79,6 +81,8 @@ func main() {
 		// Protected: requires valid JWT
 		api.GET("/me", auth.RequireAuth(), auth.Me)
 		api.GET("/notifications", auth.RequireAuth(), notifications.ListMine)
+		api.POST("/provider-callbacks/sendgrid", providerCallbacks.SendGridWebhook)
+		api.POST("/provider-callbacks/twilio", providerCallbacks.TwilioWebhook)
 		api.GET("/notifications/preferences", auth.RequireAuth(), notifications.ListPreferences)
 		api.PUT("/notifications/preferences", auth.RequireAuth(), notifications.UpsertPreferences)
 		api.GET("/bootstrap", auth.RequireAuth(), bootstrap.Get)
@@ -178,6 +182,15 @@ func main() {
 
 	addr := fmt.Sprintf(":%s", cfg.Port)
 	go workers.NewDocumentSummaryWorker(2 * time.Second).Run(context.Background())
+	notificationProviders := workers.NewNotificationProviderSet(
+		providers.NewSendGridAdapter(cfg.SendGridAPIKey, cfg.SendGridFrom),
+		providers.NewTwilioAdapter(cfg.TwilioAccountSID, cfg.TwilioAuthToken, cfg.TwilioFromNumber),
+	)
+	go workers.NewNotificationWorkerWithConfig(workers.NotificationWorkerConfig{
+		Interval:   time.Duration(cfg.NotifyIntervalMS) * time.Millisecond,
+		MaxRetries: cfg.NotifyMaxRetries,
+		Providers:  notificationProviders,
+	}).Run(context.Background())
 	log.Printf("Listening on %s", addr)
 	if err := r.Run(addr); err != nil {
 		log.Fatal(err)

--- a/backend/workers/notification_worker.go
+++ b/backend/workers/notification_worker.go
@@ -2,6 +2,7 @@ package workers
 
 import (
 	"context"
+	"database/sql"
 	"errors"
 	"log"
 	"strings"
@@ -9,6 +10,7 @@ import (
 
 	"github.com/healthonyx/backend/db"
 	"github.com/healthonyx/backend/providers"
+	"github.com/jackc/pgx/v5"
 )
 
 type NotificationProviderSet struct {
@@ -131,6 +133,34 @@ func (w *NotificationWorker) processDue(ctx context.Context) (int64, error) {
 }
 
 func (w *NotificationWorker) processSingle(ctx context.Context, n queuedNotification) error {
+	if suppressed, reason, err := w.isSuppressed(ctx, n); err != nil {
+		return err
+	} else if suppressed {
+		nextAttempt := n.Attempts + 1
+		_, _ = db.Pool.Exec(ctx, `
+			INSERT INTO notification_delivery_attempts(notification_id, channel, provider, attempt_no, success, error_message, latency_ms)
+			VALUES($1, $2, $3, $4, FALSE, $5, 0)
+		`, n.ID, n.Channel, n.Provider, nextAttempt, "suppressed:"+reason)
+		_, _ = db.Pool.Exec(ctx, `
+			INSERT INTO notification_dead_letters(notification_id, channel, provider, final_error, attempt_count)
+			VALUES($1, $2, $3, $4, $5)
+			ON CONFLICT(notification_id) DO UPDATE SET
+				provider = EXCLUDED.provider,
+				final_error = EXCLUDED.final_error,
+				attempt_count = EXCLUDED.attempt_count,
+				created_at = NOW()
+		`, n.ID, n.Channel, n.Provider, "suppressed:"+reason, nextAttempt)
+		_, updateErr := db.Pool.Exec(ctx, `
+			UPDATE notifications
+			SET status = 'failed',
+			    attempts = $2,
+			    last_error = $3,
+			    next_retry_at = NULL
+			WHERE id = $1
+		`, n.ID, nextAttempt, "suppressed:"+reason)
+		return updateErr
+	}
+
 	startedAt := time.Now()
 	mode, err := w.deliver(ctx, n)
 	latencyMS := int(time.Since(startedAt).Milliseconds())
@@ -192,6 +222,32 @@ func (w *NotificationWorker) processSingle(ctx context.Context, n queuedNotifica
 		WHERE id = $1
 	`, n.ID, nextAttempt, mode, err.Error(), nextRetry)
 	return updateErr
+}
+
+func (w *NotificationWorker) isSuppressed(ctx context.Context, n queuedNotification) (bool, string, error) {
+	channel := strings.ToLower(strings.TrimSpace(n.Channel))
+	recipient := strings.TrimSpace(strings.ToLower(n.To))
+	if recipient == "" || (channel != "email" && channel != "sms") {
+		return false, "", nil
+	}
+	provider := "sendgrid"
+	if channel == "sms" {
+		provider = "twilio"
+	}
+	var reason sql.NullString
+	err := db.Pool.QueryRow(ctx, `
+		SELECT reason_code
+		FROM notification_suppressions
+		WHERE provider = $1 AND recipient = $2 AND active = TRUE
+		LIMIT 1
+	`, provider, recipient).Scan(&reason)
+	if err != nil {
+		if err == pgx.ErrNoRows {
+			return false, "", nil
+		}
+		return false, "", err
+	}
+	return true, reason.String, nil
 }
 
 func (w *NotificationWorker) deliver(ctx context.Context, n queuedNotification) (string, error) {

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -139,6 +139,26 @@ paths:
         "401":
           $ref: "#/components/responses/Unauthorized"
 
+  /api/provider-callbacks/sendgrid:
+    post:
+      tags: [Notifications]
+      summary: Ingest SendGrid delivery callbacks
+      responses:
+        "200":
+          description: Callback processed
+        "401":
+          description: Invalid webhook signature
+
+  /api/provider-callbacks/twilio:
+    post:
+      tags: [Notifications]
+      summary: Ingest Twilio delivery callbacks
+      responses:
+        "200":
+          description: Callback processed
+        "401":
+          description: Invalid webhook signature
+
   /api/patient/dashboard/summary:
     get:
       tags: [Dashboard]


### PR DESCRIPTION
## Summary
- Add SendGrid/Twilio webhook ingestion endpoints with signature verification and callback idempotency persistence.
- Reconcile provider delivery outcomes into notification status, persist failure taxonomy classes, and upsert active suppressions.
- Honor suppressions in the notification worker to stop future sends and classify to dead-letter with suppression reason.

## Test plan
- [x] `go test ./...`
- [x] `go run ./cmd/openapi-sync-check`
- [x] Webhook signature verification unit tests
- [x] Failure taxonomy/suppression classification tests