### PR TITLE
fix(ci): create patient_documents before FK-referencing tables

### DIFF
--- a/backend/db/db.go
+++ b/backend/db/db.go
@@ -261,6 +261,20 @@ func Migrate(ctx context.Context) error {
 
 		CREATE INDEX IF NOT EXISTS idx_knowledge_doc_chunks_doc ON knowledge_doc_chunks(document_id);
 
+		-- patient_documents is referenced by FKs from other tables (e.g. critical_result_escalations),
+		-- so ensure it exists before we create those referencing tables in a fresh database.
+		CREATE TABLE IF NOT EXISTS patient_documents (
+			id            UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+			patient_id    UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+			filename      TEXT NOT NULL,
+			content_type  TEXT NOT NULL DEFAULT 'application/octet-stream',
+			size_bytes    BIGINT NOT NULL DEFAULT 0,
+			status        TEXT NOT NULL DEFAULT 'ready' CHECK (status IN ('pending', 'ready', 'failed')),
+			body          BYTEA NOT NULL,
+			created_at    TIMESTAMPTZ NOT NULL DEFAULT NOW()
+		);
+		CREATE INDEX IF NOT EXISTS idx_patient_documents_patient ON patient_documents(patient_id);
+
 		CREATE TABLE IF NOT EXISTS critical_result_escalations (
 			id                   UUID PRIMARY KEY DEFAULT gen_random_uuid(),
 			doctor_id            UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,


### PR DESCRIPTION
Fixes Clinical Release Gates CI failure by ensuring patient_documents exists before tables that reference it via foreign keys during fresh Postgres migrations.

Made with [Cursor](https://cursor.com)