### PR TITLE
fix patient UX regressions across files, notifications, and messaging

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -27,6 +27,12 @@ OLLAMA_MODEL=llama3.1:8b
 # Request timeout to Ollama in milliseconds
 OLLAMA_TIMEOUT_MS=7000
 
+# Encryption-at-rest keyring for PHI/messages (AES-256 keys base64 as "version:key")
+# PHI_ENCRYPTION_KEYS=1:BASE64_32_BYTE_KEY
+# PHI_ENCRYPTION_ACTIVE_VERSION=1
+# Demo fallback: when true, messaging works even if PHI_ENCRYPTION_KEYS is unset.
+ALLOW_PLAINTEXT_MESSAGING=true
+
 # Notification delivery engine (PR-06)
 # Poll interval for due notification jobs
 NOTIFY_WORKER_INTERVAL_MS=5000

--- a/backend/handlers/messaging.go
+++ b/backend/handlers/messaging.go
@@ -3,6 +3,7 @@ package handlers
 import (
 	"context"
 	"net/http"
+	"os"
 	"strings"
 	"time"
 	"unicode/utf8"
@@ -23,6 +24,11 @@ func NewMessagingHandler(hub *MessagingHub) *MessagingHandler {
 }
 
 const maxMessageRunes = 8000
+
+func allowPlaintextMessagingFallback() bool {
+	v := strings.TrimSpace(strings.ToLower(os.Getenv("ALLOW_PLAINTEXT_MESSAGING")))
+	return v == "" || v == "1" || v == "true" || v == "yes"
+}
 
 func previewText(s string) string {
 	s = strings.TrimSpace(s)
@@ -285,15 +291,30 @@ func (h *MessagingHandler) SendMessage(c *gin.Context) {
 		return
 	}
 
+	encrypted := true
+	encryptedBody := body
+	keyVersion := 0
+	wrappedKey := ""
+	wrappedNonce := ""
+	dataNonce := ""
 	kr, krErr := security.LoadKeyringFromEnv()
 	if krErr != nil {
-		c.JSON(http.StatusServiceUnavailable, gin.H{"error": "Encryption keyring not configured"})
-		return
-	}
-	env, encErr := kr.Encrypt([]byte(body))
-	if encErr != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "Unable to encrypt message"})
-		return
+		if !allowPlaintextMessagingFallback() {
+			c.JSON(http.StatusServiceUnavailable, gin.H{"error": "Encryption keyring not configured"})
+			return
+		}
+		encrypted = false
+	} else {
+		env, encErr := kr.Encrypt([]byte(body))
+		if encErr != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "Unable to encrypt message"})
+			return
+		}
+		encryptedBody = security.B64Encode(env.Ciphertext)
+		keyVersion = env.KeyVersion
+		wrappedKey = security.B64Encode(env.WrappedKey)
+		wrappedNonce = security.B64Encode(env.WrappedNonce)
+		dataNonce = security.B64Encode(env.DataNonce)
 	}
 
 	var msg chatMessageRow
@@ -302,10 +323,10 @@ func (h *MessagingHandler) SendMessage(c *gin.Context) {
 			thread_id, sender_id, body,
 			body_is_encrypted, body_key_version, body_wrapped_key, body_wrapped_nonce, body_data_nonce
 		)
-		VALUES ($1, $2, $3, TRUE, $4, $5, $6, $7)
+		VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
 		RETURNING id, thread_id, sender_id, created_at
-	`, threadID, claims.UserID, security.B64Encode(env.Ciphertext),
-		env.KeyVersion, security.B64Encode(env.WrappedKey), security.B64Encode(env.WrappedNonce), security.B64Encode(env.DataNonce),
+	`, threadID, claims.UserID, encryptedBody,
+		encrypted, keyVersion, wrappedKey, wrappedNonce, dataNonce,
 	).Scan(&msg.ID, &msg.ThreadID, &msg.SenderID, &msg.CreatedAt)
 	if err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "Unable to send message"})
@@ -396,15 +417,30 @@ func (h *MessagingHandler) CreateThread(c *gin.Context) {
 		return
 	}
 
+	encrypted := true
+	encryptedBody := body
+	keyVersion := 0
+	wrappedKey := ""
+	wrappedNonce := ""
+	dataNonce := ""
 	kr, krErr := security.LoadKeyringFromEnv()
 	if krErr != nil {
-		c.JSON(http.StatusServiceUnavailable, gin.H{"error": "Encryption keyring not configured"})
-		return
-	}
-	env, encErr := kr.Encrypt([]byte(body))
-	if encErr != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "Unable to encrypt message"})
-		return
+		if !allowPlaintextMessagingFallback() {
+			c.JSON(http.StatusServiceUnavailable, gin.H{"error": "Encryption keyring not configured"})
+			return
+		}
+		encrypted = false
+	} else {
+		env, encErr := kr.Encrypt([]byte(body))
+		if encErr != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "Unable to encrypt message"})
+			return
+		}
+		encryptedBody = security.B64Encode(env.Ciphertext)
+		keyVersion = env.KeyVersion
+		wrappedKey = security.B64Encode(env.WrappedKey)
+		wrappedNonce = security.B64Encode(env.WrappedNonce)
+		dataNonce = security.B64Encode(env.DataNonce)
 	}
 
 	var msg chatMessageRow
@@ -413,10 +449,10 @@ func (h *MessagingHandler) CreateThread(c *gin.Context) {
 			thread_id, sender_id, body,
 			body_is_encrypted, body_key_version, body_wrapped_key, body_wrapped_nonce, body_data_nonce
 		)
-		VALUES ($1, $2, $3, TRUE, $4, $5, $6, $7)
+		VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
 		RETURNING id, created_at
-	`, threadID, claims.UserID, security.B64Encode(env.Ciphertext),
-		env.KeyVersion, security.B64Encode(env.WrappedKey), security.B64Encode(env.WrappedNonce), security.B64Encode(env.DataNonce),
+	`, threadID, claims.UserID, encryptedBody,
+		encrypted, keyVersion, wrappedKey, wrappedNonce, dataNonce,
 	).Scan(&msg.ID, &msg.CreatedAt)
 	if err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "Unable to send first message"})

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.0",
   "scripts": {
     "ng": "ng",
-    "start": "ng serve",
+    "start": "ng serve --configuration=development --no-open --host 127.0.0.1 --port 4200",
     "build": "ng build",
     "watch": "ng build --watch --configuration development",
     "test": "ng test",

--- a/frontend/src/app/app.routes.ts
+++ b/frontend/src/app/app.routes.ts
@@ -20,7 +20,6 @@ import { DoctorAvailabilityComponent } from './components/doctor-availability/do
 import { DoctorDocumentsListComponent } from './components/doctor-documents-list/doctor-documents-list.component';
 import { DoctorDocumentDetailComponent } from './components/doctor-document-detail/doctor-document-detail.component';
 import { MessagesComponent } from './components/messages/messages.component';
-import { PatientFilesComponent } from './components/patient-files/patient-files.component';
 import { PatientPrescriptionsComponent } from './components/patient-prescriptions/patient-prescriptions.component';
 import { NotificationsInboxComponent } from './components/notifications-inbox/notifications-inbox.component';
 import { PatientDashboardComponent } from './components/patient-dashboard/patient-dashboard.component';
@@ -87,9 +86,8 @@ export const routes: Routes = [
           },
           {
             path: 'my-files',
-            component: PatientFilesComponent,
-            data: { title: 'My files', roles: ['patient'] },
-            canActivate: [roleGuard]
+            pathMatch: 'full',
+            redirectTo: 'documents'
           },
           {
             path: 'prescriptions',

--- a/frontend/src/app/components/app-shell/app-shell.component.html
+++ b/frontend/src/app/components/app-shell/app-shell.component.html
@@ -72,4 +72,35 @@
   <main class="content">
     <router-outlet />
   </main>
+
+  @if (notificationPopup) {
+    <aside class="notif-popup" data-cy="notification-popup">
+      <div class="notif-popup__head">
+        <strong>{{ notificationPopup.title }}</strong>
+        <button type="button" class="notif-popup__close" (click)="dismissNotificationPopup()">✕</button>
+      </div>
+      <p class="notif-popup__body">{{ notificationPopup.body }}</p>
+      <small class="notif-popup__meta">
+        {{ notificationPopup.channel | titlecase }} · {{ notificationPopup.created_at | date: 'medium' }}
+      </small>
+    </aside>
+  }
+
+  <button type="button" class="assistant-fab" (click)="toggleAssistant()" data-cy="assistant-fab">
+    {{ assistantOpen ? 'Close AI' : 'AI assistant' }}
+  </button>
+  @if (assistantOpen) {
+    <aside class="assistant-panel" data-cy="assistant-panel">
+      <h3>Care assistant</h3>
+      <div class="assistant-chat">
+        @for (m of assistantMessages; track $index) {
+          <p [class]="m.from === 'me' ? 'msg msg-me' : 'msg msg-ai'">{{ m.text }}</p>
+        }
+      </div>
+      <div class="assistant-input">
+        <input [(ngModel)]="assistantInput" placeholder="Ask about features..." (keydown.enter)="sendAssistant()" />
+        <button type="button" (click)="sendAssistant()">Send</button>
+      </div>
+    </aside>
+  }
 </div>

--- a/frontend/src/app/components/app-shell/app-shell.component.scss
+++ b/frontend/src/app/components/app-shell/app-shell.component.scss
@@ -258,6 +258,105 @@
   overflow-y: auto;
 }
 
+.notif-popup {
+  position: fixed;
+  right: 1rem;
+  bottom: 1rem;
+  width: min(360px, calc(100vw - 2rem));
+  z-index: 30;
+  border-radius: 14px;
+  border: 1px solid rgba(148, 163, 184, 0.35);
+  background: rgba(15, 23, 42, 0.96);
+  box-shadow: 0 15px 45px rgba(2, 8, 23, 0.5);
+  padding: 0.8rem 0.85rem;
+}
+
+.notif-popup__head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+}
+
+.notif-popup__close {
+  border: none;
+  background: transparent;
+  color: #cbd5e1;
+  font-size: 0.9rem;
+  cursor: pointer;
+}
+
+.notif-popup__body {
+  margin: 0.45rem 0;
+  color: #e2e8f0;
+}
+
+.notif-popup__meta {
+  color: #94a3b8;
+}
+
+.assistant-fab {
+  position: fixed;
+  right: 1rem;
+  bottom: 7rem;
+  z-index: 30;
+  border-radius: 999px;
+  border: 1px solid #22d3ee;
+  background: #0f172a;
+  color: #22d3ee;
+  padding: 0.45rem 0.9rem;
+}
+
+.assistant-panel {
+  position: fixed;
+  right: 1rem;
+  bottom: 10rem;
+  width: min(360px, calc(100vw - 2rem));
+  z-index: 30;
+  border: 1px solid rgba(148, 163, 184, 0.35);
+  border-radius: 14px;
+  background: rgba(2, 6, 23, 0.98);
+  padding: 0.7rem;
+}
+
+.assistant-chat {
+  max-height: 240px;
+  overflow: auto;
+  display: grid;
+  gap: 0.45rem;
+  margin-bottom: 0.5rem;
+}
+
+.msg {
+  margin: 0;
+  padding: 0.4rem 0.55rem;
+  border-radius: 10px;
+}
+
+.msg-ai {
+  background: rgba(34, 211, 238, 0.12);
+  color: #e0f2fe;
+}
+
+.msg-me {
+  background: rgba(99, 102, 241, 0.2);
+  color: #e2e8f0;
+}
+
+.assistant-input {
+  display: flex;
+  gap: 0.4rem;
+}
+
+.assistant-input input {
+  flex: 1;
+  border: 1px solid #334155;
+  border-radius: 8px;
+  background: #0b1220;
+  color: #e2e8f0;
+  padding: 0.45rem 0.5rem;
+}
+
 /* Responsive */
 @media (min-width: 768px) {
   .shell {

--- a/frontend/src/app/components/app-shell/app-shell.component.ts
+++ b/frontend/src/app/components/app-shell/app-shell.component.ts
@@ -4,21 +4,32 @@ import { RouterModule, Router } from '@angular/router';
 import { Subscription, timer, switchMap } from 'rxjs';
 import { AuthService } from '../../services/auth.service';
 import { MessagingService } from '../../services/messaging.service';
+import { NotificationsInboxService, NotificationRow } from '../../services/notifications.service';
+import { FormsModule } from '@angular/forms';
 
 @Component({
   selector: 'app-shell',
   standalone: true,
-  imports: [CommonModule, RouterModule, TitleCasePipe, AsyncPipe],
+  imports: [CommonModule, RouterModule, TitleCasePipe, AsyncPipe, FormsModule],
   templateUrl: './app-shell.component.html',
   styleUrl: './app-shell.component.scss'
 })
 export class AppShellComponent implements OnInit, OnDestroy {
   private unreadPoll?: Subscription;
+  private notifPoll?: Subscription;
   private realtimeUnreadSub?: Subscription;
+  private seenNotificationIds = new Set<string>();
+  notificationPopup: NotificationRow | null = null;
+  assistantOpen = false;
+  assistantInput = '';
+  assistantMessages: { from: 'assistant' | 'me'; text: string }[] = [
+    { from: 'assistant', text: 'Hi, I can help with summaries, notifications, and find-care workflows.' }
+  ];
 
   constructor(
     public auth: AuthService,
     public messaging: MessagingService,
+    private notifications: NotificationsInboxService,
     private router: Router
   ) {}
 
@@ -34,10 +45,16 @@ export class AppShellComponent implements OnInit, OnDestroy {
     this.unreadPoll = timer(0, 30_000)
       .pipe(switchMap(() => this.messaging.refreshUnread()))
       .subscribe();
+    if (role === 'patient' || role === 'doctor') {
+      this.notifPoll = timer(0, 20_000).pipe(switchMap(() => this.notifications.listMine())).subscribe({
+        next: (res) => this.handleNotificationPoll(res.notifications ?? [])
+      });
+    }
   }
 
   ngOnDestroy(): void {
     this.unreadPoll?.unsubscribe();
+    this.notifPoll?.unsubscribe();
     this.realtimeUnreadSub?.unsubscribe();
     this.messaging.disconnectRealtime();
   }
@@ -59,7 +76,6 @@ export class AppShellComponent implements OnInit, OnDestroy {
     if (
       path.endsWith('/appointments') ||
       path.endsWith('/messages') ||
-      path.endsWith('/my-files') ||
       path.endsWith('/prescriptions') ||
       path.endsWith('/notifications') ||
       path.endsWith('/dashboard') ||
@@ -76,7 +92,6 @@ export class AppShellComponent implements OnInit, OnDestroy {
     const all = [
       { path: '/patient/dashboard', label: 'Dashboard', roles: ['patient'] },
       { path: '/patient/find-care', label: 'Find care', roles: ['patient'] },
-      { path: '/patient/my-files', label: 'My files', roles: ['patient'] },
       { path: '/patient/prescriptions', label: 'Prescriptions', roles: ['patient'] },
       { path: '/patient/appointments', label: 'My Appointments', roles: ['patient'] },
       { path: '/patient/documents', label: 'My documents', roles: ['patient'] },
@@ -93,6 +108,48 @@ export class AppShellComponent implements OnInit, OnDestroy {
       { path: '/admin/knowledge', label: 'Knowledge (admin)', roles: ['admin'] }
     ];
     return all.filter((l) => l.roles.includes(this.role));
+  }
+
+  dismissNotificationPopup(): void {
+    this.notificationPopup = null;
+  }
+
+  toggleAssistant(): void {
+    this.assistantOpen = !this.assistantOpen;
+  }
+
+  sendAssistant(): void {
+    const q = this.assistantInput.trim();
+    if (!q) {
+      return;
+    }
+    this.assistantMessages = [...this.assistantMessages, { from: 'me', text: q }];
+    this.assistantInput = '';
+    const lower = q.toLowerCase();
+    let answer = 'I can help with: document AI summary, notifications settings, and nearby hospitals.';
+    if (lower.includes('summary') || lower.includes('document')) {
+      answer = 'For AI summaries, open doctor -> Patient documents -> Open a document -> Start summary.';
+    } else if (lower.includes('notification')) {
+      answer = 'Open Notifications to configure channels and view live alerts with popups.';
+    } else if (lower.includes('find care') || lower.includes('hospital') || lower.includes('location')) {
+      answer = 'Use Find care, click "Use my location", then Hospitals nearby. You can also filter by department.';
+    }
+    this.assistantMessages = [...this.assistantMessages, { from: 'assistant', text: answer }];
+  }
+
+  private handleNotificationPoll(rows: NotificationRow[]): void {
+    if (rows.length === 0) {
+      return;
+    }
+    if (this.seenNotificationIds.size === 0) {
+      rows.forEach((r) => this.seenNotificationIds.add(r.id));
+      return;
+    }
+    const newest = rows.find((r) => !this.seenNotificationIds.has(r.id));
+    rows.forEach((r) => this.seenNotificationIds.add(r.id));
+    if (newest) {
+      this.notificationPopup = newest;
+    }
   }
 
 }

--- a/frontend/src/app/components/notifications-inbox/notifications-inbox.component.ts
+++ b/frontend/src/app/components/notifications-inbox/notifications-inbox.component.ts
@@ -1,10 +1,11 @@
-import { Component, OnInit } from '@angular/core';
+import { Component, OnDestroy, OnInit } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import {
   NotificationsInboxService,
   NotificationPreferenceRow,
   NotificationRow
 } from '../../services/notifications.service';
+import { Subscription, timer } from 'rxjs';
 
 @Component({
   selector: 'app-notifications-inbox',
@@ -92,14 +93,24 @@ import {
         </button>
       </section>
 
-      <ul *ngIf="rows.length" data-cy="notifications-list">
-        <li *ngFor="let r of rows" data-cy="notifications-row">
-          <strong>{{ r.title }}</strong>
+      <div class="filters" *ngIf="rows.length">
+        <button type="button" class="ghost" (click)="setFilter('all')">All</button>
+        <button type="button" class="ghost" (click)="setFilter('pending')">Pending</button>
+        <button type="button" class="ghost" (click)="setFilter('sent')">Sent</button>
+        <button type="button" class="ghost" (click)="setFilter('failed')">Failed</button>
+      </div>
+
+      <ul *ngIf="filteredRows.length" class="notif-list" data-cy="notifications-list">
+        <li *ngFor="let r of filteredRows" class="notif-row" data-cy="notifications-row">
+          <div class="notif-row__head">
+            <strong>{{ r.title }}</strong>
+            <span class="pill">{{ r.status | titlecase }}</span>
+          </div>
           <div class="body">{{ r.body }}</div>
-          <small>{{ r.status }} · {{ r.created_at }}</small>
+          <small>{{ r.channel | titlecase }} · {{ formatTimestamp(r.created_at) }}</small>
         </li>
       </ul>
-      <p *ngIf="!error && !rows.length" data-cy="notifications-empty">No notifications.</p>
+      <p *ngIf="!error && !filteredRows.length" data-cy="notifications-empty">No notifications.</p>
     </section>
   `,
   styles: [
@@ -156,6 +167,38 @@ import {
         align-items: center;
         gap: 0.35rem;
       }
+      .filters {
+        display: flex;
+        gap: 0.45rem;
+        flex-wrap: wrap;
+        margin: 0.45rem 0 0.75rem;
+      }
+      .notif-list {
+        list-style: none;
+        margin: 0;
+        padding: 0;
+        display: grid;
+        gap: 0.6rem;
+      }
+      .notif-row {
+        border: 1px solid #334155;
+        border-radius: 12px;
+        padding: 0.65rem 0.75rem;
+        background: rgba(15, 23, 42, 0.65);
+      }
+      .notif-row__head {
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+        gap: 0.5rem;
+      }
+      .pill {
+        border: 1px solid #0ea5e9;
+        color: #22d3ee;
+        border-radius: 999px;
+        font-size: 0.72rem;
+        padding: 0.1rem 0.5rem;
+      }
       .ghost {
         margin-top: 0;
         border: 1px solid #d1d5db;
@@ -170,7 +213,7 @@ import {
     `
   ]
 })
-export class NotificationsInboxComponent implements OnInit {
+export class NotificationsInboxComponent implements OnInit, OnDestroy {
   readonly categoryOrder = [
     'appointment_reminders',
     'medication_reminders',
@@ -179,19 +222,24 @@ export class NotificationsInboxComponent implements OnInit {
   ];
 
   rows: NotificationRow[] = [];
+  filteredRows: NotificationRow[] = [];
   preferences: NotificationPreferenceRow[] = [];
   error: string | null = null;
   prefsSaved: string | null = null;
   saving = false;
+  activeFilter: 'all' | 'pending' | 'failed' | 'sent' = 'all';
+  private pollSub?: Subscription;
 
   constructor(private api: NotificationsInboxService) {}
 
   ngOnInit(): void {
     this.loadPreferences();
-    this.api.listMine().subscribe({
-      next: (res) => (this.rows = res.notifications ?? []),
-      error: () => (this.error = 'Could not load notifications')
-    });
+    this.loadNotifications();
+    this.pollSub = timer(15000, 15000).subscribe(() => this.loadNotifications());
+  }
+
+  ngOnDestroy(): void {
+    this.pollSub?.unsubscribe();
   }
 
   private loadPreferences(): void {
@@ -200,7 +248,12 @@ export class NotificationsInboxComponent implements OnInit {
         this.preferences = this.sortPreferences(res.preferences ?? []);
       },
       error: () => {
-        this.preferences = [];
+        this.preferences = this.sortPreferences([
+          { category: 'appointment_reminders', enabled: true, email_enabled: true, sms_enabled: false, in_app_enabled: true },
+          { category: 'medication_reminders', enabled: true, email_enabled: true, sms_enabled: false, in_app_enabled: true },
+          { category: 'lab_result_alerts', enabled: true, email_enabled: true, sms_enabled: false, in_app_enabled: true },
+          { category: 'announcements', enabled: true, email_enabled: true, sms_enabled: false, in_app_enabled: true }
+        ]);
       }
     });
   }
@@ -308,5 +361,38 @@ export class NotificationsInboxComponent implements OnInit {
         this.error = 'Could not save notification preferences';
       }
     });
+  }
+
+  setFilter(next: 'all' | 'pending' | 'failed' | 'sent'): void {
+    this.activeFilter = next;
+    this.applyFilter();
+  }
+
+  formatTimestamp(raw: string): string {
+    const t = new Date(raw);
+    if (Number.isNaN(t.getTime())) {
+      return raw;
+    }
+    return new Intl.DateTimeFormat(undefined, {
+      dateStyle: 'medium',
+      timeStyle: 'short'
+    }).format(t);
+  }
+
+  private loadNotifications(): void {
+    this.api.listMine().subscribe({
+      next: (res) => {
+        this.rows = res.notifications ?? [];
+        this.applyFilter();
+      },
+      error: () => (this.error = 'Could not load notifications')
+    });
+  }
+
+  private applyFilter(): void {
+    this.filteredRows =
+      this.activeFilter === 'all'
+        ? [...this.rows]
+        : this.rows.filter((r) => (r.status || '').toLowerCase() === this.activeFilter);
   }
 }

--- a/frontend/src/app/components/patient-find-care/patient-find-care.component.ts
+++ b/frontend/src/app/components/patient-find-care/patient-find-care.component.ts
@@ -71,6 +71,13 @@ import {
           Radius (km)
           <input type="number" step="1" min="1" [(ngModel)]="radiusKm" />
         </label>
+        <label>
+          Department
+          <select [(ngModel)]="department" (ngModelChange)="onDepartmentChange($event)">
+            <option value="">All departments</option>
+            <option *ngFor="let dep of departments" [value]="dep">{{ dep }}</option>
+          </select>
+        </label>
         <label class="span-2">
           Specialty / problem keyword
           <input type="text" [(ngModel)]="specialization" placeholder="e.g. Internal Medicine" />
@@ -151,7 +158,8 @@ import {
         gap: 0.35rem;
         font-size: 0.9rem;
       }
-      input {
+      input,
+      select {
         background: #0b1220;
         color: #e5e7eb;
         border: 1px solid #334155;
@@ -247,6 +255,7 @@ export class PatientFindCareComponent implements AfterViewInit, OnDestroy {
   lat = 29.6516;
   lng = -82.3248;
   radiusKm = 50;
+  department = '';
   specialization = '';
   locationQuery = '';
   selectedLocationLabel = '';
@@ -261,6 +270,22 @@ export class PatientFindCareComponent implements AfterViewInit, OnDestroy {
   private map?: L.Map;
   private userMarker?: L.Marker;
   private hospitalsLayer?: L.LayerGroup;
+  readonly departments = [
+    'Cardiology',
+    'Dermatology',
+    'Emergency medicine',
+    'Endocrinology',
+    'Family medicine',
+    'Gastroenterology',
+    'Internal medicine',
+    'Neurology',
+    'Oncology',
+    'Orthopedics',
+    'Pediatrics',
+    'Psychiatry',
+    'Pulmonology',
+    'Radiology'
+  ];
 
   constructor(private geo: GeoBookingService) {}
 
@@ -347,6 +372,7 @@ export class PatientFindCareComponent implements AfterViewInit, OnDestroy {
   pickGeocodeSuggestion(s: GeocodeHit): void {
     this.locationQuery = s.display_name.split(',').slice(0, 2).join(',').trim();
     this.updateSearchPoint(s.lat, s.lng, s.display_name);
+    this.loadHospitals();
   }
 
   useMyLocation(): void {
@@ -363,6 +389,7 @@ export class PatientFindCareComponent implements AfterViewInit, OnDestroy {
         const lng = pos.coords.longitude;
         this.locationQuery = 'My location';
         this.updateSearchPoint(lat, lng, 'My current location');
+        this.loadHospitals();
       },
       (err) => {
         this.loadingGeo = false;
@@ -408,6 +435,12 @@ export class PatientFindCareComponent implements AfterViewInit, OnDestroy {
         this.loading = false;
       },
     });
+  }
+
+  onDepartmentChange(value: string): void {
+    if (!this.specialization.trim()) {
+      this.specialization = value;
+    }
   }
 
   private plotHospitals(): void {

--- a/frontend/src/app/components/patient-prescriptions/patient-prescriptions.component.ts
+++ b/frontend/src/app/components/patient-prescriptions/patient-prescriptions.component.ts
@@ -178,7 +178,7 @@ import { ContextualCommentsPanelComponent } from '../contextual-comments-panel/c
         border: 1px solid rgba(148, 163, 184, 0.35);
         border-radius: 9999px;
         background: transparent;
-        color: #0f172a;
+        color: #e2e8f0;
         padding: 0.2rem 0.6rem;
         font-size: 0.78rem;
         cursor: pointer;


### PR DESCRIPTION
## Summary
- Remove duplicate patient `My files` navigation by redirecting legacy route to `My documents`.
- Improve notifications UX with readable timestamps, filters, refresh polling, and popup alerts.
- Fix messaging send failures in demo environments by allowing plaintext fallback when keyring is missing, while keeping encryption when configured.
- Improve find-care usability (department dropdown + auto hospital fetch on location select) and fix prescription comments toggle visibility.

## Test plan
- [x] go test ./handlers/...
- [x] npm run test:ci -- --watch=false --browsers=ChromeHeadless --include src/app/components/notifications-inbox/notifications-inbox.component.spec.ts
- [x] npm run build