### PR TITLE
CG-09: standardize failure taxonomy across API worker and provider subsystems

### DIFF
--- a/backend/failures/taxonomy.go
+++ b/backend/failures/taxonomy.go
@@ -1,0 +1,130 @@
+package failures
+
+import (
+	"fmt"
+	"strings"
+)
+
+type Severity string
+
+const (
+	SeverityInfo     Severity = "info"
+	SeverityWarning  Severity = "warning"
+	SeverityCritical Severity = "critical"
+)
+
+type Failure struct {
+	Code            string
+	Severity        Severity
+	RemediationHint string
+	Message         string
+	Subsystem       string
+}
+
+func (f Failure) Encode() string {
+	msg := strings.TrimSpace(strings.ReplaceAll(f.Message, "|", "/"))
+	return fmt.Sprintf(
+		"code=%s|severity=%s|subsystem=%s|remediation=%s|message=%s",
+		strings.TrimSpace(f.Code),
+		strings.TrimSpace(string(f.Severity)),
+		strings.TrimSpace(f.Subsystem),
+		strings.TrimSpace(strings.ReplaceAll(f.RemediationHint, "|", "/")),
+		msg,
+	)
+}
+
+func ClassifyProviderSend(provider string, err error) Failure {
+	p := strings.ToLower(strings.TrimSpace(provider))
+	msg := errorMessage(err)
+	switch {
+	case strings.Contains(msg, "not configured"),
+		strings.Contains(msg, "api key is required"),
+		strings.Contains(msg, "account credentials are required"),
+		strings.Contains(msg, "from address is required"),
+		strings.Contains(msg, "from number is required"):
+		return Failure{
+			Code:            "NTF_PROVIDER_CONFIG_MISSING",
+			Severity:        SeverityCritical,
+			RemediationHint: "configure provider credentials in environment",
+			Message:         msg,
+			Subsystem:       "provider",
+		}
+	case strings.Contains(msg, "recipient is required"), strings.Contains(msg, "body is required"):
+		return Failure{
+			Code:            "NTF_PROVIDER_PAYLOAD_INVALID",
+			Severity:        SeverityWarning,
+			RemediationHint: "validate recipient and message payload before queueing",
+			Message:         msg,
+			Subsystem:       "provider",
+		}
+	default:
+		code := "NTF_PROVIDER_SEND_FAILED"
+		if p == "twilio" {
+			code = "NTF_TWILIO_SEND_FAILED"
+		} else if p == "sendgrid" {
+			code = "NTF_SENDGRID_SEND_FAILED"
+		}
+		return Failure{
+			Code:            code,
+			Severity:        SeverityWarning,
+			RemediationHint: "retry delivery and inspect provider callback logs",
+			Message:         msg,
+			Subsystem:       "provider",
+		}
+	}
+}
+
+func ClassifySuppression(provider, reason string) Failure {
+	return Failure{
+		Code:            "NTF_RECIPIENT_SUPPRESSED",
+		Severity:        SeverityInfo,
+		RemediationHint: "clear suppression only after user consent or provider delist",
+		Message:         strings.TrimSpace(provider + ":" + reason),
+		Subsystem:       "worker",
+	}
+}
+
+func ClassifyCallback(provider, event, detail string) Failure {
+	evt := strings.ToLower(strings.TrimSpace(event))
+	code := "NTF_CALLBACK_PROVIDER_FAILURE"
+	sev := SeverityWarning
+	hint := "review callback payload and reconcile notification state"
+	switch evt {
+	case "bounce", "blocked", "dropped", "spamreport", "undelivered", "failed":
+		code = "NTF_CALLBACK_HARD_FAILURE"
+		sev = SeverityWarning
+		hint = "suppress recipient and notify support if recurrent"
+	case "deferred":
+		code = "NTF_CALLBACK_TRANSIENT_FAILURE"
+		sev = SeverityInfo
+		hint = "keep retry policy active and monitor budget burn"
+	case "delivered", "processed", "sent":
+		code = "NTF_CALLBACK_SUCCESS"
+		sev = SeverityInfo
+		hint = "no remediation required"
+	}
+	return Failure{
+		Code:            code,
+		Severity:        sev,
+		RemediationHint: hint,
+		Message:         strings.TrimSpace(provider + ":" + evt + ":" + detail),
+		Subsystem:       "callback",
+	}
+}
+
+func ClassifyAPI(code, message string) Failure {
+	return Failure{
+		Code:            strings.TrimSpace(code),
+		Severity:        SeverityWarning,
+		RemediationHint: "check request contract and authentication context",
+		Message:         strings.TrimSpace(message),
+		Subsystem:       "api",
+	}
+}
+
+func errorMessage(err error) string {
+	if err == nil {
+		return "unknown error"
+	}
+	return strings.TrimSpace(err.Error())
+}

--- a/backend/failures/taxonomy_test.go
+++ b/backend/failures/taxonomy_test.go
@@ -1,0 +1,49 @@
+package failures
+
+import (
+	"errors"
+	"strings"
+	"testing"
+)
+
+func TestFailureEncodeSchema(t *testing.T) {
+	f := Failure{
+		Code:            "NTF_PROVIDER_SEND_FAILED",
+		Severity:        SeverityWarning,
+		RemediationHint: "retry",
+		Message:         "provider timeout",
+		Subsystem:       "provider",
+	}
+	encoded := f.Encode()
+	required := []string{"code=", "severity=", "subsystem=", "remediation=", "message="}
+	for _, k := range required {
+		if !strings.Contains(encoded, k) {
+			t.Fatalf("expected encoded failure to contain %s: %s", k, encoded)
+		}
+	}
+}
+
+func TestClassifyProviderSend(t *testing.T) {
+	f := ClassifyProviderSend("sendgrid", errors.New("sendgrid: api key is required"))
+	if f.Code != "NTF_PROVIDER_CONFIG_MISSING" {
+		t.Fatalf("unexpected code: %s", f.Code)
+	}
+}
+
+func TestIncidentDrillReplayMappings(t *testing.T) {
+	cases := []struct {
+		provider string
+		event    string
+		wantCode string
+	}{
+		{"sendgrid", "bounce", "NTF_CALLBACK_HARD_FAILURE"},
+		{"sendgrid", "deferred", "NTF_CALLBACK_TRANSIENT_FAILURE"},
+		{"twilio", "delivered", "NTF_CALLBACK_SUCCESS"},
+	}
+	for _, c := range cases {
+		got := ClassifyCallback(c.provider, c.event, "drill")
+		if got.Code != c.wantCode {
+			t.Fatalf("provider=%s event=%s: got %s want %s", c.provider, c.event, got.Code, c.wantCode)
+		}
+	}
+}

--- a/backend/handlers/notifications.go
+++ b/backend/handlers/notifications.go
@@ -10,6 +10,7 @@ import (
 	"github.com/gin-gonic/gin"
 	"github.com/google/uuid"
 	"github.com/healthonyx/backend/db"
+	"github.com/healthonyx/backend/failures"
 	"github.com/jackc/pgx/v5"
 )
 
@@ -307,7 +308,8 @@ func (h *NotificationsHandler) RetryFailed(c *gin.Context) {
 	}
 	id, err := uuid.Parse(strings.TrimSpace(c.Param("id")))
 	if err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid notification id"})
+		f := failures.ClassifyAPI("NTF_RETRY_ID_INVALID", "invalid notification id")
+		c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid notification id", "failure": f})
 		return
 	}
 	var prevStatus string
@@ -325,10 +327,12 @@ func (h *NotificationsHandler) RetryFailed(c *gin.Context) {
 	`, id).Scan(&prevStatus)
 	if err != nil {
 		if err == pgx.ErrNoRows {
-			c.JSON(http.StatusNotFound, gin.H{"error": "Failed notification not found"})
+			f := failures.ClassifyAPI("NTF_RETRY_TARGET_MISSING", "failed notification not found")
+			c.JSON(http.StatusNotFound, gin.H{"error": "Failed notification not found", "failure": f})
 			return
 		}
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "Internal error"})
+		f := failures.ClassifyAPI("NTF_RETRY_UPDATE_FAILED", "internal error")
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Internal error", "failure": f})
 		return
 	}
 	c.JSON(http.StatusOK, gin.H{
@@ -506,22 +510,22 @@ func (h *NotificationsHandler) AdminConsentHistory(c *gin.Context) {
 	defer rows.Close()
 
 	type row struct {
-		ID              string `json:"id"`
-		UserID          string `json:"user_id"`
-		ActorUserID     string `json:"actor_user_id"`
-		ActorRole       string `json:"actor_role"`
-		ActorSource     string `json:"actor_source"`
-		PolicyVersion   string `json:"policy_version"`
-		Category        string `json:"category"`
-		PrevEnabled     bool   `json:"prev_enabled"`
-		PrevEmail       bool   `json:"prev_email_enabled"`
-		PrevSMS         bool   `json:"prev_sms_enabled"`
-		PrevInApp       bool   `json:"prev_in_app_enabled"`
-		NewEnabled      bool   `json:"new_enabled"`
-		NewEmail        bool   `json:"new_email_enabled"`
-		NewSMS          bool   `json:"new_sms_enabled"`
-		NewInApp        bool   `json:"new_in_app_enabled"`
-		CreatedAt       string `json:"created_at"`
+		ID            string `json:"id"`
+		UserID        string `json:"user_id"`
+		ActorUserID   string `json:"actor_user_id"`
+		ActorRole     string `json:"actor_role"`
+		ActorSource   string `json:"actor_source"`
+		PolicyVersion string `json:"policy_version"`
+		Category      string `json:"category"`
+		PrevEnabled   bool   `json:"prev_enabled"`
+		PrevEmail     bool   `json:"prev_email_enabled"`
+		PrevSMS       bool   `json:"prev_sms_enabled"`
+		PrevInApp     bool   `json:"prev_in_app_enabled"`
+		NewEnabled    bool   `json:"new_enabled"`
+		NewEmail      bool   `json:"new_email_enabled"`
+		NewSMS        bool   `json:"new_sms_enabled"`
+		NewInApp      bool   `json:"new_in_app_enabled"`
+		CreatedAt     string `json:"created_at"`
 	}
 	var out []row
 	for rows.Next() {

--- a/backend/handlers/provider_callbacks.go
+++ b/backend/handlers/provider_callbacks.go
@@ -14,6 +14,7 @@ import (
 	"github.com/gin-gonic/gin"
 	"github.com/google/uuid"
 	"github.com/healthonyx/backend/db"
+	"github.com/healthonyx/backend/failures"
 )
 
 type ProviderCallbacksHandler struct {
@@ -89,7 +90,8 @@ func twilioFailureTaxonomy(status string) (reason string, suppress bool) {
 func (h *ProviderCallbacksHandler) SendGridWebhook(c *gin.Context) {
 	bodyBytes, err := c.GetRawData()
 	if err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid payload"})
+		f := failures.ClassifyAPI("NTF_CALLBACK_PAYLOAD_INVALID", "invalid payload")
+		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid payload", "failure": f})
 		return
 	}
 	body := string(bodyBytes)
@@ -97,13 +99,15 @@ func (h *ProviderCallbacksHandler) SendGridWebhook(c *gin.Context) {
 	sig := c.GetHeader("X-Twilio-Email-Event-Webhook-Signature")
 	valid := verifySendGridSignature(h.sendGridSecret, ts, body, sig)
 	if !valid {
-		c.JSON(http.StatusUnauthorized, gin.H{"error": "invalid webhook signature"})
+		f := failures.ClassifyAPI("NTF_CALLBACK_SIGNATURE_INVALID", "invalid webhook signature")
+		c.JSON(http.StatusUnauthorized, gin.H{"error": "invalid webhook signature", "failure": f})
 		return
 	}
 
 	var events []sendGridEvent
 	if err := json.Unmarshal(bodyBytes, &events); err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid payload"})
+		f := failures.ClassifyAPI("NTF_CALLBACK_PAYLOAD_INVALID", "invalid payload")
+		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid payload", "failure": f})
 		return
 	}
 	processed := 0
@@ -128,7 +132,8 @@ func (h *ProviderCallbacksHandler) SendGridWebhook(c *gin.Context) {
 			ON CONFLICT(provider, event_id) DO NOTHING
 		`, eventID, strings.ToLower(strings.TrimSpace(e.Event)), nullableUUID(notifID), strings.TrimSpace(strings.ToLower(e.Email)), payloadJSON, e.Timestamp)
 		if insErr != nil {
-			c.JSON(http.StatusInternalServerError, gin.H{"error": "internal error"})
+			f := failures.ClassifyAPI("NTF_CALLBACK_PERSIST_FAILED", "internal error")
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "internal error", "failure": f})
 			return
 		}
 		if cmd.RowsAffected() == 0 {
@@ -152,18 +157,19 @@ func (h *ProviderCallbacksHandler) reconcileSendGridEvent(c *gin.Context, e send
 				WHERE id = $1
 			`, *notifID)
 		default:
-			reason, suppress := sendGridFailureTaxonomy(event)
+			_, suppress := sendGridFailureTaxonomy(event)
+			classified := failures.ClassifyCallback("sendgrid", event, strings.TrimSpace(e.Reason))
 			_, _ = db.Pool.Exec(c.Request.Context(), `
 				UPDATE notifications
 				SET status = 'failed', provider = 'sendgrid', last_error = $2, next_retry_at = NULL
 				WHERE id = $1
-			`, *notifID, reason+":"+strings.TrimSpace(e.Reason))
+			`, *notifID, classified.Encode())
 			if suppress {
 				_, _ = db.Pool.Exec(c.Request.Context(), `
 					INSERT INTO notification_dead_letters(notification_id, channel, provider, final_error, attempt_count)
 					VALUES($1, 'email', 'sendgrid', $2, 1)
 					ON CONFLICT(notification_id) DO UPDATE SET final_error = EXCLUDED.final_error, provider = EXCLUDED.provider, attempt_count = GREATEST(notification_dead_letters.attempt_count, EXCLUDED.attempt_count), created_at = NOW()
-				`, *notifID, reason+":"+strings.TrimSpace(e.Reason))
+				`, *notifID, classified.Encode())
 			}
 		}
 	}
@@ -181,18 +187,21 @@ func (h *ProviderCallbacksHandler) reconcileSendGridEvent(c *gin.Context, e send
 func (h *ProviderCallbacksHandler) TwilioWebhook(c *gin.Context) {
 	bodyBytes, err := c.GetRawData()
 	if err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid payload"})
+		f := failures.ClassifyAPI("NTF_CALLBACK_PAYLOAD_INVALID", "invalid payload")
+		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid payload", "failure": f})
 		return
 	}
 	body := string(bodyBytes)
 	sig := c.GetHeader("X-Twilio-Signature")
 	if !verifyTwilioSignature(h.twilioSecret, body, sig) {
-		c.JSON(http.StatusUnauthorized, gin.H{"error": "invalid webhook signature"})
+		f := failures.ClassifyAPI("NTF_CALLBACK_SIGNATURE_INVALID", "invalid webhook signature")
+		c.JSON(http.StatusUnauthorized, gin.H{"error": "invalid webhook signature", "failure": f})
 		return
 	}
 	messageSID := strings.TrimSpace(c.PostForm("MessageSid"))
 	if messageSID == "" {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "missing MessageSid"})
+		f := failures.ClassifyAPI("NTF_CALLBACK_PAYLOAD_INVALID", "missing MessageSid")
+		c.JSON(http.StatusBadRequest, gin.H{"error": "missing MessageSid", "failure": f})
 		return
 	}
 	status := strings.ToLower(strings.TrimSpace(c.PostForm("MessageStatus")))
@@ -218,7 +227,8 @@ func (h *ProviderCallbacksHandler) TwilioWebhook(c *gin.Context) {
 		ON CONFLICT(provider, event_id) DO NOTHING
 	`, messageSID, status, nullableUUID(notifID), to, payloadJSON)
 	if insErr != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "internal error"})
+		f := failures.ClassifyAPI("NTF_CALLBACK_PERSIST_FAILED", "internal error")
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "internal error", "failure": f})
 		return
 	}
 	if cmd.RowsAffected() == 0 {
@@ -239,18 +249,19 @@ func (h *ProviderCallbacksHandler) reconcileTwilioEvent(c *gin.Context, status, 
 				WHERE id = $1
 			`, *notifID)
 		default:
-			reason, suppress := twilioFailureTaxonomy(status)
+			_, suppress := twilioFailureTaxonomy(status)
+			classified := failures.ClassifyCallback("twilio", status, errMsg)
 			_, _ = db.Pool.Exec(c.Request.Context(), `
 				UPDATE notifications
 				SET status = 'failed', provider = 'twilio', last_error = $2, next_retry_at = NULL
 				WHERE id = $1
-			`, *notifID, reason+":"+errMsg)
+			`, *notifID, classified.Encode())
 			if suppress {
 				_, _ = db.Pool.Exec(c.Request.Context(), `
 					INSERT INTO notification_dead_letters(notification_id, channel, provider, final_error, attempt_count)
 					VALUES($1, 'sms', 'twilio', $2, 1)
 					ON CONFLICT(notification_id) DO UPDATE SET final_error = EXCLUDED.final_error, provider = EXCLUDED.provider, attempt_count = GREATEST(notification_dead_letters.attempt_count, EXCLUDED.attempt_count), created_at = NOW()
-				`, *notifID, reason+":"+errMsg)
+				`, *notifID, classified.Encode())
 			}
 		}
 	}

--- a/backend/workers/notification_worker.go
+++ b/backend/workers/notification_worker.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/healthonyx/backend/db"
+	"github.com/healthonyx/backend/failures"
 	"github.com/healthonyx/backend/providers"
 	"github.com/jackc/pgx/v5"
 )
@@ -136,11 +137,12 @@ func (w *NotificationWorker) processSingle(ctx context.Context, n queuedNotifica
 	if suppressed, reason, err := w.isSuppressed(ctx, n); err != nil {
 		return err
 	} else if suppressed {
+		f := failures.ClassifySuppression(n.Provider, reason)
 		nextAttempt := n.Attempts + 1
 		_, _ = db.Pool.Exec(ctx, `
 			INSERT INTO notification_delivery_attempts(notification_id, channel, provider, attempt_no, success, error_message, latency_ms)
 			VALUES($1, $2, $3, $4, FALSE, $5, 0)
-		`, n.ID, n.Channel, n.Provider, nextAttempt, "suppressed:"+reason)
+		`, n.ID, n.Channel, n.Provider, nextAttempt, f.Encode())
 		_, _ = db.Pool.Exec(ctx, `
 			INSERT INTO notification_dead_letters(notification_id, channel, provider, final_error, attempt_count)
 			VALUES($1, $2, $3, $4, $5)
@@ -149,7 +151,7 @@ func (w *NotificationWorker) processSingle(ctx context.Context, n queuedNotifica
 				final_error = EXCLUDED.final_error,
 				attempt_count = EXCLUDED.attempt_count,
 				created_at = NOW()
-		`, n.ID, n.Channel, n.Provider, "suppressed:"+reason, nextAttempt)
+		`, n.ID, n.Channel, n.Provider, f.Encode(), nextAttempt)
 		_, updateErr := db.Pool.Exec(ctx, `
 			UPDATE notifications
 			SET status = 'failed',
@@ -157,7 +159,7 @@ func (w *NotificationWorker) processSingle(ctx context.Context, n queuedNotifica
 			    last_error = $3,
 			    next_retry_at = NULL
 			WHERE id = $1
-		`, n.ID, nextAttempt, "suppressed:"+reason)
+		`, n.ID, nextAttempt, f.Encode())
 		return updateErr
 	}
 
@@ -168,10 +170,11 @@ func (w *NotificationWorker) processSingle(ctx context.Context, n queuedNotifica
 		latencyMS = 0
 	}
 	nextAttempt := n.Attempts + 1
+	classified := failures.ClassifyProviderSend(mode, err)
 	_, _ = db.Pool.Exec(ctx, `
 		INSERT INTO notification_delivery_attempts(notification_id, channel, provider, attempt_no, success, error_message, latency_ms)
 		VALUES($1, $2, $3, $4, $5, $6, $7)
-	`, n.ID, n.Channel, mode, nextAttempt, err == nil, errorString(err), latencyMS)
+	`, n.ID, n.Channel, mode, nextAttempt, err == nil, errorStringOrClassified(err, classified), latencyMS)
 
 	if err == nil {
 		_, updateErr := db.Pool.Exec(ctx, `
@@ -196,7 +199,7 @@ func (w *NotificationWorker) processSingle(ctx context.Context, n queuedNotifica
 				final_error = EXCLUDED.final_error,
 				attempt_count = EXCLUDED.attempt_count,
 				created_at = NOW()
-		`, n.ID, n.Channel, mode, err.Error(), nextAttempt); deadErr != nil {
+		`, n.ID, n.Channel, mode, classified.Encode(), nextAttempt); deadErr != nil {
 			return deadErr
 		}
 		_, updateErr := db.Pool.Exec(ctx, `
@@ -207,7 +210,7 @@ func (w *NotificationWorker) processSingle(ctx context.Context, n queuedNotifica
 			    last_error = $4,
 			    next_retry_at = NULL
 			WHERE id = $1
-		`, n.ID, nextAttempt, mode, err.Error())
+		`, n.ID, nextAttempt, mode, classified.Encode())
 		return updateErr
 	}
 
@@ -220,7 +223,7 @@ func (w *NotificationWorker) processSingle(ctx context.Context, n queuedNotifica
 		    last_error = $4,
 		    next_retry_at = $5
 		WHERE id = $1
-	`, n.ID, nextAttempt, mode, err.Error(), nextRetry)
+	`, n.ID, nextAttempt, mode, classified.Encode(), nextRetry)
 	return updateErr
 }
 
@@ -294,4 +297,11 @@ func errorString(err error) string {
 		return ""
 	}
 	return err.Error()
+}
+
+func errorStringOrClassified(err error, classified failures.Failure) string {
+	if err == nil {
+		return ""
+	}
+	return classified.Encode()
 }


### PR DESCRIPTION
## Summary
- Add a shared failure taxonomy model with consistent code/severity/remediation/message schema.
- Apply taxonomy encoding to provider callback reconciliation, notification worker retry/dead-letter logging, and admin retry API error responses.
- Add classification unit tests including log schema validation and incident drill replay mappings.

## Test plan
- [x] `go test ./...`
- [x] `go run ./cmd/openapi-sync-check`