### PR TITLE
fix(ci): stabilize clinical gate error-rate under escalation race

### DIFF
--- a/backend/handlers/critical_escalations.go
+++ b/backend/handlers/critical_escalations.go
@@ -58,7 +58,13 @@ func escalationMessage(tier int, filename, patientEmail string) string {
 
 func isPgUniqueViolation(err error) bool {
 	var pgErr *pgconn.PgError
-	return errors.As(err, &pgErr) && pgErr.Code == "23505"
+	if errors.As(err, &pgErr) && pgErr.Code == "23505" {
+		return true
+	}
+	// Some driver/code paths surface this as plain text; guard for the known index.
+	msg := strings.ToLower(strings.TrimSpace(err.Error()))
+	return strings.Contains(msg, "idx_critical_result_escalations_active_doc") &&
+		strings.Contains(msg, "duplicate key value")
 }
 
 func enqueueEscalationNotification(ctx context.Context, doctorID uuid.UUID, title, body string) {

--- a/backend/handlers/critical_escalations_test.go
+++ b/backend/handlers/critical_escalations_test.go
@@ -52,6 +52,12 @@ func TestIsPgUniqueViolation(t *testing.T) {
 	if !isPgUniqueViolation(&pgconn.PgError{Code: "23505"}) {
 		t.Fatal("expected true for postgres unique violation")
 	}
+	if !isPgUniqueViolation(fmt.Errorf("wrapped: %w", &pgconn.PgError{Code: "23505"})) {
+		t.Fatal("expected true for wrapped postgres unique violation")
+	}
+	if !isPgUniqueViolation(fmt.Errorf(`ERROR: duplicate key value violates unique constraint "idx_critical_result_escalations_active_doc" (SQLSTATE 23505)`)) {
+		t.Fatal("expected true for plain text duplicate key violation")
+	}
 	if isPgUniqueViolation(&pgconn.PgError{Code: "23503"}) {
 		t.Fatal("expected false for non-unique postgres error")
 	}


### PR DESCRIPTION
## Summary
- make duplicate escalation conflict detection robust for wrapped and plain-text error forms
- prevent intermittent doctor-dashboard 500s from duplicate active escalation races under soak concurrency

## Test plan
- [x] `cd backend && go test ./...`
- [x] `cd frontend && npm run cypress:e2e`
- [x] `python scripts/clinical-gates/check_gates.py --security artifacts/clinical-gates/security-evidence.json --reliability artifacts/clinical-gates/reliability-evidence.json --performance artifacts/clinical-gates/performance-evidence.json --summary artifacts/clinical-gates/release-gate-summary.json`