### PR TITLE
docs(sprint4): add comprehensive report, API collection, and narration plan

### DIFF
--- a/Sprint4.md
+++ b/Sprint4.md
@@ -1,0 +1,329 @@
+# Sprint 4 Comprehensive Delivery Report
+
+Team: Healthonyx  
+Branch baseline: `dev`  
+Sprint objective: stabilize clinical-grade flows, close CI/runtime gaps, polish UX, and strengthen test/documentation evidence across patient, doctor, and admin modules.
+
+---
+
+## 1) Website restart status
+
+The website was restarted successfully before producing this report:
+
+- Backend: running on `http://127.0.0.1:8080`
+- Frontend: running on `http://127.0.0.1:4200`
+
+---
+
+## 2) Progress comparison: Sprint 1 + Sprint 2 + Sprint 3 vs Sprint 4
+
+### Sprint 1 foundation (already completed previously)
+
+- Identity and access baseline: register/login/JWT/RBAC
+- Role-aware app shell and guarded navigation
+- Placeholder dashboards and logout flow
+- DB + migration/bootstrap foundation
+
+### Sprint 2 expansion (already completed previously)
+
+- Geocode + nearby care discovery baseline
+- Find-care route and map-assisted flow
+- Appointment slot/booking foundations
+- Initial frontend/backend/Cypress testing lane for find-care
+
+### Sprint 3 scale-up (already completed previously)
+
+- Large feature surface across appointments, docs, prescriptions, notifications, messaging, admin modules
+- Enhanced test inventory and CI disciplines
+- OpenAPI route documentation maturity
+- Operational merge workflows and integration hardening
+
+### Sprint 4 (new delivery focus)
+
+Sprint 4 concentrated on production-readiness improvements and issue closure:
+
+- Fixed repeated CI failures blocking merges
+- Fixed patient appointment bug allowing past date/time requests
+- Closed admin reason guardrail mismatch shown in runtime UI
+- Improved assistant UI and find-care UX with location autofill
+- Added Google map visualization embed for selected location
+- Updated AI runtime guidance messaging + environment defaults
+- Consolidated updated API/test evidence for demos and stakeholder review
+
+---
+
+## 3) Sprint 4 detailed work completed
+
+### 3.1 Reliability and CI hardening
+
+- Fixed backend CI contract check by syncing missing documented routes in `docs/openapi.yaml`:
+  - `POST /api/assistant/chat`
+  - `POST /api/find-care/places/nearby`
+  - `GET /api/doctor/documents/{id}/download`
+- Fixed frontend CI break in find-care unit tests by updating Google Places mock pathways:
+  - Added `hospitalsNearGoogle` mock
+  - Updated assertions for Google-first hospital loading flow
+- Verified CI-equivalent suites locally:
+  - `go test ./...`
+  - `go run ./cmd/openapi-sync-check`
+  - `npm run test:ci`
+
+### 3.2 Appointment booking safety fix (real-time validation)
+
+- Backend enforcement:
+  - Appointment create now rejects past/now `scheduled_at`
+  - Slot booking now rejects slots whose `start_at` is in the past
+- Frontend enforcement:
+  - Date picker min constraint set to current day
+  - Time options auto-filtered for current day to only future slots
+  - Submit-time guard rejects stale date-time combination
+- Added backend test coverage for past appointment rejection path
+
+### 3.3 Admin management and AI runtime UX fixes
+
+- Resolved reason-length mismatch:
+  - Guardrail backend now requires non-empty reason instead of 8+ characters
+  - Existing `CONFIRM` safeguard remains enforced for high-risk actions
+- Updated admin AI observability notice:
+  - Message now explicitly tells operator to set `AI_ENABLED=true` and restart backend
+- Updated default environment docs:
+  - `backend/.env.example` now uses `AI_ENABLED=true` for standard demo behavior
+
+### 3.4 Assistant and find-care UI polish
+
+- AI assistant button redesign:
+  - Improved visual hierarchy, pulse indicator, hover behavior, and accessibility label
+- Find-care UX improvements:
+  - Debounced location autofill (typeahead geocode suggestions)
+  - Auto-updating map center on selected place
+  - Embedded Google map visualization iframe for selected coordinates
+  - Maintained fallback compatibility with existing hospital provider logic
+
+---
+
+## 4) Sprint-level functional status matrix
+
+Legend:  
+`Done` = implemented and integrated in `dev`  
+`In Progress` = partially wired or environment-dependent  
+`Planned` = identified but not yet implemented
+
+| Capability Area | Sprint 1 | Sprint 2 | Sprint 3 | Sprint 4 | Current |
+|---|---|---|---|---|---|
+| Auth + JWT + RBAC | Done | Done | Done | Hardened | Done |
+| Patient/Doctor/Admin shells | Done | Done | Expanded | Polished | Done |
+| Find-care geocode + hospitals | Planned | Done | Expanded | Autofill + map polish | Done |
+| Google Places nearby hospitals | Planned | Planned | Done | Stabilized | Done |
+| Appointment booking flow | Planned | Foundation | Done | Past-time safety fix | Done |
+| Messaging core | Planned | Planned | Done | Stability/UX pass | Done |
+| AI assistant chat endpoint | Planned | Planned | Done | UI and ops clarity polish | In Progress (env/model dependent) |
+| Admin lifecycle management | Planned | Planned | Done | Guardrail mismatch fix | Done |
+| Notifications preferences/inbox | Planned | Planned | Done | Iterative polish | Done |
+| OpenAPI contract discipline | Planned | Planned | Done | CI sync fixes | Done |
+| FHIR/HL7 boundaries | Planned | Planned | Added | Maintained | Done (boundary-level) |
+| Clinical release gate evidence | Planned | Planned | Added | Extended tests + bug closures | In Progress |
+
+---
+
+## 5) Frontend unit tests and Cypress tests inventory
+
+## 5.1 Frontend unit tests (`*.spec.ts`)
+
+Primary suite files in `frontend/src/app` include:
+
+- `components/admin-ai-observability/admin-ai-observability.component.spec.ts`
+- `components/admin-audit/admin-audit.component.spec.ts`
+- `components/admin-knowledge/admin-knowledge.component.spec.ts`
+- `components/admin-management/admin-management.component.spec.ts`
+- `components/admin-notifications-log/admin-notifications-log.component.spec.ts`
+- `components/contextual-comments-panel/contextual-comments-panel.component.spec.ts`
+- `components/doctor-appointments/doctor-appointments.component.spec.ts`
+- `components/doctor-availability/doctor-availability.component.spec.ts`
+- `components/doctor-dashboard/doctor-dashboard.component.spec.ts`
+- `components/doctor-document-detail/doctor-document-detail.component.spec.ts`
+- `components/doctor-documents-list/doctor-documents-list.component.spec.ts`
+- `components/notifications-inbox/notifications-inbox.component.spec.ts`
+- `components/patient-dashboard/patient-dashboard.component.spec.ts`
+- `components/patient-files/patient-files.component.spec.ts`
+- `components/patient-find-care/patient-find-care.component.spec.ts`
+- `components/patient-prescriptions/patient-prescriptions.component.spec.ts`
+- `services/admin-ai-runtime.service.spec.ts`
+- `services/documents.service.spec.ts`
+- `services/doctor-documents.service.spec.ts`
+- `services/fhir-boundary.service.spec.ts`
+- `services/geo-booking.service.spec.ts`
+- `services/messaging.service.spec.ts`
+
+Run command:
+
+```bash
+cd frontend
+npm run test:ci
+```
+
+Latest recorded status in this sprint cycle: passing.
+
+## 5.2 Cypress test inventory (`frontend/cypress/e2e`)
+
+- `admin-ai.cy.js`
+- `admin-audit.cy.js`
+- `ai-document-summary.cy.js`
+- `ai-summary-retry.cy.js`
+- `appointment-comments.cy.js`
+- `appointment-lifecycle.cy.js`
+- `clinician-usability.cy.js`
+- `dashboard.cy.js`
+- `demo-data.cy.js`
+- `doctor-availability.cy.js`
+- `find-care.cy.js`
+- `knowledge.cy.js`
+- `messaging.cy.js`
+- `notifications.cy.js`
+- `patient-files.cy.js`
+- `prescriptions.cy.js`
+
+Run command:
+
+```bash
+cd frontend
+npm run cypress:e2e
+```
+
+---
+
+## 6) Backend unit tests inventory
+
+Representative backend unit/integration test files include:
+
+- `backend/handlers/admin_ai_eval_harness_test.go`
+- `backend/handlers/admin_ai_runtime_test.go`
+- `backend/handlers/admin_audit_test.go`
+- `backend/handlers/admin_slo_test.go`
+- `backend/handlers/admin_user_lifecycle_test.go`
+- `backend/handlers/ai_runtime_core_test.go`
+- `backend/handlers/appointment_comments_test.go`
+- `backend/handlers/appointments_lifecycle_test.go`
+- `backend/handlers/audit_log_chain_test.go`
+- `backend/handlers/auth_integration_test.go`
+- `backend/handlers/bootstrap_test.go`
+- `backend/handlers/contextual_comments_test.go`
+- `backend/handlers/critical_escalations_test.go`
+- `backend/handlers/dashboard_test.go`
+- `backend/handlers/document_text_extraction_test.go`
+- `backend/handlers/documents_test.go`
+- `backend/handlers/doctor_documents_rate_limit_test.go`
+- `backend/handlers/doctor_documents_test.go`
+- `backend/handlers/embedding_math_test.go`
+- `backend/handlers/fhir_boundary_test.go`
+- `backend/handlers/geocode_handler_test.go`
+- `backend/handlers/geo_booking_test.go`
+- `backend/handlers/high_risk_guardrails_test.go`
+- `backend/handlers/hl7_ingestion_test.go`
+- `backend/handlers/knowledge_admin_test.go`
+- `backend/handlers/knowledge_health_test.go`
+- `backend/handlers/malware_scanner_test.go`
+- `backend/handlers/messaging_test.go`
+- `backend/handlers/messaging_ws_test.go`
+- `backend/handlers/notifications_test.go`
+- `backend/handlers/patient_files_test.go`
+- `backend/handlers/prescriptions_guardrails_test.go`
+- `backend/handlers/prescriptions_test.go`
+- `backend/handlers/provider_callbacks_test.go`
+- `backend/workers/document_summary_worker_test.go`
+- `backend/workers/notification_worker_test.go`
+- `backend/security/envelope_test.go`
+- `backend/providers/notification_adapters_test.go`
+- `backend/failures/taxonomy_test.go`
+- `backend/db/migration_versioning_test.go`
+- `backend/cmd/clinical-evidence/main_test.go`
+
+Run command:
+
+```bash
+cd backend
+go test ./...
+```
+
+Latest recorded status in this sprint cycle: passing.
+
+---
+
+## 7) Updated backend API documentation
+
+Primary API documentation sources:
+
+- OpenAPI contract: `docs/openapi.yaml`
+- Runtime route wiring: `backend/main.go`
+
+The currently documented API surface includes:
+
+- Health: `/health`
+- Auth/bootstrap: `/api/register`, `/api/login`, `/api/me`, `/api/bootstrap`
+- Notifications and preferences: `/api/notifications`, `/api/notifications/preferences`
+- Provider callbacks: `/api/provider-callbacks/sendgrid`, `/api/provider-callbacks/twilio`
+- Dashboards and escalations
+- Doctor document lifecycle + summarize + download
+- Admin lifecycle, observability, notifications, knowledge base, AI controls, FHIR import/export
+- HL7 ingestion
+- Geocode/find-care/nearby search
+- Appointment booking, status, activity, comments
+- Contextual comments
+- Documents/files/prescriptions
+- Messaging REST and websocket endpoints
+- AI assistant chat endpoint
+
+For ready-to-import API requests, use:
+
+- `docs/Healthonyx-Sprint4.postman_collection.json`
+
+---
+
+## 8) Sprint 4 presentation and narration split (4 members)
+
+Detailed script is provided in:
+
+- `docs/SPRINT4-NARRATED-VIDEO-SCRIPT.md`
+
+Narration ownership split:
+
+- Member 1 (Kaushik): architecture + backend/API + reliability fixes
+- Member 2 (Rohith): doctor/admin workflows + lifecycle/guardrails
+- Member 3 (Abhinav): patient UX + notifications + assistant + find-care polish
+- Member 4 (Karthik): QA evidence + tests + demo walkthrough + project pitch close
+
+---
+
+## 9) Full-project pitch outline (for an external audience)
+
+When pitching to someone new to Healthonyx, the recommended structure is:
+
+1. Problem framing: fragmented patient-doctor workflows, weak traceability, inconsistent follow-up
+2. Platform walkthrough:
+   - Patient: find care, appointments, documents, prescriptions, messaging, notifications
+   - Doctor: availability, appointment queue, patient documents, messaging, summaries
+   - Admin: lifecycle governance, AI controls, audit/knowledge/notification operations
+3. API credibility:
+   - Comprehensive OpenAPI and Postman collection
+   - Role-protected endpoint surface with strict auth boundaries
+4. Quality evidence:
+   - Backend unit/integration coverage
+   - Frontend unit coverage
+   - Cypress workflow-level tests
+5. Clinical-grade trajectory:
+   - Current reliability and safety guardrails
+   - Interoperability path (FHIR/HL7)
+   - Incremental production-hardening roadmap
+
+---
+
+## 10) Sprint 4 completion summary
+
+Sprint 4 achieved a high-impact stabilization and polish pass:
+
+- CI blockers removed
+- Booking safety bug fixed
+- Admin/runtime inconsistencies resolved
+- UX and map experience upgraded
+- API and testing evidence consolidated for grading/demo readiness
+
+This report, the Postman collection, and the narrated script together form the complete Sprint 4 submission package.

--- a/docs/Healthonyx-Sprint4.postman_collection.json
+++ b/docs/Healthonyx-Sprint4.postman_collection.json
@@ -1,0 +1,566 @@
+{
+  "info": {
+    "_postman_id": "6cda7a47-6b07-4b28-b1a6-95d7d6f9d941",
+    "name": "Healthonyx Backend API - Sprint 4",
+    "description": "Comprehensive backend API collection aligned with docs/openapi.yaml and current backend/main.go wiring on dev.",
+    "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
+  },
+  "auth": {
+    "type": "bearer",
+    "bearer": [
+      {
+        "key": "token",
+        "value": "{{jwt_token}}",
+        "type": "string"
+      }
+    ]
+  },
+  "variable": [
+    { "key": "base_url", "value": "http://127.0.0.1:8080" },
+    { "key": "jwt_token", "value": "" },
+    { "key": "patient_id", "value": "" },
+    { "key": "doctor_id", "value": "" },
+    { "key": "admin_user_id", "value": "" },
+    { "key": "appointment_id", "value": "" },
+    { "key": "document_id", "value": "" },
+    { "key": "file_id", "value": "" },
+    { "key": "thread_id", "value": "" },
+    { "key": "slot_id", "value": "" },
+    { "key": "knowledge_doc_id", "value": "" },
+    { "key": "notification_id", "value": "" },
+    { "key": "comment_context_id", "value": "" }
+  ],
+  "item": [
+    {
+      "name": "Health",
+      "item": [
+        {
+          "name": "GET /health",
+          "request": {
+            "method": "GET",
+            "header": [],
+            "url": "{{base_url}}/health"
+          }
+        },
+        {
+          "name": "HEAD /health",
+          "request": {
+            "method": "HEAD",
+            "header": [],
+            "url": "{{base_url}}/health"
+          }
+        }
+      ]
+    },
+    {
+      "name": "Auth and Bootstrap",
+      "auth": { "type": "noauth" },
+      "item": [
+        {
+          "name": "POST /api/register",
+          "request": {
+            "method": "POST",
+            "header": [{ "key": "Content-Type", "value": "application/json" }],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"email\": \"patient.demo@healthonyx.local\",\n  \"password\": \"Password123!\",\n  \"role\": \"patient\"\n}"
+            },
+            "url": "{{base_url}}/api/register"
+          }
+        },
+        {
+          "name": "POST /api/login",
+          "request": {
+            "method": "POST",
+            "header": [{ "key": "Content-Type", "value": "application/json" }],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"email\": \"patient.demo@healthonyx.local\",\n  \"password\": \"Password123!\"\n}"
+            },
+            "url": "{{base_url}}/api/login"
+          }
+        },
+        {
+          "name": "GET /api/me",
+          "request": { "method": "GET", "url": "{{base_url}}/api/me" }
+        },
+        {
+          "name": "GET /api/bootstrap",
+          "request": { "method": "GET", "url": "{{base_url}}/api/bootstrap" }
+        }
+      ]
+    },
+    {
+      "name": "Notifications",
+      "item": [
+        {
+          "name": "GET /api/notifications",
+          "request": { "method": "GET", "url": "{{base_url}}/api/notifications" }
+        },
+        {
+          "name": "GET /api/notifications/preferences",
+          "request": { "method": "GET", "url": "{{base_url}}/api/notifications/preferences" }
+        },
+        {
+          "name": "PUT /api/notifications/preferences",
+          "request": {
+            "method": "PUT",
+            "header": [{ "key": "Content-Type", "value": "application/json" }],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"preferences\": [\n    {\n      \"category\": \"appointment_reminders\",\n      \"enabled\": true,\n      \"email_enabled\": true,\n      \"sms_enabled\": false,\n      \"in_app_enabled\": true\n    }\n  ]\n}"
+            },
+            "url": "{{base_url}}/api/notifications/preferences"
+          }
+        }
+      ]
+    },
+    {
+      "name": "Provider Callbacks",
+      "auth": { "type": "noauth" },
+      "item": [
+        {
+          "name": "POST /api/provider-callbacks/sendgrid",
+          "request": {
+            "method": "POST",
+            "header": [{ "key": "Content-Type", "value": "application/json" }],
+            "body": { "mode": "raw", "raw": "{\n  \"event\": \"delivered\"\n}" },
+            "url": "{{base_url}}/api/provider-callbacks/sendgrid"
+          }
+        },
+        {
+          "name": "POST /api/provider-callbacks/twilio",
+          "request": {
+            "method": "POST",
+            "header": [{ "key": "Content-Type", "value": "application/json" }],
+            "body": { "mode": "raw", "raw": "{\n  \"MessageStatus\": \"delivered\"\n}" },
+            "url": "{{base_url}}/api/provider-callbacks/twilio"
+          }
+        }
+      ]
+    },
+    {
+      "name": "Dashboards and Escalations",
+      "item": [
+        {
+          "name": "GET /api/patient/dashboard/summary",
+          "request": { "method": "GET", "url": "{{base_url}}/api/patient/dashboard/summary" }
+        },
+        {
+          "name": "GET /api/doctor/dashboard/summary",
+          "request": { "method": "GET", "url": "{{base_url}}/api/doctor/dashboard/summary" }
+        },
+        {
+          "name": "GET /api/doctor/critical-escalations",
+          "request": { "method": "GET", "url": "{{base_url}}/api/doctor/critical-escalations" }
+        },
+        {
+          "name": "POST /api/doctor/critical-escalations/{id}/ack",
+          "request": {
+            "method": "POST",
+            "url": "{{base_url}}/api/doctor/critical-escalations/{{notification_id}}/ack"
+          }
+        }
+      ]
+    },
+    {
+      "name": "Doctor Documents",
+      "item": [
+        {
+          "name": "GET /api/doctor/documents",
+          "request": { "method": "GET", "url": "{{base_url}}/api/doctor/documents" }
+        },
+        {
+          "name": "GET /api/doctor/documents/{id}",
+          "request": { "method": "GET", "url": "{{base_url}}/api/doctor/documents/{{document_id}}" }
+        },
+        {
+          "name": "POST /api/doctor/documents/{id}/summarize",
+          "request": {
+            "method": "POST",
+            "header": [{ "key": "Content-Type", "value": "application/json" }],
+            "body": { "mode": "raw", "raw": "{\n  \"force\": false\n}" },
+            "url": "{{base_url}}/api/doctor/documents/{{document_id}}/summarize"
+          }
+        },
+        {
+          "name": "GET /api/doctor/documents/{id}/download",
+          "request": {
+            "method": "GET",
+            "url": "{{base_url}}/api/doctor/documents/{{document_id}}/download"
+          }
+        }
+      ]
+    },
+    {
+      "name": "Admin Core and Lifecycle",
+      "item": [
+        { "name": "GET /api/admin", "request": { "method": "GET", "url": "{{base_url}}/api/admin" } },
+        { "name": "GET /api/admin/audit-log", "request": { "method": "GET", "url": "{{base_url}}/api/admin/audit-log" } },
+        { "name": "GET /api/admin/user-lifecycle/settings-kpis", "request": { "method": "GET", "url": "{{base_url}}/api/admin/user-lifecycle/settings-kpis" } },
+        {
+          "name": "PUT /api/admin/user-lifecycle/settings",
+          "request": {
+            "method": "PUT",
+            "header": [{ "key": "Content-Type", "value": "application/json" }],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"new_user_window_days\": 14,\n  \"inactive_window_days\": 30,\n  \"reason\": \"policy update\",\n  \"confirm\": \"CONFIRM\"\n}"
+            },
+            "url": "{{base_url}}/api/admin/user-lifecycle/settings"
+          }
+        },
+        { "name": "GET /api/admin/user-lifecycle/users", "request": { "method": "GET", "url": "{{base_url}}/api/admin/user-lifecycle/users" } },
+        {
+          "name": "POST /api/admin/user-lifecycle/users",
+          "request": {
+            "method": "POST",
+            "header": [{ "key": "Content-Type", "value": "application/json" }],
+            "body": { "mode": "raw", "raw": "{\n  \"email\": \"new.user@healthonyx.local\",\n  \"password\": \"Password123!\",\n  \"role\": \"patient\"\n}" },
+            "url": "{{base_url}}/api/admin/user-lifecycle/users"
+          }
+        },
+        {
+          "name": "PUT /api/admin/user-lifecycle/users/{id}",
+          "request": {
+            "method": "PUT",
+            "header": [{ "key": "Content-Type", "value": "application/json" }],
+            "body": { "mode": "raw", "raw": "{\n  \"email\": \"updated.user@healthonyx.local\",\n  \"role\": \"doctor\"\n}" },
+            "url": "{{base_url}}/api/admin/user-lifecycle/users/{{admin_user_id}}"
+          }
+        },
+        {
+          "name": "PATCH /api/admin/user-lifecycle/users/{id}/deactivate",
+          "request": {
+            "method": "PATCH",
+            "header": [{ "key": "Content-Type", "value": "application/json" }],
+            "body": { "mode": "raw", "raw": "{\n  \"reason\": \"demo cleanup\",\n  \"confirm\": \"CONFIRM\"\n}" },
+            "url": "{{base_url}}/api/admin/user-lifecycle/users/{{admin_user_id}}/deactivate"
+          }
+        },
+        {
+          "name": "POST /api/admin/user-lifecycle/users/{id}/reset-password",
+          "request": {
+            "method": "POST",
+            "header": [{ "key": "Content-Type", "value": "application/json" }],
+            "body": { "mode": "raw", "raw": "{\n  \"new_password\": \"Password123!\",\n  \"reason\": \"support request\",\n  \"confirm\": \"CONFIRM\"\n}" },
+            "url": "{{base_url}}/api/admin/user-lifecycle/users/{{admin_user_id}}/reset-password"
+          }
+        }
+      ]
+    },
+    {
+      "name": "Admin AI / Interoperability / Notifications / Knowledge",
+      "item": [
+        { "name": "GET /api/admin/ai/observability", "request": { "method": "GET", "url": "{{base_url}}/api/admin/ai/observability" } },
+        {
+          "name": "PUT /api/admin/ai/settings",
+          "request": {
+            "method": "PUT",
+            "header": [{ "key": "Content-Type", "value": "application/json" }],
+            "body": { "mode": "raw", "raw": "{\n  \"ollama_enabled\": true,\n  \"fallback_enabled\": true,\n  \"rate_limit_enabled\": true,\n  \"rate_limit_per_minute\": 30,\n  \"cache_enabled\": true,\n  \"cache_ttl_seconds\": 900,\n  \"ollama_model\": \"llama3.1:8b\"\n}" },
+            "url": "{{base_url}}/api/admin/ai/settings"
+          }
+        },
+        { "name": "POST /api/admin/ai/eval", "request": { "method": "POST", "url": "{{base_url}}/api/admin/ai/eval" } },
+        { "name": "GET /api/admin/fhir/export", "request": { "method": "GET", "url": "{{base_url}}/api/admin/fhir/export" } },
+        {
+          "name": "POST /api/admin/fhir/import",
+          "request": {
+            "method": "POST",
+            "header": [{ "key": "Content-Type", "value": "application/json" }],
+            "body": { "mode": "raw", "raw": "{\n  \"resourceType\": \"Bundle\",\n  \"type\": \"collection\",\n  \"entry\": []\n}" },
+            "url": "{{base_url}}/api/admin/fhir/import"
+          }
+        },
+        {
+          "name": "POST /api/integrations/hl7/lab-results",
+          "request": {
+            "method": "POST",
+            "header": [{ "key": "Content-Type", "value": "text/plain" }],
+            "body": { "mode": "raw", "raw": "MSH|^~\\&|LAB|..." },
+            "url": "{{base_url}}/api/integrations/hl7/lab-results"
+          }
+        },
+        { "name": "GET /api/admin/notifications", "request": { "method": "GET", "url": "{{base_url}}/api/admin/notifications" } },
+        { "name": "GET /api/admin/notifications/summary", "request": { "method": "GET", "url": "{{base_url}}/api/admin/notifications/summary" } },
+        { "name": "GET /api/admin/notifications/consent-history", "request": { "method": "GET", "url": "{{base_url}}/api/admin/notifications/consent-history" } },
+        { "name": "POST /api/admin/notifications/{id}/retry", "request": { "method": "POST", "url": "{{base_url}}/api/admin/notifications/{{notification_id}}/retry" } },
+        { "name": "GET /api/admin/knowledge-docs", "request": { "method": "GET", "url": "{{base_url}}/api/admin/knowledge-docs" } },
+        {
+          "name": "POST /api/admin/knowledge-docs",
+          "request": {
+            "method": "POST",
+            "header": [{ "key": "Content-Type", "value": "application/json" }],
+            "body": { "mode": "raw", "raw": "{\n  \"title\": \"Clinical note\",\n  \"body\": \"Knowledge content\",\n  \"review_interval_days\": 30\n}" },
+            "url": "{{base_url}}/api/admin/knowledge-docs"
+          }
+        },
+        { "name": "GET /api/admin/knowledge-docs/{id}", "request": { "method": "GET", "url": "{{base_url}}/api/admin/knowledge-docs/{{knowledge_doc_id}}" } },
+        {
+          "name": "PATCH /api/admin/knowledge-docs/{id}",
+          "request": {
+            "method": "PATCH",
+            "header": [{ "key": "Content-Type", "value": "application/json" }],
+            "body": { "mode": "raw", "raw": "{\n  \"title\": \"Updated title\",\n  \"body\": \"Updated content\"\n}" },
+            "url": "{{base_url}}/api/admin/knowledge-docs/{{knowledge_doc_id}}"
+          }
+        },
+        { "name": "GET /api/admin/knowledge-docs/similarity-scan", "request": { "method": "GET", "url": "{{base_url}}/api/admin/knowledge-docs/similarity-scan" } },
+        { "name": "POST /api/admin/knowledge-docs/{id}/embeddings", "request": { "method": "POST", "url": "{{base_url}}/api/admin/knowledge-docs/{{knowledge_doc_id}}/embeddings" } },
+        { "name": "GET /api/admin/knowledge-docs/{id}/versions", "request": { "method": "GET", "url": "{{base_url}}/api/admin/knowledge-docs/{{knowledge_doc_id}}/versions" } },
+        { "name": "POST /api/admin/knowledge-docs/{id}/review", "request": { "method": "POST", "url": "{{base_url}}/api/admin/knowledge-docs/{{knowledge_doc_id}}/review" } }
+      ]
+    },
+    {
+      "name": "Role Validation Endpoints",
+      "item": [
+        { "name": "GET /api/doctor", "request": { "method": "GET", "url": "{{base_url}}/api/doctor" } },
+        { "name": "GET /api/patient", "request": { "method": "GET", "url": "{{base_url}}/api/patient" } }
+      ]
+    },
+    {
+      "name": "Find Care and Geo Booking",
+      "item": [
+        {
+          "name": "GET /api/geocode",
+          "request": {
+            "method": "GET",
+            "url": {
+              "raw": "{{base_url}}/api/geocode?q=Orlando&limit=5",
+              "host": ["{{base_url}}"],
+              "path": ["api", "geocode"],
+              "query": [
+                { "key": "q", "value": "Orlando" },
+                { "key": "limit", "value": "5" }
+              ]
+            }
+          }
+        },
+        {
+          "name": "GET /api/hospitals/near",
+          "request": {
+            "method": "GET",
+            "url": {
+              "raw": "{{base_url}}/api/hospitals/near?lat=28.5421&lng=-81.379&radius_km=25",
+              "host": ["{{base_url}}"],
+              "path": ["api", "hospitals", "near"],
+              "query": [
+                { "key": "lat", "value": "28.5421" },
+                { "key": "lng", "value": "-81.379" },
+                { "key": "radius_km", "value": "25" }
+              ]
+            }
+          }
+        },
+        {
+          "name": "POST /api/find-care/places/nearby",
+          "request": {
+            "method": "POST",
+            "header": [{ "key": "Content-Type", "value": "application/json" }],
+            "body": { "mode": "raw", "raw": "{\n  \"lat\": 28.5421,\n  \"lng\": -81.379,\n  \"radius_km\": 25,\n  \"department\": \"Cardiology\"\n}" },
+            "url": "{{base_url}}/api/find-care/places/nearby"
+          }
+        },
+        {
+          "name": "GET /api/doctors/search",
+          "request": {
+            "method": "GET",
+            "url": {
+              "raw": "{{base_url}}/api/doctors/search?lat=28.5421&lng=-81.379&radius_km=25&specialization=Cardiology",
+              "host": ["{{base_url}}"],
+              "path": ["api", "doctors", "search"],
+              "query": [
+                { "key": "lat", "value": "28.5421" },
+                { "key": "lng", "value": "-81.379" },
+                { "key": "radius_km", "value": "25" },
+                { "key": "specialization", "value": "Cardiology" }
+              ]
+            }
+          }
+        },
+        { "name": "GET /api/doctors/{id}/slots", "request": { "method": "GET", "url": "{{base_url}}/api/doctors/{{doctor_id}}/slots" } },
+        {
+          "name": "POST /api/doctor/slots",
+          "request": {
+            "method": "POST",
+            "header": [{ "key": "Content-Type", "value": "application/json" }],
+            "body": { "mode": "raw", "raw": "{\n  \"start_at\": \"2026-05-10T10:00:00Z\",\n  \"end_at\": \"2026-05-10T10:30:00Z\"\n}" },
+            "url": "{{base_url}}/api/doctor/slots"
+          }
+        },
+        { "name": "DELETE /api/doctor/slots/{id}", "request": { "method": "DELETE", "url": "{{base_url}}/api/doctor/slots/{{slot_id}}" } },
+        {
+          "name": "POST /api/appointments/book-slot",
+          "request": {
+            "method": "POST",
+            "header": [{ "key": "Content-Type", "value": "application/json" }],
+            "body": { "mode": "raw", "raw": "{\n  \"slot_id\": \"{{slot_id}}\",\n  \"reason\": \"Follow-up consultation\"\n}" },
+            "url": "{{base_url}}/api/appointments/book-slot"
+          }
+        }
+      ]
+    },
+    {
+      "name": "Appointments and Comments",
+      "item": [
+        {
+          "name": "POST /api/appointments",
+          "request": {
+            "method": "POST",
+            "header": [{ "key": "Content-Type", "value": "application/json" }],
+            "body": { "mode": "raw", "raw": "{\n  \"doctor_id\": \"{{doctor_id}}\",\n  \"scheduled_at\": \"2026-05-11T14:30:00Z\",\n  \"reason\": \"General consultation\"\n}" },
+            "url": "{{base_url}}/api/appointments"
+          }
+        },
+        { "name": "POST /api/patient/appointments/{id}/cancel", "request": { "method": "POST", "url": "{{base_url}}/api/patient/appointments/{{appointment_id}}/cancel" } },
+        { "name": "GET /api/appointments/patient", "request": { "method": "GET", "url": "{{base_url}}/api/appointments/patient" } },
+        { "name": "GET /api/appointments/doctor", "request": { "method": "GET", "url": "{{base_url}}/api/appointments/doctor" } },
+        { "name": "GET /api/appointments/{id}", "request": { "method": "GET", "url": "{{base_url}}/api/appointments/{{appointment_id}}" } },
+        {
+          "name": "PATCH /api/appointments/{id}/status",
+          "request": {
+            "method": "PATCH",
+            "header": [{ "key": "Content-Type", "value": "application/json" }],
+            "body": { "mode": "raw", "raw": "{\n  \"status\": \"approved\"\n}" },
+            "url": "{{base_url}}/api/appointments/{{appointment_id}}/status"
+          }
+        },
+        { "name": "GET /api/appointments/{id}/activity", "request": { "method": "GET", "url": "{{base_url}}/api/appointments/{{appointment_id}}/activity" } },
+        { "name": "GET /api/appointments/{id}/comments", "request": { "method": "GET", "url": "{{base_url}}/api/appointments/{{appointment_id}}/comments" } },
+        {
+          "name": "POST /api/appointments/{id}/comments",
+          "request": {
+            "method": "POST",
+            "header": [{ "key": "Content-Type", "value": "application/json" }],
+            "body": { "mode": "raw", "raw": "{\n  \"body\": \"Clinical note comment\",\n  \"visibility\": \"internal\"\n}" },
+            "url": "{{base_url}}/api/appointments/{{appointment_id}}/comments"
+          }
+        },
+        { "name": "GET /api/comments/{contextType}/{contextId}", "request": { "method": "GET", "url": "{{base_url}}/api/comments/document/{{comment_context_id}}" } },
+        {
+          "name": "POST /api/comments/{contextType}/{contextId}",
+          "request": {
+            "method": "POST",
+            "header": [{ "key": "Content-Type", "value": "application/json" }],
+            "body": { "mode": "raw", "raw": "{\n  \"body\": \"Contextual comment\",\n  \"visibility\": \"internal\"\n}" },
+            "url": "{{base_url}}/api/comments/document/{{comment_context_id}}"
+          }
+        },
+        { "name": "GET /api/doctors", "request": { "method": "GET", "url": "{{base_url}}/api/doctors" } }
+      ]
+    },
+    {
+      "name": "Documents, Files, Prescriptions",
+      "item": [
+        { "name": "GET /api/documents", "request": { "method": "GET", "url": "{{base_url}}/api/documents" } },
+        {
+          "name": "POST /api/documents (multipart)",
+          "request": {
+            "method": "POST",
+            "header": [],
+            "body": {
+              "mode": "formdata",
+              "formdata": [{ "key": "file", "type": "file", "src": "" }]
+            },
+            "url": "{{base_url}}/api/documents"
+          }
+        },
+        { "name": "GET /api/documents/{id}/download", "request": { "method": "GET", "url": "{{base_url}}/api/documents/{{document_id}}/download" } },
+        { "name": "GET /api/patients/{patientId}/files", "request": { "method": "GET", "url": "{{base_url}}/api/patients/{{patient_id}}/files" } },
+        {
+          "name": "POST /api/patients/{patientId}/files (multipart)",
+          "request": {
+            "method": "POST",
+            "body": {
+              "mode": "formdata",
+              "formdata": [
+                { "key": "file", "type": "file", "src": "" },
+                { "key": "description", "type": "text", "value": "Lab report upload" }
+              ]
+            },
+            "url": "{{base_url}}/api/patients/{{patient_id}}/files"
+          }
+        },
+        { "name": "GET /api/files/{id}", "request": { "method": "GET", "url": "{{base_url}}/api/files/{{file_id}}" } },
+        { "name": "GET /api/patients/{patientId}/prescriptions", "request": { "method": "GET", "url": "{{base_url}}/api/patients/{{patient_id}}/prescriptions" } },
+        {
+          "name": "POST /api/patients/{patientId}/prescriptions",
+          "request": {
+            "method": "POST",
+            "header": [{ "key": "Content-Type", "value": "application/json" }],
+            "body": { "mode": "raw", "raw": "{\n  \"medication_name\": \"Amoxicillin\",\n  \"dosage\": \"500mg\",\n  \"frequency\": \"Twice daily\",\n  \"duration_days\": 5,\n  \"instructions\": \"After food\"\n}" },
+            "url": "{{base_url}}/api/patients/{{patient_id}}/prescriptions"
+          }
+        },
+        {
+          "name": "PATCH /api/prescriptions/{id}/revoke",
+          "request": {
+            "method": "PATCH",
+            "header": [{ "key": "Content-Type", "value": "application/json" }],
+            "body": { "mode": "raw", "raw": "{\n  \"reason\": \"duplicate entry\",\n  \"confirm\": \"CONFIRM\"\n}" },
+            "url": "{{base_url}}/api/prescriptions/{{document_id}}/revoke"
+          }
+        },
+        { "name": "GET /api/prescriptions/{id}/pdf", "request": { "method": "GET", "url": "{{base_url}}/api/prescriptions/{{document_id}}/pdf" } },
+        {
+          "name": "PUT /api/prescriptions/{id}",
+          "request": {
+            "method": "PUT",
+            "header": [{ "key": "Content-Type", "value": "application/json" }],
+            "body": { "mode": "raw", "raw": "{\n  \"dosage\": \"250mg\",\n  \"frequency\": \"Once daily\"\n}" },
+            "url": "{{base_url}}/api/prescriptions/{{document_id}}"
+          }
+        }
+      ]
+    },
+    {
+      "name": "Messaging and Assistant",
+      "item": [
+        { "name": "GET /api/messages/unread", "request": { "method": "GET", "url": "{{base_url}}/api/messages/unread" } },
+        { "name": "GET /api/messages/threads", "request": { "method": "GET", "url": "{{base_url}}/api/messages/threads" } },
+        {
+          "name": "POST /api/messages/threads",
+          "request": {
+            "method": "POST",
+            "header": [{ "key": "Content-Type", "value": "application/json" }],
+            "body": { "mode": "raw", "raw": "{\n  \"recipient_id\": \"{{doctor_id}}\",\n  \"subject\": \"Follow-up\",\n  \"message\": \"Hello doctor\"\n}" },
+            "url": "{{base_url}}/api/messages/threads"
+          }
+        },
+        { "name": "GET /api/messages/threads/{threadId}", "request": { "method": "GET", "url": "{{base_url}}/api/messages/threads/{{thread_id}}" } },
+        {
+          "name": "POST /api/messages/threads/{threadId}/messages",
+          "request": {
+            "method": "POST",
+            "header": [{ "key": "Content-Type", "value": "application/json" }],
+            "body": { "mode": "raw", "raw": "{\n  \"body\": \"Can we reschedule?\"\n}" },
+            "url": "{{base_url}}/api/messages/threads/{{thread_id}}/messages"
+          }
+        },
+        { "name": "POST /api/messages/threads/{threadId}/read", "request": { "method": "POST", "url": "{{base_url}}/api/messages/threads/{{thread_id}}/read" } },
+        {
+          "name": "GET /api/messages/ws",
+          "request": {
+            "method": "GET",
+            "url": {
+              "raw": "{{base_url}}/api/messages/ws?token={{jwt_token}}",
+              "host": ["{{base_url}}"],
+              "path": ["api", "messages", "ws"],
+              "query": [{ "key": "token", "value": "{{jwt_token}}" }]
+            }
+          }
+        },
+        {
+          "name": "POST /api/assistant/chat",
+          "request": {
+            "method": "POST",
+            "header": [{ "key": "Content-Type", "value": "application/json" }],
+            "body": { "mode": "raw", "raw": "{\n  \"message\": \"Summarize my current care plan\",\n  \"context\": \"patient dashboard\"\n}" },
+            "url": "{{base_url}}/api/assistant/chat"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/docs/SPRINT4-NARRATED-VIDEO-SCRIPT.md
+++ b/docs/SPRINT4-NARRATED-VIDEO-SCRIPT.md
@@ -1,0 +1,148 @@
+# Sprint 4 Narrated Video Script (4 Members)
+
+Target duration: 18-24 minutes  
+Format: narrated walkthrough with live app + terminal + test evidence + API explorer  
+Audience: evaluator or stakeholder unfamiliar with project history
+
+---
+
+## Segment 0 - Opening (00:00-01:00) [All / Host handoff]
+
+Script:
+
+"Welcome to the Sprint 4 presentation for Healthonyx. In this demo, we will show what was built, what was fixed, and how the full-stack platform performs end-to-end across patient, doctor, and admin workflows. We will also show unit test and Cypress evidence, and then close with a complete project pitch as if this is your first time seeing Healthonyx."
+
+---
+
+## Segment 1 - Backend and platform architecture (01:00-06:00) [Kaushik]
+
+Focus:
+
+- Explain role-based architecture:
+  - Patient, doctor, admin
+  - JWT and RBAC enforcement
+- Explain sprint progression:
+  - Sprint 1 foundation
+  - Sprint 2 geospatial baseline
+  - Sprint 3 feature expansion
+  - Sprint 4 stabilization and reliability
+- Show backend runtime:
+  - backend server logs on `:8080`
+  - core route groups from `backend/main.go`
+- Highlight Sprint 4 reliability fixes:
+  - OpenAPI route sync CI fix
+  - past appointment prevention logic
+
+Suggested lines:
+
+"The key Sprint 4 backend achievement was to close merge-blocking quality gaps. We made the OpenAPI contract fully consistent with route wiring and added strict future-time validation for appointment create and slot booking so that stale appointments cannot be created."
+
+---
+
+## Segment 2 - Doctor and admin governance workflows (06:00-11:00) [Rohith]
+
+Focus:
+
+- Doctor workflow demo:
+  - availability management
+  - appointment queue
+  - patient documents + download
+- Admin workflow demo:
+  - lifecycle settings page
+  - reason + CONFIRM guardrails
+  - AI observability panel
+- Sprint 4 issue fix demo:
+  - show that short but non-empty reason now works
+  - explain backend/UX guardrail alignment
+
+Suggested lines:
+
+"In Sprint 4 we removed the mismatch where the UI accepted a reason but backend rejected it due to a stricter hidden length check. Now both sides consistently enforce non-empty reason plus explicit CONFIRM for sensitive admin actions."
+
+---
+
+## Segment 3 - Patient UX, assistant, notifications, and find-care polish (11:00-16:00) [Abhinav]
+
+Focus:
+
+- Patient workflow demo:
+  - find-care location search
+  - location autofill/typeahead
+  - use-my-location behavior
+  - Google map visualization update
+  - appointments form preventing past date/time
+- Assistant UX:
+  - improved floating button design and interaction
+  - open assistant and send example prompt
+- Notifications:
+  - show inbox and preference flow
+  - popup behavior and interactive routing mention
+
+Suggested lines:
+
+"Sprint 4 focused heavily on usability in addition to correctness. We improved the assistant entry point, added location autofill, added a clear map visualization, and enforced safer booking behavior directly in the patient form and backend."
+
+---
+
+## Segment 4 - Test evidence and project pitch close (16:00-24:00) [Karthik]
+
+### Part A: unit + e2e evidence
+
+Show terminal outputs for:
+
+- Backend:
+  - `cd backend`
+  - `go test ./...`
+- Frontend:
+  - `cd frontend`
+  - `npm run test:ci`
+- Cypress:
+  - `npm run cypress:e2e` (or selected spec run if time constrained)
+
+Call out:
+
+- Sprint 3 test suites are still included and running in current combined suite
+- Sprint 4 added/updated tests around appointment safety and find-care Google flow
+
+### Part B: backend API documentation evidence
+
+Show:
+
+- `docs/openapi.yaml`
+- `docs/Healthonyx-Sprint4.postman_collection.json`
+
+Explain:
+
+- endpoint coverage by domain (auth, appointments, docs, notifications, admin, messaging, AI, interoperability)
+- role protection and request examples
+
+### Part C: final project pitch (for first-time audience)
+
+Suggested close narrative:
+
+"Healthonyx is a full-stack care coordination platform that unifies patient, doctor, and admin operations in one secure workflow. Patients can discover care, manage appointments, receive prescriptions, upload/view records, and message clinicians. Doctors can manage availability, review patient records, and operate appointment queues. Admins can control lifecycle and safety policies, monitor observability, and manage audit/knowledge workflows. The system is API-first with documented contracts, test-backed reliability, and an interoperability path via FHIR and HL7 boundaries."
+
+"Sprint 4 specifically pushed the platform from feature-complete toward deployment-ready by eliminating CI blockers, closing critical workflow bugs, and polishing high-visibility UX surfaces."
+
+---
+
+## Backup Q&A responses (optional)
+
+- Q: "How do you ensure outdated appointments are not booked?"
+  - A: "Validation is enforced in both frontend and backend; backend acts as source-of-truth."
+- Q: "How do you prove API integrity after many route additions?"
+  - A: "OpenAPI sync checks run in CI and fail if route/method drift is detected."
+- Q: "Is AI required for core workflows?"
+  - A: "No. Core patient/doctor/admin workflows remain operational; AI is additive and configurable."
+
+---
+
+## Recording checklist
+
+- [ ] Backend and frontend are running before recording
+- [ ] Demo accounts ready (patient/doctor/admin)
+- [ ] Terminal prepared with test commands
+- [ ] Postman collection imported before API segment
+- [ ] Each member has practiced their time slice
+- [ ] Final cut includes all four narrators
+

--- a/frontend/src/app/components/patient-appointments/patient-appointments.component.ts
+++ b/frontend/src/app/components/patient-appointments/patient-appointments.component.ts
@@ -446,7 +446,7 @@ export class PatientAppointmentsComponent implements OnInit {
     return `${hour12}:${minute.toString().padStart(2, '0')} ${ampm}`;
   }
 
-  private getTodayLocalDate(): string {
+  getTodayLocalDate(): string {
     const now = new Date();
     const offset = now.getTimezoneOffset() * 60000;
     return new Date(now.getTime() - offset).toISOString().slice(0, 10);


### PR DESCRIPTION
## Summary
- add a complete Sprint 4 report with sprint-to-sprint progress comparison and deliverable matrix
- add a detailed backend Postman collection covering the full documented API surface
- add a 4-member narrated video presentation script with test-evidence walkthrough structure
- fix frontend serve-time template visibility for patient appointment date binding helper

## Test plan
- [x] backend restart + /health check
- [x] frontend restart + 4200 status check
- [x] postman collection JSON parse validation