### PR TITLE
CG-08: add SLO dashboards and service telemetry with threshold alerts

### DIFF
--- a/backend/db/db.go
+++ b/backend/db/db.go
@@ -421,6 +421,17 @@ func Migrate(ctx context.Context) error {
 		);
 		CREATE INDEX IF NOT EXISTS idx_notification_suppressions_active ON notification_suppressions(provider, recipient) WHERE active = TRUE;
 
+		CREATE TABLE IF NOT EXISTS api_request_telemetry (
+			id            UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+			method        TEXT NOT NULL,
+			path          TEXT NOT NULL,
+			status_code   INTEGER NOT NULL,
+			latency_ms    INTEGER NOT NULL DEFAULT 0,
+			created_at    TIMESTAMPTZ NOT NULL DEFAULT NOW()
+		);
+		CREATE INDEX IF NOT EXISTS idx_api_request_telemetry_created ON api_request_telemetry(created_at DESC);
+		CREATE INDEX IF NOT EXISTS idx_api_request_telemetry_path ON api_request_telemetry(path, created_at DESC);
+
 		CREATE TABLE IF NOT EXISTS message_thread_reads (
 			thread_id    UUID NOT NULL REFERENCES message_threads(id) ON DELETE CASCADE,
 			user_id      UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,

--- a/backend/handlers/admin_ai_runtime.go
+++ b/backend/handlers/admin_ai_runtime.go
@@ -36,6 +36,23 @@ type adminAIObservability struct {
 	FailedDocsCount   int     `json:"failed_docs_count"`
 }
 
+type adminSLOMetric struct {
+	TargetPercent   float64 `json:"target_percent"`
+	SuccessPercent  float64 `json:"success_percent"`
+	ErrorBudgetUsed float64 `json:"error_budget_used_percent"`
+	Errors24h       int     `json:"errors_24h"`
+	Requests24h     int     `json:"requests_24h"`
+	AvgLatencyMS    float64 `json:"avg_latency_ms"`
+	P95LatencyMS    float64 `json:"p95_latency_ms"`
+}
+
+type adminSLOOverview struct {
+	Notifications adminSLOMetric `json:"notifications"`
+	AI            adminSLOMetric `json:"ai"`
+	API           adminSLOMetric `json:"api"`
+	Alerts        []gin.H        `json:"alerts"`
+}
+
 type adminAIEvalResult struct {
 	ModelName        string  `json:"model_name"`
 	SamplesEvaluated int     `json:"samples_evaluated"`
@@ -98,6 +115,7 @@ func (h *AdminAIRuntimeHandler) GetObservability(c *gin.Context) {
 		"observability": obs,
 		"runtime":       runtime,
 		"recent_evals":  recentRuns,
+		"slo_overview":  loadSLOOverview(c),
 	})
 }
 
@@ -367,4 +385,115 @@ func loadAIObservability(c *gin.Context) (adminAIObservability, error) {
 		return out, err
 	}
 	return out, nil
+}
+
+func loadSLOOverview(c *gin.Context) adminSLOOverview {
+	out := adminSLOOverview{
+		Notifications: adminSLOMetric{TargetPercent: 99.0},
+		AI:            adminSLOMetric{TargetPercent: 97.0},
+		API:           adminSLOMetric{TargetPercent: 99.5},
+		Alerts:        []gin.H{},
+	}
+
+	_ = db.Pool.QueryRow(c.Request.Context(), `
+		SELECT
+			COUNT(*)::int AS total,
+			COUNT(*) FILTER (WHERE success = FALSE)::int AS failed,
+			COALESCE(AVG(latency_ms)::float8, 0)::float8 AS avg_latency,
+			COALESCE(PERCENTILE_CONT(0.95) WITHIN GROUP (ORDER BY latency_ms), 0)::float8 AS p95_latency
+		FROM notification_delivery_attempts
+		WHERE created_at >= NOW() - INTERVAL '24 hours'
+	`).Scan(&out.Notifications.Requests24h, &out.Notifications.Errors24h, &out.Notifications.AvgLatencyMS, &out.Notifications.P95LatencyMS)
+	out.Notifications.SuccessPercent = successPercent(out.Notifications.Requests24h, out.Notifications.Errors24h)
+	out.Notifications.ErrorBudgetUsed = errorBudgetUsed(out.Notifications.SuccessPercent, out.Notifications.TargetPercent)
+
+	_ = db.Pool.QueryRow(c.Request.Context(), `
+		SELECT
+			COUNT(*)::int AS total,
+			COUNT(*) FILTER (WHERE status = 'failed')::int AS failed,
+			COALESCE(AVG(EXTRACT(EPOCH FROM (finished_at - started_at)) * 1000) FILTER (
+				WHERE started_at IS NOT NULL AND finished_at IS NOT NULL
+			), 0)::float8 AS avg_latency,
+			COALESCE(PERCENTILE_CONT(0.95) WITHIN GROUP (
+				ORDER BY EXTRACT(EPOCH FROM (finished_at - started_at)) * 1000
+			) FILTER (WHERE started_at IS NOT NULL AND finished_at IS NOT NULL), 0)::float8 AS p95_latency
+		FROM document_summary_jobs
+		WHERE created_at >= NOW() - INTERVAL '24 hours'
+	`).Scan(&out.AI.Requests24h, &out.AI.Errors24h, &out.AI.AvgLatencyMS, &out.AI.P95LatencyMS)
+	out.AI.SuccessPercent = successPercent(out.AI.Requests24h, out.AI.Errors24h)
+	out.AI.ErrorBudgetUsed = errorBudgetUsed(out.AI.SuccessPercent, out.AI.TargetPercent)
+
+	_ = db.Pool.QueryRow(c.Request.Context(), `
+		SELECT
+			COUNT(*)::int AS total,
+			COUNT(*) FILTER (WHERE status_code >= 500)::int AS failed,
+			COALESCE(AVG(latency_ms)::float8, 0)::float8 AS avg_latency,
+			COALESCE(PERCENTILE_CONT(0.95) WITHIN GROUP (ORDER BY latency_ms), 0)::float8 AS p95_latency
+		FROM api_request_telemetry
+		WHERE created_at >= NOW() - INTERVAL '24 hours'
+	`).Scan(&out.API.Requests24h, &out.API.Errors24h, &out.API.AvgLatencyMS, &out.API.P95LatencyMS)
+	out.API.SuccessPercent = successPercent(out.API.Requests24h, out.API.Errors24h)
+	out.API.ErrorBudgetUsed = errorBudgetUsed(out.API.SuccessPercent, out.API.TargetPercent)
+
+	out.Alerts = buildSLOAlerts(out)
+	return out
+}
+
+func successPercent(total, errors int) float64 {
+	if total <= 0 {
+		return 100
+	}
+	ok := float64(total - errors)
+	if ok < 0 {
+		ok = 0
+	}
+	return (ok / float64(total)) * 100
+}
+
+func errorBudgetUsed(successPercentValue, targetPercent float64) float64 {
+	if targetPercent >= 100 {
+		return 0
+	}
+	allowed := 100 - targetPercent
+	if allowed <= 0 {
+		return 0
+	}
+	actualFailure := 100 - successPercentValue
+	if actualFailure <= 0 {
+		return 0
+	}
+	return (actualFailure / allowed) * 100
+}
+
+func buildSLOAlerts(overview adminSLOOverview) []gin.H {
+	alerts := []gin.H{}
+	add := func(domain string, m adminSLOMetric) {
+		if m.ErrorBudgetUsed >= 100 {
+			alerts = append(alerts, gin.H{
+				"severity": "warning",
+				"code":     domain + "_error_budget_exhausted",
+				"message":  domain + " SLO error budget exhausted in last 24h.",
+				"value":    m.ErrorBudgetUsed,
+			})
+		} else if m.ErrorBudgetUsed >= 50 {
+			alerts = append(alerts, gin.H{
+				"severity": "info",
+				"code":     domain + "_error_budget_burn_high",
+				"message":  domain + " SLO error budget burn is above 50% in last 24h.",
+				"value":    m.ErrorBudgetUsed,
+			})
+		}
+		if m.P95LatencyMS >= 2000 {
+			alerts = append(alerts, gin.H{
+				"severity": "warning",
+				"code":     domain + "_p95_latency_high",
+				"message":  domain + " p95 latency is above 2000ms.",
+				"value":    m.P95LatencyMS,
+			})
+		}
+	}
+	add("notifications", overview.Notifications)
+	add("ai", overview.AI)
+	add("api", overview.API)
+	return alerts
 }

--- a/backend/handlers/admin_slo_test.go
+++ b/backend/handlers/admin_slo_test.go
@@ -1,0 +1,24 @@
+package handlers
+
+import "testing"
+
+func TestSLOThresholdAlerts(t *testing.T) {
+	overview := adminSLOOverview{
+		Notifications: adminSLOMetric{ErrorBudgetUsed: 120, P95LatencyMS: 2200},
+		AI:            adminSLOMetric{ErrorBudgetUsed: 55, P95LatencyMS: 900},
+		API:           adminSLOMetric{ErrorBudgetUsed: 10, P95LatencyMS: 2500},
+	}
+	alerts := buildSLOAlerts(overview)
+	if len(alerts) < 4 {
+		t.Fatalf("expected multiple alerts, got %d", len(alerts))
+	}
+}
+
+func TestSLOMetricCalculations(t *testing.T) {
+	if got := successPercent(100, 2); got < 97.9 || got > 98.1 {
+		t.Fatalf("unexpected success percent: %f", got)
+	}
+	if got := errorBudgetUsed(98, 99); got < 199.9 || got > 200.1 {
+		t.Fatalf("unexpected error budget used: %f", got)
+	}
+}

--- a/backend/main.go
+++ b/backend/main.go
@@ -69,6 +69,7 @@ func main() {
 		origins = []string{"http://localhost:4200"}
 	}
 	r.Use(middleware.CORS(origins))
+	r.Use(middleware.RequestTelemetry())
 
 	r.GET("/health", func(c *gin.Context) { c.JSON(http.StatusOK, gin.H{"status": "ok"}) })
 	r.HEAD("/health", func(c *gin.Context) { c.Status(http.StatusOK) })

--- a/backend/middleware/request_telemetry.go
+++ b/backend/middleware/request_telemetry.go
@@ -1,0 +1,35 @@
+package middleware
+
+import (
+	"strings"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/healthonyx/backend/db"
+)
+
+func RequestTelemetry() gin.HandlerFunc {
+	return func(c *gin.Context) {
+		start := time.Now()
+		c.Next()
+
+		if db.Pool == nil {
+			return
+		}
+		path := strings.TrimSpace(c.FullPath())
+		if path == "" {
+			path = strings.TrimSpace(c.Request.URL.Path)
+		}
+		if !strings.HasPrefix(path, "/api/") {
+			return
+		}
+		latencyMS := int(time.Since(start).Milliseconds())
+		if latencyMS < 0 {
+			latencyMS = 0
+		}
+		_, _ = db.Pool.Exec(c.Request.Context(), `
+			INSERT INTO api_request_telemetry(method, path, status_code, latency_ms)
+			VALUES($1, $2, $3, $4)
+		`, c.Request.Method, path, c.Writer.Status(), latencyMS)
+	}
+}

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -378,7 +378,7 @@ paths:
   /api/admin/ai/observability:
     get:
       tags: [Admin]
-      summary: Get AI runtime settings, observability, and runtime health
+      summary: Get AI runtime settings, observability, runtime health, and SLO telemetry
       security:
         - bearerAuth: []
       responses:

--- a/frontend/src/app/components/admin-ai-observability/admin-ai-observability.component.html
+++ b/frontend/src/app/components/admin-ai-observability/admin-ai-observability.component.html
@@ -48,6 +48,30 @@
     <article><span>Pending docs</span><strong>{{ obs.pending_docs_count }}</strong></article>
   </div>
 
+  <section class="runtime-health" *ngIf="!loading && slo" data-cy="admin-slo-overview">
+    <h2>SLO overview (24h)</h2>
+    <div class="runtime-grid">
+      <article>
+        <span>Notifications SLO</span>
+        <strong>{{ slo.notifications.success_percent | number: '1.2-2' }}%</strong>
+        <small>budget used {{ slo.notifications.error_budget_used_percent | number: '1.1-1' }}%</small>
+      </article>
+      <article>
+        <span>AI SLO</span>
+        <strong>{{ slo.ai.success_percent | number: '1.2-2' }}%</strong>
+        <small>budget used {{ slo.ai.error_budget_used_percent | number: '1.1-1' }}%</small>
+      </article>
+      <article>
+        <span>API SLO</span>
+        <strong>{{ slo.api.success_percent | number: '1.2-2' }}%</strong>
+        <small>budget used {{ slo.api.error_budget_used_percent | number: '1.1-1' }}%</small>
+      </article>
+    </div>
+    <ul *ngIf="slo.alerts.length > 0" data-cy="admin-slo-alerts">
+      <li *ngFor="let a of slo.alerts">{{ a.message }}</li>
+    </ul>
+  </section>
+
   <form class="controls" *ngIf="!loading" (ngSubmit)="save()">
     <h2>Runtime settings</h2>
     <label><input type="checkbox" name="ollamaEnabled" [(ngModel)]="form.ollama_enabled" /> Ollama enabled</label>

--- a/frontend/src/app/components/admin-ai-observability/admin-ai-observability.component.spec.ts
+++ b/frontend/src/app/components/admin-ai-observability/admin-ai-observability.component.spec.ts
@@ -42,6 +42,36 @@ describe('AdminAiObservabilityComponent', () => {
           ollama_reachable: true,
           model_available: true,
           active_mode: 'ollama'
+        },
+        slo_overview: {
+          notifications: {
+            target_percent: 99,
+            success_percent: 99.1,
+            error_budget_used_percent: 90,
+            errors_24h: 5,
+            requests_24h: 550,
+            avg_latency_ms: 45,
+            p95_latency_ms: 210
+          },
+          ai: {
+            target_percent: 97,
+            success_percent: 98.4,
+            error_budget_used_percent: 53,
+            errors_24h: 2,
+            requests_24h: 120,
+            avg_latency_ms: 330,
+            p95_latency_ms: 980
+          },
+          api: {
+            target_percent: 99.5,
+            success_percent: 99.8,
+            error_budget_used_percent: 40,
+            errors_24h: 3,
+            requests_24h: 1500,
+            avg_latency_ms: 22,
+            p95_latency_ms: 120
+          },
+          alerts: [{ severity: 'info', code: 'ai_error_budget_burn_high', message: 'ai SLO error budget burn is above 50% in last 24h.', value: 53 }]
         }
       })
     );
@@ -60,6 +90,7 @@ describe('AdminAiObservabilityComponent', () => {
     expect(serviceSpy.getObservability).toHaveBeenCalled();
     expect(el.querySelector('[data-cy="admin-ai-observability-page"]')).toBeTruthy();
     expect(el.querySelector('[data-cy="ai-runtime-health"]')).toBeTruthy();
+    expect(el.querySelector('[data-cy="admin-slo-overview"]')).toBeTruthy();
   });
 
   it('saves settings', () => {

--- a/frontend/src/app/components/admin-ai-observability/admin-ai-observability.component.ts
+++ b/frontend/src/app/components/admin-ai-observability/admin-ai-observability.component.ts
@@ -7,6 +7,7 @@ import {
   AdminAiRuntimeService,
   AdminAiRuntimeSettings
 } from '../../services/admin-ai-runtime.service';
+import { AdminSloOverview } from '../../services/api-types';
 
 @Component({
   selector: 'app-admin-ai-observability',
@@ -23,6 +24,7 @@ export class AdminAiObservabilityComponent implements OnInit {
   success: string | null = null;
   settings: AdminAiRuntimeSettings | null = null;
   obs: AdminAiObservability | null = null;
+  slo: AdminSloOverview | null = null;
   runtime: AdminAiObservabilityResponse['runtime'] | null = null;
   evalResult: { model_name: string; samples_evaluated: number; success_rate: number; quality_score: number } | null =
     null;
@@ -67,6 +69,7 @@ export class AdminAiObservabilityComponent implements OnInit {
         this.settings = res.settings;
         this.obs = res.observability;
         this.runtime = res.runtime ?? null;
+        this.slo = res.slo_overview ?? null;
         this.form = {
           ollama_enabled: res.settings.ollama_enabled,
           fallback_enabled: res.settings.fallback_enabled,
@@ -100,6 +103,7 @@ export class AdminAiObservabilityComponent implements OnInit {
           this.settings = res.settings;
           this.obs = res.observability;
           this.runtime = res.runtime ?? null;
+          this.slo = res.slo_overview ?? this.slo;
           this.success = 'AI runtime settings updated.';
           this.saving = false;
         },

--- a/frontend/src/app/services/api-types.ts
+++ b/frontend/src/app/services/api-types.ts
@@ -107,6 +107,23 @@ export type AdminAiObservability = {
   failed_docs_count: number;
 };
 
+export type AdminSloMetric = {
+  target_percent: number;
+  success_percent: number;
+  error_budget_used_percent: number;
+  errors_24h: number;
+  requests_24h: number;
+  avg_latency_ms: number;
+  p95_latency_ms: number;
+};
+
+export type AdminSloOverview = {
+  notifications: AdminSloMetric;
+  ai: AdminSloMetric;
+  api: AdminSloMetric;
+  alerts: { severity: string; code: string; message: string; value: number }[];
+};
+
 export type AdminAiRuntimeStatus = {
   ai_enabled: boolean;
   ollama_host: string;
@@ -120,6 +137,7 @@ export type AdminAiObservabilityResponse = {
   settings: AdminAiRuntimeSettings;
   observability: AdminAiObservability;
   runtime?: AdminAiRuntimeStatus;
+  slo_overview?: AdminSloOverview;
 };
 
 export type AdminAiEvalResponse = {


### PR DESCRIPTION
## Summary
- Add backend SLO telemetry for notifications, AI pipeline, and API requests with error-budget and p95-latency threshold alerting.
- Introduce request telemetry middleware and API contract coverage for SLO overview in admin observability response.
- Add frontend admin observability UI rendering for SLO panels and threshold alerts with component tests.

## Test plan
- [x] `go test ./...`
- [x] `go run ./cmd/openapi-sync-check`
- [x] `npm run test:ci`