### PR TITLE
Fix: notification worker schema + expanded clinical seed scenarios

### DIFF
--- a/backend/cmd/seed/main.go
+++ b/backend/cmd/seed/main.go
@@ -1,14 +1,16 @@
 package main
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"log"
+	"strings"
 	"time"
 
+	"github.com/google/uuid"
 	"github.com/healthonyx/backend/config"
 	"github.com/healthonyx/backend/db"
-	"github.com/google/uuid"
 	"golang.org/x/crypto/bcrypt"
 )
 
@@ -24,10 +26,13 @@ func main() {
 	defer db.Close()
 
 	ctx := context.Background()
+	if err := db.Migrate(ctx); err != nil {
+		log.Fatalf("migration: %v", err)
+	}
 
 	hospitals := []struct {
 		name, city, region string
-		lat, lng            float64
+		lat, lng           float64
 	}{
 		{"UF Health Shands Hospital", "Gainesville", "Florida", 29.6406, -82.3444},
 		{"Orlando Health", "Orlando", "Florida", 28.5383, -81.3792},
@@ -90,9 +95,18 @@ func main() {
 		fmt.Println("Doctor profile: specialization + hospital linked.")
 	}
 
+	ids, err := loadDemoUserIDs(ctx)
+	if err != nil {
+		log.Fatalf("load demo user ids: %v", err)
+	}
+
+	if err := seedClinicalScenarioData(ctx, ids); err != nil {
+		log.Fatalf("seed clinical scenario data: %v", err)
+	}
+
 	// One demo open slot for the demo doctor (tomorrow 10:00 UTC window — adjust in app as needed)
 	var docID uuid.UUID
-	err := db.Pool.QueryRow(ctx, `SELECT id FROM users WHERE email = 'doctor@healthonyx.demo' AND role = 'doctor'`).Scan(&docID)
+	err = db.Pool.QueryRow(ctx, `SELECT id FROM users WHERE email = 'doctor@healthonyx.demo' AND role = 'doctor'`).Scan(&docID)
 	if err != nil {
 		log.Printf("demo slot: doctor id: %v", err)
 	} else {
@@ -112,4 +126,182 @@ func main() {
 	}
 
 	fmt.Println("Demo users seeded. Use these credentials to log in.")
+}
+
+type demoIDs struct {
+	admin   uuid.UUID
+	doctor  uuid.UUID
+	patient uuid.UUID
+}
+
+func loadDemoUserIDs(ctx context.Context) (demoIDs, error) {
+	var out demoIDs
+	if err := db.Pool.QueryRow(ctx, `SELECT id FROM users WHERE email='admin@healthonyx.demo'`).Scan(&out.admin); err != nil {
+		return out, err
+	}
+	if err := db.Pool.QueryRow(ctx, `SELECT id FROM users WHERE email='doctor@healthonyx.demo'`).Scan(&out.doctor); err != nil {
+		return out, err
+	}
+	if err := db.Pool.QueryRow(ctx, `SELECT id FROM users WHERE email='patient@healthonyx.demo'`).Scan(&out.patient); err != nil {
+		return out, err
+	}
+	return out, nil
+}
+
+func seedClinicalScenarioData(ctx context.Context, ids demoIDs) error {
+	now := time.Now().UTC()
+
+	// Appointment scenarios: pending + approved + completed.
+	var apptID uuid.UUID
+	err := db.Pool.QueryRow(ctx, `
+		INSERT INTO appointments (patient_id, doctor_id, scheduled_at, reason, status)
+		VALUES ($1, $2, $3, $4, 'approved')
+		RETURNING id
+	`, ids.patient, ids.doctor, now.Add(48*time.Hour), "Follow-up blood pressure review").Scan(&apptID)
+	if err != nil {
+		return err
+	}
+	_, _ = db.Pool.Exec(ctx, `
+		INSERT INTO appointment_activities (appointment_id, actor_user_id, action, detail)
+		VALUES ($1, $2, 'status_changed', 'approved')
+	`, apptID, ids.doctor)
+
+	// Prescription + reminder + guardrail-related notification scenarios.
+	var rxID uuid.UUID
+	err = db.Pool.QueryRow(ctx, `
+		INSERT INTO prescriptions (patient_id, doctor_id, medication_name, dosage, frequency, duration_days, instructions, status)
+		VALUES ($1, $2, $3, $4, $5, $6, $7, 'active')
+		RETURNING id
+	`, ids.patient, ids.doctor, "Atorvastatin", "20mg", "once daily", 30, "Take after dinner").Scan(&rxID)
+	if err != nil {
+		return err
+	}
+	_, _ = db.Pool.Exec(ctx, `
+		INSERT INTO notifications (user_id, title, body, channel, status, scheduled_for, provider, attempts, last_error)
+		VALUES ($1, $2, $3, 'email', 'pending', $4, 'sendgrid', 0, '')
+	`, ids.patient, "Medication reminder", "Take Atorvastatin 20mg tonight.", now.Add(12*time.Hour))
+
+	// AI summary ready documents: normal + critical.
+	docBodyNormal := []byte("CBC panel within expected range. Continue current regimen and hydration.")
+	docBodyCritical := []byte("Critical alert: potassium level dangerously high. Immediate doctor follow-up required.")
+	if err := insertPatientDocument(ctx, ids.patient, "cbc-report.pdf", docBodyNormal, "CBC panel within expected range.", "ready"); err != nil {
+		return err
+	}
+	if err := insertPatientDocument(ctx, ids.patient, "critical-potassium-lab.pdf", docBodyCritical, "Critical potassium result; urgent follow-up needed.", "ready"); err != nil {
+		return err
+	}
+
+	// Knowledge base scenario docs for stale/conflict/similarity workflows.
+	if err := insertKnowledgeDocIfMissing(ctx, ids.admin, "Hypertension Protocol v1", "Start with low-dose ACE inhibitor; monitor weekly."); err != nil {
+		return err
+	}
+	if err := insertKnowledgeDocIfMissing(ctx, ids.admin, "Hypertension Protocol Legacy", "Begin with beta blocker as first-line for all patients."); err != nil {
+		return err
+	}
+	if err := insertKnowledgeDocIfMissing(ctx, ids.admin, "Lab Escalation SOP", "Escalate critical results within 15 minutes and track acknowledgments."); err != nil {
+		return err
+	}
+
+	// Interoperability test fixtures for FHIR/HL7 boundaries.
+	hl7Fixture := strings.Join([]string{
+		"MSH|^~\\&|LAB|HOSP|HEALTHONYX|APP|" + now.Format("20060102150405") + "||ORU^R01|SEED-MSG-1|P|2.5",
+		"PID|1||" + ids.patient.String() + "^^^HEALTHONYX||Demo^Patient",
+		"OBX|1|NM|GLU^Glucose||110|mg/dL|70-110|N|||F",
+	}, "\r")
+	_, _ = db.Pool.Exec(ctx, `
+		INSERT INTO hl7_lab_ingestion_events (
+			message_control_id, patient_identifier, patient_id, observation_code, observation_value, units,
+			transform_status, transform_outcome, hl7_message
+		) VALUES ($1, $2, $3, $4, $5, $6, 'reconciled', 'seed_fixture_loaded', $7)
+	`, "SEED-MSG-1", ids.patient.String(), ids.patient, "GLU", "110", "mg/dL", hl7Fixture)
+
+	// Admin AI runtime seeded for observability/usability checks.
+	_, _ = db.Pool.Exec(ctx, `
+		UPDATE admin_ai_runtime_settings
+		SET fallback_enabled = TRUE,
+		    rate_limit_enabled = TRUE,
+		    cache_enabled = TRUE,
+		    prompt_version = 'v1',
+		    updated_by = $1,
+		    updated_at = NOW()
+		WHERE id = TRUE
+	`, ids.admin)
+
+	_, _ = db.Pool.Exec(ctx, `
+		INSERT INTO admin_ai_eval_runs (model_name, prompt_version, fixture_count, passed_count, success_rate, quality_score, runtime_mode, ai_enabled, ollama_reachable, model_available, created_by)
+		VALUES ('llama3.1:8b', 'v1', 5, 4, 0.8, 0.84, 'fallback_local', FALSE, FALSE, FALSE, $1)
+	`, ids.admin)
+
+	fmt.Printf("Seeded clinical scenarios for patient=%s doctor=%s rx=%s appointment=%s\n", ids.patient, ids.doctor, rxID, apptID)
+	return nil
+}
+
+func insertPatientDocument(ctx context.Context, patientID uuid.UUID, filename string, body []byte, summary string, summaryStatus string) error {
+	var existing int
+	if err := db.Pool.QueryRow(ctx, `SELECT COUNT(*) FROM patient_documents WHERE patient_id = $1 AND filename = $2`, patientID, filename).Scan(&existing); err != nil {
+		return err
+	}
+	if existing > 0 {
+		return nil
+	}
+	hasBody, err := tableHasColumn(ctx, "patient_documents", "body")
+	if err != nil {
+		return err
+	}
+	hasFileData, err := tableHasColumn(ctx, "patient_documents", "file_data")
+	if err != nil {
+		return err
+	}
+
+	switch {
+	case hasBody && hasFileData:
+		_, err = db.Pool.Exec(ctx, `
+			INSERT INTO patient_documents (patient_id, filename, content_type, size_bytes, status, body, file_data, summary, summary_status)
+			VALUES ($1, $2, 'application/pdf', $3, 'ready', $4, $5, $6, $7)
+		`, patientID, filename, len(body), bytes.Clone(body), bytes.Clone(body), summary, summaryStatus)
+		return err
+	case hasBody:
+		_, err = db.Pool.Exec(ctx, `
+			INSERT INTO patient_documents (patient_id, filename, content_type, size_bytes, status, body, summary, summary_status)
+			VALUES ($1, $2, 'application/pdf', $3, 'ready', $4, $5, $6)
+		`, patientID, filename, len(body), bytes.Clone(body), summary, summaryStatus)
+		return err
+	case hasFileData:
+		_, err = db.Pool.Exec(ctx, `
+			INSERT INTO patient_documents (patient_id, filename, file_data, summary, summary_status)
+			VALUES ($1, $2, $3, $4, $5)
+		`, patientID, filename, bytes.Clone(body), summary, summaryStatus)
+		return err
+	default:
+		return fmt.Errorf("patient_documents has neither body nor file_data columns")
+	}
+}
+
+func insertKnowledgeDocIfMissing(ctx context.Context, createdBy uuid.UUID, title string, body string) error {
+	var existing int
+	if err := db.Pool.QueryRow(ctx, `SELECT COUNT(*) FROM knowledge_docs WHERE title = $1`, title).Scan(&existing); err != nil {
+		return err
+	}
+	if existing > 0 {
+		return nil
+	}
+	_, err := db.Pool.Exec(ctx, `
+		INSERT INTO knowledge_docs (title, body, created_by)
+		VALUES ($1, $2, $3)
+	`, title, body, createdBy)
+	return err
+}
+
+func tableHasColumn(ctx context.Context, tableName string, columnName string) (bool, error) {
+	var exists bool
+	err := db.Pool.QueryRow(ctx, `
+		SELECT EXISTS (
+			SELECT 1
+			FROM information_schema.columns
+			WHERE table_schema = 'public'
+			  AND table_name = $1
+			  AND column_name = $2
+		)
+	`, tableName, columnName).Scan(&exists)
+	return exists, err
 }

--- a/backend/db/db.go
+++ b/backend/db/db.go
@@ -309,6 +309,12 @@ func Migrate(ctx context.Context) error {
 		);
 
 		CREATE INDEX IF NOT EXISTS idx_patient_documents_patient ON patient_documents(patient_id);
+		ALTER TABLE patient_documents ADD COLUMN IF NOT EXISTS content_type TEXT NOT NULL DEFAULT 'application/octet-stream';
+		ALTER TABLE patient_documents ADD COLUMN IF NOT EXISTS size_bytes BIGINT NOT NULL DEFAULT 0;
+		ALTER TABLE patient_documents ADD COLUMN IF NOT EXISTS status TEXT NOT NULL DEFAULT 'ready';
+		ALTER TABLE patient_documents ADD COLUMN IF NOT EXISTS body BYTEA NOT NULL DEFAULT ''::bytea;
+		ALTER TABLE patient_documents DROP CONSTRAINT IF EXISTS patient_documents_status_check;
+		ALTER TABLE patient_documents ADD CONSTRAINT patient_documents_status_check CHECK (status IN ('pending', 'ready', 'failed'));
 
 		ALTER TABLE patient_documents ADD COLUMN IF NOT EXISTS summary TEXT;
 		ALTER TABLE patient_documents ADD COLUMN IF NOT EXISTS summary_status TEXT NOT NULL DEFAULT 'none';
@@ -390,6 +396,38 @@ func Migrate(ctx context.Context) error {
 		);
 
 		CREATE INDEX IF NOT EXISTS idx_notifications_user ON notifications(user_id);
+		ALTER TABLE notifications ADD COLUMN IF NOT EXISTS provider TEXT NOT NULL DEFAULT '';
+		ALTER TABLE notifications ADD COLUMN IF NOT EXISTS attempts INTEGER NOT NULL DEFAULT 0;
+		ALTER TABLE notifications ADD COLUMN IF NOT EXISTS last_error TEXT NOT NULL DEFAULT '';
+		ALTER TABLE notifications ADD COLUMN IF NOT EXISTS next_retry_at TIMESTAMPTZ;
+		ALTER TABLE notifications ADD COLUMN IF NOT EXISTS sent_at TIMESTAMPTZ;
+		CREATE INDEX IF NOT EXISTS idx_notifications_pending_schedule
+			ON notifications(status, scheduled_for, next_retry_at);
+
+		CREATE TABLE IF NOT EXISTS notification_delivery_attempts (
+			id              UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+			notification_id UUID NOT NULL REFERENCES notifications(id) ON DELETE CASCADE,
+			channel         TEXT NOT NULL,
+			provider        TEXT NOT NULL DEFAULT '',
+			attempt_no      INTEGER NOT NULL CHECK (attempt_no >= 1),
+			success         BOOLEAN NOT NULL DEFAULT FALSE,
+			error_message   TEXT NOT NULL DEFAULT '',
+			latency_ms      INTEGER NOT NULL DEFAULT 0,
+			created_at      TIMESTAMPTZ NOT NULL DEFAULT NOW()
+		);
+		CREATE INDEX IF NOT EXISTS idx_notification_delivery_attempts_notification
+			ON notification_delivery_attempts(notification_id, created_at DESC);
+
+		CREATE TABLE IF NOT EXISTS notification_dead_letters (
+			notification_id UUID PRIMARY KEY REFERENCES notifications(id) ON DELETE CASCADE,
+			channel         TEXT NOT NULL,
+			provider        TEXT NOT NULL DEFAULT '',
+			final_error     TEXT NOT NULL DEFAULT '',
+			attempt_count   INTEGER NOT NULL DEFAULT 0 CHECK (attempt_count >= 0),
+			created_at      TIMESTAMPTZ NOT NULL DEFAULT NOW()
+		);
+		CREATE INDEX IF NOT EXISTS idx_notification_dead_letters_created
+			ON notification_dead_letters(created_at DESC);
 
 		CREATE TABLE IF NOT EXISTS provider_callback_events (
 			id               UUID PRIMARY KEY DEFAULT gen_random_uuid(),

--- a/docs/CLINICAL-GRADE-STORIES.md
+++ b/docs/CLINICAL-GRADE-STORIES.md
@@ -1,0 +1,41 @@
+# Clinical Grade Gap-Closure Stories
+
+This backlog translates remaining clinical-grade gaps into testable user stories.
+
+## CGS-01: Notification Worker Schema Reliability
+
+- **As** a platform operator
+- **I want** notification worker queries and writes to run against guaranteed DB schema
+- **So that** delivery processing does not fail at runtime in production.
+
+### Acceptance Criteria
+- Runtime logs contain no `column n.provider does not exist` worker errors.
+- New and existing databases both include required `notifications` columns.
+- Delivery telemetry persists to `notification_delivery_attempts`.
+- Exhausted retries persist to `notification_dead_letters`.
+- `go test ./...` and `npm run cypress:e2e` pass after migration.
+
+## CGS-02: Production-Grade Evidence Expansion
+
+- **As** a release manager
+- **I want** sustained performance and chaos evidence from production-like runs
+- **So that** release gates are based on operationally meaningful proof.
+
+### Acceptance Criteria
+- Soak test window >= 30 minutes captured in artifact.
+- Chaos scenarios include provider outage and delayed callback replay.
+- Evidence artifacts include run parameters, observed p95, error-rate, and pass/fail.
+- Gate summary links each result to timestamped evidence.
+
+## CGS-03: Usability Validation for Clinical Workflows
+
+- **As** a clinical product owner
+- **I want** repeatable usability benchmark scenarios with seeded data
+- **So that** we can verify that critical workflows are usable under realistic conditions.
+
+### Acceptance Criteria
+- Seeded scenario dataset covers patient, doctor, and admin workflows end-to-end.
+- Includes AI summary-ready documents and critical-result examples.
+- Includes notification, escalation, guardrail, FHIR, and HL7 scenarios.
+- Website smoke + E2E runs complete using seeded dataset without manual setup.
+


### PR DESCRIPTION
## Summary
- Fix notification worker runtime reliability by ensuring DB schema has provider/attempts/etc.
- Expand seed data for multi-feature clinical workflows and AI scenarios.
- Add clinical-grade gap closure stories (CGS-01..03) to make remaining upgrade work testable.

## Test plan
- [x] `go test ./...` (backend)
- [x] `go run ./cmd/seed` (seed clinical scenarios for smoke)