### PR TITLE
fix(ci): sync routes and block past appointments

### DIFF
--- a/backend/handlers/appointments.go
+++ b/backend/handlers/appointments.go
@@ -64,6 +64,10 @@ func (h *AppointmentHandler) Create(c *gin.Context) {
 		c.JSON(http.StatusBadRequest, gin.H{"error": "scheduled_at is required"})
 		return
 	}
+	if !req.ScheduledAt.UTC().After(time.Now().UTC()) {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "scheduled_at must be in the future"})
+		return
+	}
 
 	reason := strings.TrimSpace(req.Reason)
 	if reason == "" {

--- a/backend/handlers/appointments_lifecycle_test.go
+++ b/backend/handlers/appointments_lifecycle_test.go
@@ -1,9 +1,11 @@
 package handlers
 
 import (
+	"bytes"
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 
 	"github.com/gin-gonic/gin"
 	"github.com/google/uuid"
@@ -21,5 +23,23 @@ func TestPatientCancel_Unauthorized(t *testing.T) {
 
 	if w.Code != http.StatusUnauthorized {
 		t.Fatalf("expected 401, got %d", w.Code)
+	}
+}
+
+func TestCreate_RejectsPastScheduledAt(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+
+	body := `{"doctor_id":"` + uuid.New().String() + `","scheduled_at":"` + time.Now().UTC().Add(-1*time.Hour).Format(time.RFC3339) + `","reason":"follow up"}`
+	c.Request = httptest.NewRequest("POST", "/api/appointments", bytes.NewBufferString(body))
+	c.Request.Header.Set("Content-Type", "application/json")
+	c.Set("claims", &Claims{UserID: uuid.New(), Role: "patient"})
+
+	h := NewAppointmentHandler()
+	h.Create(c)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d", w.Code)
 	}
 }

--- a/backend/handlers/geo_booking.go
+++ b/backend/handlers/geo_booking.go
@@ -405,6 +405,10 @@ func (h *GeoBookingHandler) BookSlot(c *gin.Context) {
 		c.JSON(http.StatusConflict, gin.H{"error": "Slot is no longer available"})
 		return
 	}
+	if !startAt.UTC().After(time.Now().UTC()) {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "Cannot book a slot in the past"})
+		return
+	}
 
 	if doctorID == claims.UserID {
 		c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid slot"})

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -249,6 +249,25 @@ paths:
         "404":
           $ref: "#/components/responses/NotFound"
 
+  /api/doctor/documents/{id}/download:
+    get:
+      tags: [Documents]
+      summary: Download doctor-visible patient document
+      security:
+        - bearerAuth: []
+      parameters:
+        - $ref: "#/components/parameters/IdPath"
+      responses:
+        "200":
+          description: Document stream
+          content:
+            application/octet-stream:
+              schema:
+                type: string
+                format: binary
+        "404":
+          $ref: "#/components/responses/NotFound"
+
   /api/admin:
     get:
       tags: [Admin]
@@ -644,6 +663,16 @@ paths:
       responses:
         "200":
           description: Nearby hospitals
+
+  /api/find-care/places/nearby:
+    post:
+      tags: [GeoBooking]
+      summary: List nearby hospitals using Google Places
+      security:
+        - bearerAuth: []
+      responses:
+        "200":
+          description: Nearby hospitals via Places
 
   /api/doctors/search:
     get:
@@ -1113,6 +1142,16 @@ paths:
           description: WebSocket upgraded
         "401":
           $ref: "#/components/responses/Unauthorized"
+
+  /api/assistant/chat:
+    post:
+      tags: [Messaging]
+      summary: Chat with care assistant (Azure OpenAI/Ollama fallback)
+      security:
+        - bearerAuth: []
+      responses:
+        "200":
+          description: Assistant reply payload
 
 components:
   securitySchemes:

--- a/frontend/src/app/components/patient-appointments/patient-appointments.component.ts
+++ b/frontend/src/app/components/patient-appointments/patient-appointments.component.ts
@@ -38,6 +38,7 @@ import { Appointment, AppointmentsService, DoctorOption } from '../../services/a
                 type="date"
                 name="selectedDate"
                 [(ngModel)]="selectedDate"
+                [min]="getTodayLocalDate()"
                 required
                 (click)="openDatePicker()"
               />
@@ -66,11 +67,12 @@ import { Appointment, AppointmentsService, DoctorOption } from '../../services/a
               [(ngModel)]="selectedTime"
               required
             >
-              <option *ngFor="let slot of daySlots" [value]="slot.value">
+              <option *ngFor="let slot of availableDaySlots" [value]="slot.value">
                 {{ slot.label }}
               </option>
             </select>
           </label>
+          <p *ngIf="availableDaySlots.length === 0" class="error">No remaining slots for this date. Please choose another date.</p>
         </div>
 
         <label>
@@ -341,6 +343,16 @@ export class PatientAppointmentsComponent implements OnInit {
     return slots;
   }
 
+  get availableDaySlots(): { value: string; label: string; minutes: number }[] {
+    const slots = this.daySlots;
+    if (this.selectedDate !== this.getTodayLocalDate()) {
+      return slots;
+    }
+    const now = new Date();
+    const currentMinutes = now.getHours() * 60 + now.getMinutes();
+    return slots.filter((slot) => slot.minutes > currentMinutes);
+  }
+
   cancelAppointment(id: string, ev: Event): void {
     ev.preventDefault();
     ev.stopPropagation();
@@ -363,6 +375,11 @@ export class PatientAppointmentsComponent implements OnInit {
     if (!scheduledAt) {
       this.submitting = false;
       this.formMessage = 'Please choose a valid date and 15-minute time slot.';
+      return;
+    }
+    if (new Date(scheduledAt).getTime() <= Date.now()) {
+      this.submitting = false;
+      this.formMessage = 'Please choose a future date and time.';
       return;
     }
     const payload = {

--- a/frontend/src/app/components/patient-find-care/patient-find-care.component.spec.ts
+++ b/frontend/src/app/components/patient-find-care/patient-find-care.component.spec.ts
@@ -9,12 +9,14 @@ describe('PatientFindCareComponent', () => {
 
   const geoMock = {
     geocodeSearch: jasmine.createSpy('geocodeSearch'),
+    hospitalsNearGoogle: jasmine.createSpy('hospitalsNearGoogle'),
     hospitalsNear: jasmine.createSpy('hospitalsNear'),
     searchDoctors: jasmine.createSpy('searchDoctors'),
   };
 
   beforeEach(async () => {
     geoMock.geocodeSearch.calls.reset();
+    geoMock.hospitalsNearGoogle.calls.reset();
     geoMock.hospitalsNear.calls.reset();
     geoMock.searchDoctors.calls.reset();
 
@@ -94,17 +96,14 @@ describe('PatientFindCareComponent', () => {
     component.lng = -82.3248;
     component.radiusKm = 25;
 
-    geoMock.hospitalsNear.and.returnValue(
+    geoMock.hospitalsNearGoogle.and.returnValue(
       of({
         hospitals: [
           {
-            id: '11111111-1111-1111-1111-111111111111',
             name: 'UF Health Shands Hospital',
-            city: 'Gainesville',
-            region: 'Florida',
+            address: 'Gainesville, Florida',
             latitude: 29.6516,
             longitude: -82.3248,
-            distance_km: 1.23,
           },
         ],
       })
@@ -112,9 +111,9 @@ describe('PatientFindCareComponent', () => {
 
     component.loadHospitals();
 
-    expect(geoMock.hospitalsNear).toHaveBeenCalledWith(29.6516, -82.3248, 25);
-    expect(component.hospitals.length).toBe(1);
-    expect(component.hospitals[0].name).toBe('UF Health Shands Hospital');
+    expect(geoMock.hospitalsNearGoogle).toHaveBeenCalledWith(29.6516, -82.3248, 25, '');
+    expect(component.googleHospitals.length).toBe(1);
+    expect(component.googleHospitals[0].name).toBe('UF Health Shands Hospital');
     expect((component as any).plotHospitals).toHaveBeenCalled();
   });
 


### PR DESCRIPTION
## Summary
- update OpenAPI spec with newly wired assistant, doctor-download, and places-nearby routes so backend sync checks pass
- fix Find Care unit mock to support Google Places hospital API path
- enforce future-only booking for appointment create and slot booking in backend + patient booking form guardrails

## Test plan
- [x] go test ./...
- [x] go run ./cmd/openapi-sync-check
- [x] npm run test:ci