### PR TITLE
feat(ai+care): add proxy chat assistant and Google Places fallback for find-care

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -16,6 +16,8 @@ PORT=8080
 # NOMINATIM_BASE_URL=https://nominatim.openstreetmap.org
 # Identifiable User-Agent for Nominatim (set to your real contact URL in production).
 # GEOCODE_USER_AGENT=Healthonyx/1.0 (https://example.com/contact)
+# Google Maps/Places key (optional). When set, /api/geocode and nearby hospitals can use Google providers.
+# GOOGLE_MAPS_API_KEY=
 
 # AI runtime core integration (PR-01)
 # Global switch: false forces fallback-safe local behavior.
@@ -26,6 +28,10 @@ OLLAMA_HOST=http://127.0.0.1:11434
 OLLAMA_MODEL=llama3.1:8b
 # Request timeout to Ollama in milliseconds
 OLLAMA_TIMEOUT_MS=7000
+AZURE_OPENAI_ENDPOINT=
+AZURE_OPENAI_API_KEY=
+AZURE_OPENAI_API_VERSION=2025-01-01-preview
+AZURE_OPENAI_MODEL=gpt-4.1-mini
 
 # Encryption-at-rest keyring for PHI/messages (AES-256 keys base64 as "version:key")
 # PHI_ENCRYPTION_KEYS=1:BASE64_32_BYTE_KEY

--- a/backend/config/config.go
+++ b/backend/config/config.go
@@ -33,6 +33,11 @@ type Config struct {
 	TwilioAuthToken       string // Optional Twilio auth token.
 	TwilioFromNumber      string // Optional Twilio sender number.
 	TwilioWebhookSecret   string // Optional webhook HMAC secret for Twilio callbacks.
+	GoogleMapsAPIKey      string // Optional Google Maps/Places API key for geocode + nearby hospitals.
+	AzureOpenAIEndpoint   string // Optional Azure OpenAI endpoint.
+	AzureOpenAIAPIKey     string // Optional Azure OpenAI API key.
+	AzureOpenAIAPIVersion string // Optional Azure OpenAI API version.
+	AzureOpenAIModel      string // Optional Azure OpenAI model/deployment name.
 }
 
 func Load() *Config {
@@ -73,6 +78,11 @@ func Load() *Config {
 		TwilioAuthToken:       strings.TrimSpace(os.Getenv("TWILIO_AUTH_TOKEN")),
 		TwilioFromNumber:      strings.TrimSpace(os.Getenv("TWILIO_FROM_NUMBER")),
 		TwilioWebhookSecret:   strings.TrimSpace(os.Getenv("TWILIO_WEBHOOK_SECRET")),
+		GoogleMapsAPIKey:      strings.TrimSpace(os.Getenv("GOOGLE_MAPS_API_KEY")),
+		AzureOpenAIEndpoint:   strings.TrimSpace(os.Getenv("AZURE_OPENAI_ENDPOINT")),
+		AzureOpenAIAPIKey:     strings.TrimSpace(os.Getenv("AZURE_OPENAI_API_KEY")),
+		AzureOpenAIAPIVersion: strings.TrimSpace(os.Getenv("AZURE_OPENAI_API_VERSION")),
+		AzureOpenAIModel:      strings.TrimSpace(os.Getenv("AZURE_OPENAI_MODEL")),
 	}
 }
 

--- a/backend/handlers/assistant_chat.go
+++ b/backend/handlers/assistant_chat.go
@@ -1,0 +1,157 @@
+package handlers
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/gin-gonic/gin"
+)
+
+type AssistantChatHandler struct {
+	azureEndpoint   string
+	azureAPIKey     string
+	azureAPIVersion string
+	azureModel      string
+}
+
+type assistantChatRequest struct {
+	Message string `json:"message"`
+	Context string `json:"context"`
+}
+
+func NewAssistantChatHandler(endpoint, apiKey, apiVersion, model string) *AssistantChatHandler {
+	if strings.TrimSpace(apiVersion) == "" {
+		apiVersion = "2025-01-01-preview"
+	}
+	if strings.TrimSpace(model) == "" {
+		model = "gpt-4.1-mini"
+	}
+	return &AssistantChatHandler{
+		azureEndpoint:   strings.TrimRight(strings.TrimSpace(endpoint), "/"),
+		azureAPIKey:     strings.TrimSpace(apiKey),
+		azureAPIVersion: strings.TrimSpace(apiVersion),
+		azureModel:      strings.TrimSpace(model),
+	}
+}
+
+func (h *AssistantChatHandler) Chat(c *gin.Context) {
+	if _, ok := getClaims(c); !ok {
+		return
+	}
+	var req assistantChatRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid request body"})
+		return
+	}
+	msg := strings.TrimSpace(req.Message)
+	if msg == "" {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "message is required"})
+		return
+	}
+	prompt := "You are Healthonyx Care Assistant. Give concise, actionable, safe guidance for patients and clinicians. " +
+		"If clinical uncertainty exists, suggest contacting a clinician."
+	if ctx := strings.TrimSpace(req.Context); ctx != "" {
+		prompt += "\n\nContext:\n" + ctx
+	}
+
+	if h.azureEndpoint != "" && h.azureAPIKey != "" {
+		if out, err := h.callAzure(c.Request.Context(), prompt+"\n\nUser: "+msg); err == nil && strings.TrimSpace(out) != "" {
+			c.JSON(http.StatusOK, gin.H{
+				"reply":            strings.TrimSpace(out),
+				"provider":         "azure_openai",
+				"azure_configured": true,
+				"ollama_reachable": h.ollamaReachable(c.Request.Context()),
+				"fallback_used":    false,
+			})
+			return
+		}
+	}
+
+	cfg := getAIRuntimeConfig()
+	if cfg.AIEnabled {
+		if out, err := callOllamaGenerate(c.Request.Context(), cfg, cfg.OllamaModel, prompt+"\n\nUser: "+msg); err == nil && strings.TrimSpace(out) != "" {
+			c.JSON(http.StatusOK, gin.H{
+				"reply":            strings.TrimSpace(out),
+				"provider":         "ollama",
+				"azure_configured": h.azureEndpoint != "" && h.azureAPIKey != "",
+				"ollama_reachable": true,
+				"fallback_used":    false,
+			})
+			return
+		}
+	}
+
+	c.JSON(http.StatusOK, gin.H{
+		"reply":            fallbackAssistantReply(msg),
+		"provider":         "rule_fallback",
+		"azure_configured": h.azureEndpoint != "" && h.azureAPIKey != "",
+		"ollama_reachable": h.ollamaReachable(c.Request.Context()),
+		"fallback_used":    true,
+	})
+}
+
+func (h *AssistantChatHandler) callAzure(ctx context.Context, prompt string) (string, error) {
+	payload := map[string]any{
+		"model": h.azureModel,
+		"input": prompt,
+	}
+	raw, _ := json.Marshal(payload)
+	u := h.azureEndpoint + "/openai/responses?api-version=" + h.azureAPIVersion
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, u, bytes.NewReader(raw))
+	if err != nil {
+		return "", err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("api-key", h.azureAPIKey)
+
+	client := &http.Client{Timeout: 15 * time.Second}
+	resp, err := client.Do(req)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+	body, err := io.ReadAll(io.LimitReader(resp.Body, 2<<20))
+	if err != nil {
+		return "", err
+	}
+	if resp.StatusCode >= http.StatusBadRequest {
+		return "", io.EOF
+	}
+	var parsed struct {
+		OutputText string `json:"output_text"`
+	}
+	if err := json.Unmarshal(body, &parsed); err != nil {
+		return "", err
+	}
+	return parsed.OutputText, nil
+}
+
+func (h *AssistantChatHandler) ollamaReachable(ctx context.Context) bool {
+	cfg := getAIRuntimeConfig()
+	if !cfg.AIEnabled {
+		return false
+	}
+	_, err := fetchOllamaModels(ctx, cfg)
+	return err == nil
+}
+
+func fallbackAssistantReply(msg string) string {
+	m := strings.ToLower(msg)
+	switch {
+	case strings.Contains(m, "appointment"):
+		return "Open Appointments and choose your request to view status, comments, and follow-up actions."
+	case strings.Contains(m, "message"):
+		return "Messaging is available in the Messages page. If send fails, refresh once and retry."
+	case strings.Contains(m, "document"), strings.Contains(m, "summary"):
+		return "Use My documents for uploads and doctor view for AI summary actions."
+	case strings.Contains(m, "hospital"), strings.Contains(m, "find care"):
+		return "Use Find care with your location and department filter to locate nearby hospitals."
+	default:
+		return "I can help with messages, appointments, documents, notifications, and find care."
+	}
+}

--- a/backend/handlers/geocode.go
+++ b/backend/handlers/geocode.go
@@ -1,6 +1,8 @@
 package handlers
 
 import (
+	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -20,10 +22,11 @@ import (
 type GeocodeHandler struct {
 	baseURL    string
 	userAgent  string
+	googleKey  string
 	httpClient *http.Client
 }
 
-func NewGeocodeHandler(baseURL, userAgent string) *GeocodeHandler {
+func NewGeocodeHandler(baseURL, userAgent, googleKey string) *GeocodeHandler {
 	b := strings.TrimRight(strings.TrimSpace(baseURL), "/")
 	if b == "" {
 		b = "https://nominatim.openstreetmap.org"
@@ -35,6 +38,7 @@ func NewGeocodeHandler(baseURL, userAgent string) *GeocodeHandler {
 	return &GeocodeHandler{
 		baseURL:   b,
 		userAgent: ua,
+		googleKey: strings.TrimSpace(googleKey),
 		httpClient: &http.Client{
 			Timeout: 12 * time.Second,
 		},
@@ -51,6 +55,58 @@ type nominatimRow struct {
 	Lat         string `json:"lat"`
 	Lon         string `json:"lon"`
 	DisplayName string `json:"display_name"`
+}
+
+type googleGeocodeRow struct {
+	FormattedAddress string `json:"formatted_address"`
+	Geometry         struct {
+		Location struct {
+			Lat float64 `json:"lat"`
+			Lng float64 `json:"lng"`
+		} `json:"location"`
+	} `json:"geometry"`
+}
+
+type googleGeocodeResponse struct {
+	Results []googleGeocodeRow `json:"results"`
+	Status  string             `json:"status"`
+}
+
+type nearbyHospitalsRequest struct {
+	Lat        float64 `json:"lat"`
+	Lng        float64 `json:"lng"`
+	RadiusKM   float64 `json:"radius_km"`
+	Department string  `json:"department"`
+}
+
+type googleNearbyPlacesRequest struct {
+	IncludedTypes       []string `json:"includedTypes,omitempty"`
+	MaxResultCount      int      `json:"maxResultCount,omitempty"`
+	LocationRestriction struct {
+		Circle struct {
+			Center struct {
+				Latitude  float64 `json:"latitude"`
+				Longitude float64 `json:"longitude"`
+			} `json:"center"`
+			Radius float64 `json:"radius"`
+		} `json:"circle"`
+	} `json:"locationRestriction"`
+	TextQuery string `json:"textQuery,omitempty"`
+}
+
+type googleNearbyPlace struct {
+	DisplayName struct {
+		Text string `json:"text"`
+	} `json:"displayName"`
+	FormattedAddress string `json:"formattedAddress"`
+	Location         struct {
+		Latitude  float64 `json:"latitude"`
+		Longitude float64 `json:"longitude"`
+	} `json:"location"`
+}
+
+type googleNearbyPlacesResponse struct {
+	Places []googleNearbyPlace `json:"places"`
 }
 
 // GeocodeSearch handles GET /api/geocode?q=...&limit=5
@@ -73,6 +129,14 @@ func (h *GeocodeHandler) GeocodeSearch(c *gin.Context) {
 			return
 		}
 		limit = n
+	}
+
+	if h.googleKey != "" {
+		out, err := h.googleGeocode(c.Request.Context(), q, limit)
+		if err == nil {
+			c.JSON(http.StatusOK, gin.H{"results": out})
+			return
+		}
 	}
 
 	u, err := url.Parse(h.baseURL + "/search")
@@ -134,4 +198,137 @@ func (h *GeocodeHandler) GeocodeSearch(c *gin.Context) {
 	}
 
 	c.JSON(http.StatusOK, gin.H{"results": out})
+}
+
+func (h *GeocodeHandler) googleGeocode(ctx context.Context, query string, limit int) ([]geocodeHitJSON, error) {
+	u, err := url.Parse("https://maps.googleapis.com/maps/api/geocode/json")
+	if err != nil {
+		return nil, err
+	}
+	qv := url.Values{}
+	qv.Set("address", query)
+	qv.Set("key", h.googleKey)
+	u.RawQuery = qv.Encode()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := h.httpClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	raw, err := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
+	if err != nil {
+		return nil, err
+	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("google geocode status=%d", resp.StatusCode)
+	}
+	var parsed googleGeocodeResponse
+	if err := json.Unmarshal(raw, &parsed); err != nil {
+		return nil, err
+	}
+	out := make([]geocodeHitJSON, 0, min(limit, len(parsed.Results)))
+	for i, row := range parsed.Results {
+		if i >= limit {
+			break
+		}
+		out = append(out, geocodeHitJSON{
+			Lat:         row.Geometry.Location.Lat,
+			Lng:         row.Geometry.Location.Lng,
+			DisplayName: row.FormattedAddress,
+		})
+	}
+	return out, nil
+}
+
+// NearbyHospitalsGoogle handles POST /api/find-care/places/nearby.
+func (h *GeocodeHandler) NearbyHospitalsGoogle(c *gin.Context) {
+	if _, ok := getClaims(c); !ok {
+		return
+	}
+	if h.googleKey == "" {
+		c.JSON(http.StatusServiceUnavailable, gin.H{"error": "Google Maps API key not configured"})
+		return
+	}
+	var reqBody nearbyHospitalsRequest
+	if err := c.ShouldBindJSON(&reqBody); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid request body"})
+		return
+	}
+	if reqBody.Lat < -90 || reqBody.Lat > 90 || reqBody.Lng < -180 || reqBody.Lng > 180 {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid coordinates"})
+		return
+	}
+	if reqBody.RadiusKM <= 0 {
+		reqBody.RadiusKM = 25
+	}
+	if reqBody.RadiusKM > 200 {
+		reqBody.RadiusKM = 200
+	}
+
+	payload := googleNearbyPlacesRequest{
+		IncludedTypes:  []string{"hospital"},
+		MaxResultCount: 15,
+	}
+	payload.LocationRestriction.Circle.Center.Latitude = reqBody.Lat
+	payload.LocationRestriction.Circle.Center.Longitude = reqBody.Lng
+	payload.LocationRestriction.Circle.Radius = reqBody.RadiusKM * 1000
+	if q := strings.TrimSpace(reqBody.Department); q != "" {
+		payload.TextQuery = q + " hospital"
+	}
+	rawBody, _ := json.Marshal(payload)
+	httpReq, err := http.NewRequestWithContext(
+		c.Request.Context(),
+		http.MethodPost,
+		"https://places.googleapis.com/v1/places:searchNearby",
+		bytes.NewReader(rawBody),
+	)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Could not build places request"})
+		return
+	}
+	httpReq.Header.Set("Content-Type", "application/json")
+	httpReq.Header.Set("X-Goog-Api-Key", h.googleKey)
+	httpReq.Header.Set("X-Goog-FieldMask", "places.displayName,places.formattedAddress,places.location")
+
+	resp, err := h.httpClient.Do(httpReq)
+	if err != nil {
+		c.JSON(http.StatusBadGateway, gin.H{"error": "Google Places request failed"})
+		return
+	}
+	defer resp.Body.Close()
+	raw, err := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
+	if err != nil {
+		c.JSON(http.StatusBadGateway, gin.H{"error": "Could not read Google Places response"})
+		return
+	}
+	if resp.StatusCode >= http.StatusBadRequest {
+		c.JSON(http.StatusBadGateway, gin.H{"error": "Google Places search failed"})
+		return
+	}
+	var parsed googleNearbyPlacesResponse
+	if err := json.Unmarshal(raw, &parsed); err != nil {
+		c.JSON(http.StatusBadGateway, gin.H{"error": "Could not parse Google Places response"})
+		return
+	}
+
+	type placeRow struct {
+		Name      string  `json:"name"`
+		Address   string  `json:"address"`
+		Latitude  float64 `json:"latitude"`
+		Longitude float64 `json:"longitude"`
+	}
+	out := make([]placeRow, 0, len(parsed.Places))
+	for _, p := range parsed.Places {
+		out = append(out, placeRow{
+			Name:      p.DisplayName.Text,
+			Address:   p.FormattedAddress,
+			Latitude:  p.Location.Latitude,
+			Longitude: p.Location.Longitude,
+		})
+	}
+	c.JSON(http.StatusOK, gin.H{"hospitals": out})
 }

--- a/backend/handlers/geocode_handler_test.go
+++ b/backend/handlers/geocode_handler_test.go
@@ -20,7 +20,7 @@ func TestGeocodeSearch_MissingQ(t *testing.T) {
 		Role:   "patient",
 	})
 
-	h := NewGeocodeHandler("", "")
+	h := NewGeocodeHandler("", "", "")
 	h.GeocodeSearch(c)
 
 	if w.Code != http.StatusBadRequest {
@@ -51,7 +51,7 @@ func TestGeocodeSearch_ParsesUpstreamResults(t *testing.T) {
 		Role:   "patient",
 	})
 
-	h := NewGeocodeHandler(ts.URL, "Healthonyx-test/1.0")
+	h := NewGeocodeHandler(ts.URL, "Healthonyx-test/1.0", "")
 	h.GeocodeSearch(c)
 
 	if w.Code != http.StatusOK {

--- a/backend/main.go
+++ b/backend/main.go
@@ -53,7 +53,13 @@ func main() {
 	fhirBoundary := handlers.NewFHIRBoundaryHandler()
 	hl7Ingestion := handlers.NewHL7LabIngestionHandler()
 	geo := handlers.NewGeoBookingHandler()
-	geocode := handlers.NewGeocodeHandler(cfg.NominatimBaseURL, cfg.GeocodeUserAgent)
+	geocode := handlers.NewGeocodeHandler(cfg.NominatimBaseURL, cfg.GeocodeUserAgent, cfg.GoogleMapsAPIKey)
+	assistant := handlers.NewAssistantChatHandler(
+		cfg.AzureOpenAIEndpoint,
+		cfg.AzureOpenAIAPIKey,
+		cfg.AzureOpenAIAPIVersion,
+		cfg.AzureOpenAIModel,
+	)
 	patientFiles := handlers.NewPatientFilesHandler(cfg.UploadDir)
 	r := gin.Default()
 	r.MaxMultipartMemory = 8 << 20 // 8 MiB multipart buffer (handler still enforces 5 MiB file cap)
@@ -140,6 +146,7 @@ func main() {
 		})
 
 		api.GET("/geocode", auth.RequireAuth(), auth.RequireRole("patient"), geocode.GeocodeSearch)
+		api.POST("/find-care/places/nearby", auth.RequireAuth(), auth.RequireRole("patient"), geocode.NearbyHospitalsGoogle)
 		api.GET("/hospitals/near", auth.RequireAuth(), auth.RequireRole("patient"), geo.ListHospitalsNear)
 		api.GET("/doctors/search", auth.RequireAuth(), auth.RequireRole("patient"), geo.SearchDoctors)
 		api.GET("/doctors/:id/slots", auth.RequireAuth(), auth.RequireRole("patient", "doctor"), geo.ListOpenSlotsForDoctor)
@@ -184,6 +191,7 @@ func main() {
 			msg.POST("/threads/:threadId/read", messaging.MarkRead)
 		}
 		api.GET("/messages/ws", messaging.ServeWebSocket(auth))
+		api.POST("/assistant/chat", auth.RequireAuth(), assistant.Chat)
 	}
 
 	addr := fmt.Sprintf(":%s", cfg.Port)

--- a/frontend/src/app/components/app-shell/app-shell.component.html
+++ b/frontend/src/app/components/app-shell/app-shell.component.html
@@ -94,12 +94,24 @@
       <h3>Care assistant</h3>
       <div class="assistant-chat">
         @for (m of assistantMessages; track $index) {
-          <p [class]="m.from === 'me' ? 'msg msg-me' : 'msg msg-ai'">{{ m.text }}</p>
+          <div [class]="m.from === 'me' ? 'msg msg-me' : 'msg msg-ai'">
+            <p>{{ m.text }}</p>
+            @if (m.meta) {
+              <small>{{ m.meta }}</small>
+            }
+          </div>
         }
       </div>
       <div class="assistant-input">
-        <input [(ngModel)]="assistantInput" placeholder="Ask about features..." (keydown.enter)="sendAssistant()" />
-        <button type="button" (click)="sendAssistant()">Send</button>
+        <input
+          [(ngModel)]="assistantInput"
+          placeholder="Ask about features..."
+          (keydown.enter)="sendAssistant()"
+          [disabled]="assistantSending"
+        />
+        <button type="button" (click)="sendAssistant()" [disabled]="assistantSending || !assistantInput.trim()">
+          {{ assistantSending ? '...' : 'Send' }}
+        </button>
       </div>
     </aside>
   }

--- a/frontend/src/app/components/app-shell/app-shell.component.scss
+++ b/frontend/src/app/components/app-shell/app-shell.component.scss
@@ -315,7 +315,7 @@
   z-index: 30;
   border: 1px solid rgba(148, 163, 184, 0.35);
   border-radius: 14px;
-  background: rgba(2, 6, 23, 0.98);
+  background: linear-gradient(180deg, rgba(2, 6, 23, 0.98), rgba(15, 23, 42, 0.98));
   padding: 0.7rem;
 }
 
@@ -331,6 +331,15 @@
   margin: 0;
   padding: 0.4rem 0.55rem;
   border-radius: 10px;
+}
+
+.msg p {
+  margin: 0;
+}
+
+.msg small {
+  color: #94a3b8;
+  font-size: 0.72rem;
 }
 
 .msg-ai {
@@ -355,6 +364,15 @@
   background: #0b1220;
   color: #e2e8f0;
   padding: 0.45rem 0.5rem;
+}
+
+.assistant-input button {
+  border: 1px solid #22d3ee;
+  border-radius: 8px;
+  background: linear-gradient(135deg, #22d3ee, #6366f1);
+  color: #0b1022;
+  font-weight: 600;
+  padding: 0.45rem 0.75rem;
 }
 
 /* Responsive */

--- a/frontend/src/app/components/app-shell/app-shell.component.ts
+++ b/frontend/src/app/components/app-shell/app-shell.component.ts
@@ -6,6 +6,7 @@ import { AuthService } from '../../services/auth.service';
 import { MessagingService } from '../../services/messaging.service';
 import { NotificationsInboxService, NotificationRow } from '../../services/notifications.service';
 import { FormsModule } from '@angular/forms';
+import { AssistantService } from '../../services/assistant.service';
 
 @Component({
   selector: 'app-shell',
@@ -22,7 +23,8 @@ export class AppShellComponent implements OnInit, OnDestroy {
   notificationPopup: NotificationRow | null = null;
   assistantOpen = false;
   assistantInput = '';
-  assistantMessages: { from: 'assistant' | 'me'; text: string }[] = [
+  assistantSending = false;
+  assistantMessages: { from: 'assistant' | 'me'; text: string; meta?: string }[] = [
     { from: 'assistant', text: 'Hi, I can help with summaries, notifications, and find-care workflows.' }
   ];
 
@@ -30,6 +32,7 @@ export class AppShellComponent implements OnInit, OnDestroy {
     public auth: AuthService,
     public messaging: MessagingService,
     private notifications: NotificationsInboxService,
+    private assistant: AssistantService,
     private router: Router
   ) {}
 
@@ -120,21 +123,29 @@ export class AppShellComponent implements OnInit, OnDestroy {
 
   sendAssistant(): void {
     const q = this.assistantInput.trim();
-    if (!q) {
+    if (!q || this.assistantSending) {
       return;
     }
     this.assistantMessages = [...this.assistantMessages, { from: 'me', text: q }];
     this.assistantInput = '';
-    const lower = q.toLowerCase();
-    let answer = 'I can help with: document AI summary, notifications settings, and nearby hospitals.';
-    if (lower.includes('summary') || lower.includes('document')) {
-      answer = 'For AI summaries, open doctor -> Patient documents -> Open a document -> Start summary.';
-    } else if (lower.includes('notification')) {
-      answer = 'Open Notifications to configure channels and view live alerts with popups.';
-    } else if (lower.includes('find care') || lower.includes('hospital') || lower.includes('location')) {
-      answer = 'Use Find care, click "Use my location", then Hospitals nearby. You can also filter by department.';
-    }
-    this.assistantMessages = [...this.assistantMessages, { from: 'assistant', text: answer }];
+    this.assistantSending = true;
+    const context = `Role: ${this.role}. User asks from app shell care assistant.`;
+    this.assistant.chat(q, context).subscribe({
+      next: (res) => {
+        this.assistantSending = false;
+        this.assistantMessages = [
+          ...this.assistantMessages,
+          { from: 'assistant', text: res.reply, meta: `via ${res.provider}` }
+        ];
+      },
+      error: () => {
+        this.assistantSending = false;
+        this.assistantMessages = [
+          ...this.assistantMessages,
+          { from: 'assistant', text: 'Assistant is temporarily unavailable. Please try again.' }
+        ];
+      }
+    });
   }
 
   private handleNotificationPoll(rows: NotificationRow[]): void {

--- a/frontend/src/app/components/messages/messages.component.html
+++ b/frontend/src/app/components/messages/messages.component.html
@@ -161,6 +161,15 @@
           <button
             type="button"
             class="btn-send-primary"
+            (click)="generateReplyDraft()"
+            [disabled]="drafting || sending || messages.length === 0"
+            data-cy="messages-ai-draft"
+          >
+            {{ drafting ? 'Drafting…' : 'AI Draft' }}
+          </button>
+          <button
+            type="button"
+            class="btn-send-primary"
             (click)="send()"
             [disabled]="sending || !replyBody.trim()"
             data-cy="messages-send-reply"

--- a/frontend/src/app/components/messages/messages.component.ts
+++ b/frontend/src/app/components/messages/messages.component.ts
@@ -10,6 +10,7 @@ import {
 } from '../../services/messaging.service';
 import { AuthService } from '../../services/auth.service';
 import { AppointmentsService } from '../../services/appointments.service';
+import { AssistantService } from '../../services/assistant.service';
 
 /** Inbox + thread view for patients and doctors (Sprint 3 feature 9). */
 @Component({
@@ -37,6 +38,7 @@ export class MessagesComponent implements OnInit, OnDestroy {
   /** Doctor: patient user id for first message (MVP until "my patients" API exists). */
   peerPatientId = '';
   showNewThread = false;
+  drafting = false;
 
   private routeSub?: Subscription;
   private pollSub?: Subscription;
@@ -49,6 +51,7 @@ export class MessagesComponent implements OnInit, OnDestroy {
 
   constructor(
     private messaging: MessagingService,
+    private assistant: AssistantService,
     private auth: AuthService,
     private appointments: AppointmentsService,
     private route: ActivatedRoute,
@@ -206,6 +209,27 @@ export class MessagesComponent implements OnInit, OnDestroy {
           this.error = err?.error?.error ?? 'Unable to send message.';
         }
       });
+  }
+
+  generateReplyDraft(): void {
+    if (!this.selectedThreadId || this.drafting) {
+      return;
+    }
+    const recent = this.messages.slice(-6);
+    const context = recent
+      .map((m) => `${this.isMine(m) ? 'me' : 'peer'}: ${m.body}`)
+      .join('\n');
+    this.drafting = true;
+    this.assistant.chat('Draft a short professional reply for this conversation.', context).subscribe({
+      next: (res) => {
+        this.drafting = false;
+        this.replyBody = (res.reply || '').trim();
+      },
+      error: () => {
+        this.drafting = false;
+        this.error = 'Could not generate AI draft right now.';
+      }
+    });
   }
 
   createThread(): void {

--- a/frontend/src/app/components/notifications-inbox/notifications-inbox.component.ts
+++ b/frontend/src/app/components/notifications-inbox/notifications-inbox.component.ts
@@ -6,6 +6,8 @@ import {
   NotificationRow
 } from '../../services/notifications.service';
 import { Subscription, timer } from 'rxjs';
+import { Router } from '@angular/router';
+import { AuthService } from '../../services/auth.service';
 
 @Component({
   selector: 'app-notifications-inbox',
@@ -108,6 +110,9 @@ import { Subscription, timer } from 'rxjs';
           </div>
           <div class="body">{{ r.body }}</div>
           <small>{{ r.channel | titlecase }} · {{ formatTimestamp(r.created_at) }}</small>
+          <div class="notif-actions">
+            <button type="button" class="ghost" (click)="openNotification(r)">Open</button>
+          </div>
         </li>
       </ul>
       <p *ngIf="!error && !filteredRows.length" data-cy="notifications-empty">No notifications.</p>
@@ -199,6 +204,11 @@ import { Subscription, timer } from 'rxjs';
         font-size: 0.72rem;
         padding: 0.1rem 0.5rem;
       }
+      .notif-actions {
+        margin-top: 0.45rem;
+        display: flex;
+        justify-content: flex-end;
+      }
       .ghost {
         margin-top: 0;
         border: 1px solid #d1d5db;
@@ -230,7 +240,11 @@ export class NotificationsInboxComponent implements OnInit, OnDestroy {
   activeFilter: 'all' | 'pending' | 'failed' | 'sent' = 'all';
   private pollSub?: Subscription;
 
-  constructor(private api: NotificationsInboxService) {}
+  constructor(
+    private api: NotificationsInboxService,
+    private router: Router,
+    private auth: AuthService
+  ) {}
 
   ngOnInit(): void {
     this.loadPreferences();
@@ -394,5 +408,27 @@ export class NotificationsInboxComponent implements OnInit, OnDestroy {
       this.activeFilter === 'all'
         ? [...this.rows]
         : this.rows.filter((r) => (r.status || '').toLowerCase() === this.activeFilter);
+  }
+
+  openNotification(r: NotificationRow): void {
+    const role = this.auth.getUser()?.role === 'doctor' ? 'doctor' : 'patient';
+    const text = `${r.title} ${r.body}`.toLowerCase();
+    if (text.includes('appointment')) {
+      void this.router.navigate([`/${role}/appointments`]);
+      return;
+    }
+    if (text.includes('lab') || text.includes('document')) {
+      void this.router.navigate([`/${role}/documents`]);
+      return;
+    }
+    if (text.includes('medication') || text.includes('prescription')) {
+      void this.router.navigate(['/patient/prescriptions']);
+      return;
+    }
+    if (text.includes('message')) {
+      void this.router.navigate([`/${role}/messages`]);
+      return;
+    }
+    void this.router.navigate([`/${role}/dashboard`]);
   }
 }

--- a/frontend/src/app/components/patient-find-care/patient-find-care.component.ts
+++ b/frontend/src/app/components/patient-find-care/patient-find-care.component.ts
@@ -12,6 +12,7 @@ import {
   DoctorSearchRow,
   GeocodeHit,
   GeoBookingService,
+  HospitalPlaceRow,
   HospitalNear,
 } from '../../services/geo-booking.service';
 
@@ -29,8 +30,7 @@ import {
       <h1>Find care near you</h1>
       <p class="subtitle">
         Search for a place or address, or use your current location. Then load nearby
-        hospitals and matching doctors. Map uses OpenStreetMap (free tiles); search uses
-        Nominatim through our API so we can switch to Google Maps in a later sprint.
+        hospitals and matching doctors. Search uses Google geocoding/places when configured.
       </p>
 
       <div class="card">
@@ -98,11 +98,14 @@ import {
 
       <p *ngIf="error" class="error">{{ error }}</p>
 
-      <div *ngIf="hospitals.length" class="card">
+      <div *ngIf="hospitals.length || googleHospitals.length" class="card">
         <h2>Hospitals</h2>
         <ul>
           <li *ngFor="let h of hospitals">
             {{ h.name }} — {{ h.city }}, {{ h.region }} ({{ h.distance_km }} km)
+          </li>
+          <li *ngFor="let g of googleHospitals">
+            {{ g.name }} — {{ g.address }}
           </li>
         </ul>
       </div>
@@ -261,6 +264,7 @@ export class PatientFindCareComponent implements AfterViewInit, OnDestroy {
   selectedLocationLabel = '';
   geocodeSuggestions: GeocodeHit[] = [];
   hospitals: HospitalNear[] = [];
+  googleHospitals: HospitalPlaceRow[] = [];
   doctors: DoctorSearchRow[] = [];
   loading = false;
   loadingGeocode = false;
@@ -406,18 +410,32 @@ export class PatientFindCareComponent implements AfterViewInit, OnDestroy {
   loadHospitals(): void {
     this.error = '';
     this.loading = true;
-    this.geo.hospitalsNear(this.lat, this.lng, this.radiusKm).subscribe({
+    this.geo.hospitalsNearGoogle(this.lat, this.lng, this.radiusKm, this.department).subscribe({
       next: (res) => {
-        this.hospitals = res.hospitals ?? [];
+        this.googleHospitals = res.hospitals ?? [];
+        this.hospitals = [];
         this.loading = false;
         this.plotHospitals();
-        if (!this.hospitals.length) {
+        if (!this.googleHospitals.length) {
           this.error = 'No hospitals within this radius.';
         }
       },
       error: (err) => {
-        this.error = err?.error?.error ?? 'Could not load hospitals';
-        this.loading = false;
+        this.geo.hospitalsNear(this.lat, this.lng, this.radiusKm).subscribe({
+          next: (fallback) => {
+            this.hospitals = fallback.hospitals ?? [];
+            this.googleHospitals = [];
+            this.loading = false;
+            this.plotHospitals();
+            if (!this.hospitals.length) {
+              this.error = 'No hospitals within this radius.';
+            }
+          },
+          error: () => {
+            this.error = err?.error?.error ?? 'Could not load hospitals';
+            this.loading = false;
+          }
+        });
       },
     });
   }
@@ -457,7 +475,14 @@ export class PatientFindCareComponent implements AfterViewInit, OnDestroy {
         .bindPopup(`<strong>${h.name}</strong><br>${h.distance_km} km`)
         .addTo(this.hospitalsLayer);
     }
-    if (this.hospitals.length) {
+    for (const g of this.googleHospitals) {
+      const ll: L.LatLngExpression = [g.latitude, g.longitude];
+      bounds.push(ll);
+      L.marker(ll)
+        .bindPopup(`<strong>${g.name}</strong><br>${g.address}`)
+        .addTo(this.hospitalsLayer);
+    }
+    if (this.hospitals.length || this.googleHospitals.length) {
       this.map.fitBounds(L.latLngBounds(bounds), { padding: [28, 28], maxZoom: 12 });
     }
   }

--- a/frontend/src/app/services/api-contract.ts
+++ b/frontend/src/app/services/api-contract.ts
@@ -23,6 +23,7 @@ export const ApiContract = {
   geoBooking: {
     geocode: `${API}/geocode`,
     hospitalsNear: `${API}/hospitals/near`,
+    hospitalsNearGoogle: `${API}/find-care/places/nearby`,
     doctorsSearch: `${API}/doctors/search`,
     doctorSlots: (doctorId: string): string => `${API}/doctors/${doctorId}/slots`,
     createDoctorSlot: `${API}/doctor/slots`,
@@ -66,6 +67,9 @@ export const ApiContract = {
     threadMessages: (threadId: string): string => `${API}/messages/threads/${threadId}`,
     sendMessage: (threadId: string): string => `${API}/messages/threads/${threadId}/messages`,
     markRead: (threadId: string): string => `${API}/messages/threads/${threadId}/read`
+  },
+  assistant: {
+    chat: `${API}/assistant/chat`
   },
   contextualComments: {
     byContext: (contextType: string, contextId: string): string => `${API}/comments/${contextType}/${contextId}`

--- a/frontend/src/app/services/assistant.service.ts
+++ b/frontend/src/app/services/assistant.service.ts
@@ -1,0 +1,22 @@
+import { Injectable } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { Observable } from 'rxjs';
+import { ApiContract } from './api-contract';
+
+export type AssistantChatResponse = {
+  reply: string;
+  provider: string;
+  azure_configured: boolean;
+  ollama_reachable: boolean;
+  fallback_used: boolean;
+};
+
+@Injectable({ providedIn: 'root' })
+export class AssistantService {
+  constructor(private http: HttpClient) {}
+
+  chat(message: string, context = ''): Observable<AssistantChatResponse> {
+    return this.http.post<AssistantChatResponse>(ApiContract.assistant.chat, { message, context });
+  }
+}
+

--- a/frontend/src/app/services/geo-booking.service.ts
+++ b/frontend/src/app/services/geo-booking.service.ts
@@ -13,6 +13,13 @@ export interface HospitalNear {
   distance_km: number;
 }
 
+export interface HospitalPlaceRow {
+  name: string;
+  address: string;
+  latitude: number;
+  longitude: number;
+}
+
 export interface DoctorSearchRow {
   id: string;
   email: string;
@@ -50,6 +57,20 @@ export class GeoBookingService {
   hospitalsNear(lat: number, lng: number, radiusKm: number): Observable<{ hospitals: HospitalNear[] }> {
     let p = new HttpParams().set('lat', String(lat)).set('lng', String(lng)).set('radius_km', String(radiusKm));
     return this.http.get<{ hospitals: HospitalNear[] }>(ApiContract.geoBooking.hospitalsNear, { params: p });
+  }
+
+  hospitalsNearGoogle(
+    lat: number,
+    lng: number,
+    radiusKm: number,
+    department: string
+  ): Observable<{ hospitals: HospitalPlaceRow[] }> {
+    return this.http.post<{ hospitals: HospitalPlaceRow[] }>(ApiContract.geoBooking.hospitalsNearGoogle, {
+      lat,
+      lng,
+      radius_km: radiusKm,
+      department
+    });
   }
 
   searchDoctors(lat: number, lng: number, radiusKm: number, specialization: string): Observable<{ doctors: DoctorSearchRow[] }> {


### PR DESCRIPTION
## Summary
- Add backend assistant chat proxy (`/api/assistant/chat`) with provider order Azure OpenAI -> Ollama -> fallback.
- Integrate assistant into shell and messages (AI draft), and improve assistant UI states.
- Add Google-based geocode/nearby hospital support (`/api/find-care/places/nearby`) with fallback to existing hospital search.
- Add notification row actions that deep-link users to relevant pages.

## Test plan
- [x] go test ./...
- [x] npm run build